### PR TITLE
EdkRepo: Edkrepo cache doesn't download manifest files

### DIFF
--- a/edkrepo/commands/cache_command.py
+++ b/edkrepo/commands/cache_command.py
@@ -3,7 +3,7 @@
 ## @file
 # cache_command.py
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2020-2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -17,6 +17,7 @@ from edkrepo.common.common_cache_functions import add_missing_cache_repos
 from edkrepo.common.common_cache_functions import get_repo_cache_obj
 from edkrepo.common.edkrepo_exception import EdkrepoCacheException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_project_in_all_indices
+from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_all_manifest_repos
 from edkrepo.config.config_factory import get_workspace_manifest
 from edkrepo_manifest_parser.edk_manifest import ManifestXml
 
@@ -69,6 +70,8 @@ class CacheCommand(EdkrepoCommand):
 
         # State is enabled so make sure cache directory exists
         cache_obj = get_repo_cache_obj(config)
+
+        pull_all_manifest_repos(config['cfg_file'], config['user_cfg_file'])
 
         # Check to see if a manifest was provided and add any missing remotes
         manifest = None


### PR DESCRIPTION
Edkrepo cache command is updated to clone/sync all the global manifests defined in the edkrepo_cfg and the edkrepo_user.cfg

Cc: Ashley E Desimone <ashley.e.desimone@intel.com>
Cc: Nate DeSimone <nathaniel.l.desimone@intel.com>
Cc: Puja Pandya <puja.pandya@intel.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Erik Bjorge <erik.c.bjorge@intel.com>

Signed-off-by: Moonjung Kyung <moonjung.kyung@intel.com>