### PR TITLE
EdkRepo - Update the edkrepo.cfg

### DIFF
--- a/edkrepo_installer/Vendor/edkrepo.cfg
+++ b/edkrepo_installer/Vendor/edkrepo.cfg
@@ -2,9 +2,9 @@
 edk2-staging
 
 [edk2-staging]
-URL = https://github.com/tianocore/edk2-staging.git
-Branch = EdkRepo-Manifest
-LocalPath = edk2-staging-manifest-master
+URL = https://github.com/tianocore/edk2-edkrepo-manifest.git
+Branch = main
+LocalPath = edk2-edkrepo-manifest-main
 
 [git-ver]
 minimum = 2.13.0


### PR DESCRIPTION
Use the newly created edk2-edkrepo-manifest repository for the
global manifest repository instead of the one in Edk2-staging

Signed-off-by: Ashley E Desimone <ashley.e.desimone@intel.com>