### PR TITLE
EdkRepo: Rename edk2-staging to edk2-edkrepo-manifest

### DIFF
--- a/edkrepo_installer/Vendor/edkrepo.cfg
+++ b/edkrepo_installer/Vendor/edkrepo.cfg
@@ -1,7 +1,7 @@
 [manifest-repos]
-edk2-staging
+edk2-edkrepo-manifest
 
-[edk2-staging]
+[edk2-edkrepo-manifest]
 URL = https://github.com/tianocore/edk2-edkrepo-manifest.git
 Branch = main
 LocalPath = edk2-edkrepo-manifest-main


### PR DESCRIPTION
Rename edk2-staging to edk2-edkrepo-manifest in
edkrepo.cfg to accurately reflect the new name
of the manifest repo.

Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>