### PR TITLE
'edkrepo*.tar.gz' pattern added to cln.bat to remove all build artifacts.

### DIFF
--- a/build-scripts/cln.bat
+++ b/build-scripts/cln.bat
@@ -42,6 +42,7 @@ if exist ..\dist (
   pushd ..\dist
   del /F EdkRepoSetup*.exe
   del /F *.whl
+  del /F edkrepo*.tar.gz
   rmdir /S /Q self_extract
   popd
 )


### PR DESCRIPTION
'edkrepo*.tar.gz' pattern added to files to delete in cln.bat to remove all build artifacts.