### PR TITLE
EdkRepo: clean command to have standardized messaging

### DIFF
--- a/edkrepo/commands/clean_command.py
+++ b/edkrepo/commands/clean_command.py
@@ -15,6 +15,7 @@ from git import Repo
 from edkrepo.commands.edkrepo_command import EdkrepoCommand
 import edkrepo.commands.arguments.clean_args as arguments
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest
+import edkrepo.common.ui_functions as ui_functions
 
 class CleanCommand(EdkrepoCommand):
     def __init__(self):
@@ -56,4 +57,4 @@ class CleanCommand(EdkrepoCommand):
                                     n=(not args.force),
                                     q=(args.quiet and args.force))
             if result:
-                print(result)
+                ui_functions.print_info_msg(result, header = False)


### PR DESCRIPTION
print_info_msg to print the result in a standardized way.

Signed-off-by: Isil Berkun <isil.berkun@intel.com>
![clean_command_print_msg](https://user-images.githubusercontent.com/83428067/124045831-61f28300-d9c5-11eb-834d-dabebbacee58.png)
