### PR TITLE
EdkRepo: clone command to have standardized messaging

### DIFF
--- a/edkrepo/commands/clone_command.py
+++ b/edkrepo/commands/clone_command.py
@@ -28,6 +28,7 @@ from edkrepo.common.workspace_maintenance.workspace_maintenance import case_inse
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_all_manifest_repos, find_project_in_all_indices
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
 from edkrepo.common.workspace_maintenance.humble.manifest_repos_maintenance_humble import PROJ_NOT_IN_REPO, SOURCE_MANIFEST_REPO_NOT_FOUND
+import edkrepo.common.ui_functions as ui_functions
 from edkrepo_manifest_parser.edk_manifest import CiIndexXml, ManifestXml
 from project_utils.submodule import maintain_submodules
 from edkrepo.config.tool_config import SUBMODULE_CACHE_REPO_NAME
@@ -181,5 +182,5 @@ class CloneCommand(EdkrepoCommand):
             # Command line disables sparse checkout
             use_sparse = False
         if use_sparse:
-            print(SPARSE_CHECKOUT)
+            ui_functions.print_info_msg(SPARSE_CHECKOUT)
             sparse_checkout(workspace_dir, repo_sources_to_clone, manifest)

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -64,7 +64,7 @@ from edkrepo.common.edkrepo_exception import EdkrepoFoundMultipleException, Edkr
 from edkrepo.common.edkrepo_exception import EdkrepoGitConfigSetupException, EdkrepoManifestInvalidException, EdkrepoManifestNotFoundException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo, list_available_manifest_repos
 from edkrepo.common.workspace_maintenance.workspace_maintenance import case_insensitive_single_match
-from edkrepo.common.ui_functions import init_color_console
+import edkrepo.common.ui_functions as ui_functions
 from edkrepo_manifest_parser import edk_manifest
 from edkrepo_manifest_parser.edk_manifest_validation import validate_manifestrepo
 from edkrepo_manifest_parser.edk_manifest_validation import get_manifest_validation_status
@@ -84,9 +84,9 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
         cache_path = None
         if cache_obj is not None:
             cache_path = cache_obj.get_cache_path(local_repo_url)
-        print("Cloning from: " + str(local_repo_url))
+        ui_functions.print_info_msg("Cloning from: " + str(local_repo_url), header = False)
         if cache_path is not None:
-            print('+ Using cache at {}'.format(cache_path))
+            ui_functions.print_info_msg('+ Using cache at {}'.format(cache_path))
             repo = Repo.clone_from(local_repo_url, local_repo_path,
                                    progress=GitProgressHandler(),
                                    reference_if_able=cache_path,
@@ -108,11 +108,11 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
         # out
         if repo_to_clone.commit:
             if args.verbose and (repo_to_clone.branch or repo_to_clone.tag):
-                print(MULTIPLE_SOURCE_ATTRIBUTES_SPECIFIED.format(repo_to_clone.root))
+                ui_functions.print_info_msg(MULTIPLE_SOURCE_ATTRIBUTES_SPECIFIED.format(repo_to_clone.root))
             repo.git.checkout(repo_to_clone.commit)
         elif repo_to_clone.tag and repo_to_clone.commit is None:
             if args.verbose and repo_to_clone.branch:
-                print(TAG_AND_BRANCH_SPECIFIED.format(repo_to_clone.root))
+                ui_functions.print_info_msg(TAG_AND_BRANCH_SPECIFIED.format(repo_to_clone.root))
             repo.git.checkout(repo_to_clone.tag)
         elif repo_to_clone.branch and (repo_to_clone.commit is None and repo_to_clone.tag is None):
             if repo_to_clone.branch not in repo.remotes['origin'].refs:
@@ -150,7 +150,7 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
 
         # Check to see if mirror is in sync with primary repo
         if not in_sync_with_primary(repo, repo_to_clone, args.verbose):
-            print(MIRROR_BEHIND_PRIMARY_REPO)
+            ui_functions.print_warning_msg(MIRROR_BEHIND_PRIMARY_REPO)
 
 def write_included_config(remotes, submodule_alt_remotes, repo_directory):
     included_configs = []


### PR DESCRIPTION
print_x_msg to print the result in a standardized way in clone
command as well as the following function in
edkrepo/common/common_repo_functions.py: clone_repos()

Signed-off-by: Isil Berkun <isil.berkun@intel.com>
![screenshot-1](https://user-images.githubusercontent.com/83428067/124051395-4b522900-d9d1-11eb-8637-23d75ae65640.png)

