### PR TITLE
EdkRepo: f2f-cherry-pick will drop the top commit in some cases

### DIFF
--- a/edkrepo/commands/f2f_cherry_pick_command.py
+++ b/edkrepo/commands/f2f_cherry_pick_command.py
@@ -299,7 +299,7 @@ class F2fCherryPickCommand(EdkrepoCommand):
                 try:
                     squash_commits(start_commit, end_commit, f2f_cherry_pick_squash, commit_message, repo, False)
                     repo.heads[original_branch].checkout()
-                    repo.git.reset('--hard', '{}~'.format(start_commit))
+                    repo.git.reset('--hard', '{}'.format(start_commit))
                     repo.git.cherry_pick(str(repo.commit(f2f_cherry_pick_squash)))
                 finally:
                     if f2f_cherry_pick_squash in repo.heads:


### PR DESCRIPTION
In the case of f2f-cherry-pick needs to perform more than one
cherry-pick operation to complete the f2f-cherry-pick, the
final action edkrepo will perform is squashing the several
cherry-picks down to one commit. This squash will erroneously
drop the top commit on the target branch before performing
the final cherry-pick.

Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>