### PR TITLE
EdkRepo: reset command to have standardized messaging

### DIFF
--- a/edkrepo/commands/reset_command.py
+++ b/edkrepo/commands/reset_command.py
@@ -25,7 +25,7 @@ from git import Repo
 from edkrepo.commands.edkrepo_command import EdkrepoCommand
 import edkrepo.commands.arguments.reset_args as arguments
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest
-
+import edkrepo.common.ui_functions as ui_functions
 class ResetCommand(EdkrepoCommand):
     def __init__(self):
         super().__init__()
@@ -51,5 +51,5 @@ class ResetCommand(EdkrepoCommand):
             local_repo_path = os.path.join(workspace_path, repo_to_reset.root)
             repo = Repo(local_repo_path)
             if args.verbose:
-                print("{}Resetting {}".format("Hard " if args.hard else "", repo_to_reset.root))
+                ui_functions.print_info_msg("{}Resetting {}".format("Hard " if args.hard else "", repo_to_reset.root))
             repo.head.reset(working_tree=args.hard)


### PR DESCRIPTION
print statements use standardized formatting.

Signed-off-by: Isil Berkun <isil.berkun@intel.com>

![image](https://user-images.githubusercontent.com/83428067/127546332-92cb4f1c-b2cf-4490-9aef-59f9d7152776.png)
