### PR TITLE
Handle broken source manifest repo links and sync modifies the global manifest repo if it needs to clone a new repo

### DIFF
--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -57,6 +57,8 @@ class CheckoutPinCommand(EdkrepoCommand):
             manifest_repo_path = config['cfg_file'].manifest_repo_abs_path(manifest_repo)
         elif manifest_repo in user_cfg:
             manifest_repo_path = config['user_cfg_file'].manifest_repo_abs_path(manifest_repo)
+        else:
+            manifest_repo_path = None
 
         pin_path = self.__get_pin_path(args, workspace_path, manifest_repo_path, manifest)
         pin = ManifestXml(pin_path)
@@ -96,9 +98,9 @@ class CheckoutPinCommand(EdkrepoCommand):
     def __get_pin_path(self, args, workspace_path, manifest_repo_path, manifest):
         if os.path.isabs(args.pinfile) and os.path.isfile(args.pinfile):
             return os.path.normpath(args.pinfile)
-        elif os.path.isfile(os.path.join(manifest_repo_path, os.path.normpath(manifest.general_config.pin_path), args.pinfile)):
+        elif manifest_repo_path is not None and os.path.isfile(os.path.join(manifest_repo_path, os.path.normpath(manifest.general_config.pin_path), args.pinfile)):
             return os.path.join(manifest_repo_path, os.path.normpath(manifest.general_config.pin_path), args.pinfile)
-        elif os.path.isfile(os.path.join(manifest_repo_path, args.pinfile)):
+        elif manifest_repo_path is not None and os.path.isfile(os.path.join(manifest_repo_path, args.pinfile)):
             return os.path.join(manifest_repo_path, args.pinfile)
         elif os.path.isfile(os.path.join(workspace_path, args.pinfile)):
             return os.path.join(workspace_path, args.pinfile)

--- a/edkrepo/commands/clone_command.py
+++ b/edkrepo/commands/clone_command.py
@@ -27,6 +27,7 @@ from edkrepo.common.pathfix import get_subst_drive_dict
 from edkrepo.common.workspace_maintenance.workspace_maintenance import case_insensitive_single_match
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_all_manifest_repos, find_project_in_all_indices
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
+from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo
 from edkrepo.common.workspace_maintenance.humble.manifest_repos_maintenance_humble import PROJ_NOT_IN_REPO, SOURCE_MANIFEST_REPO_NOT_FOUND
 import edkrepo.common.ui_functions as ui_functions
 from edkrepo_manifest_parser.edk_manifest import CiIndexXml, ManifestXml
@@ -119,6 +120,15 @@ class CloneCommand(EdkrepoCommand):
         local_manifest_path = os.path.join(local_manifest_dir, "Manifest.xml")
         shutil.copy(global_manifest_path, local_manifest_path)
         manifest = ManifestXml(local_manifest_path)
+
+        # Update the source manifest repository tag in the local copy of the manifest XML
+        try:
+            if 'source_manifest_repo' in vars(args).keys():
+                find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo)
+            else:
+                find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], None)
+        except EdkrepoManifestNotFoundException:
+            pass
 
         # Process the combination name and make sure it can be found in the manifest
         if args.Combination is not None:

--- a/edkrepo/commands/create_pin_command.py
+++ b/edkrepo/commands/create_pin_command.py
@@ -3,7 +3,7 @@
 ## @file
 # create_pin_command.py
 #
-# Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -15,10 +15,11 @@ from git import Repo
 from edkrepo.commands.edkrepo_command import EdkrepoCommand, SourceManifestRepoArgument
 import edkrepo.commands.arguments.create_pin_args as arguments
 from edkrepo.common.edkrepo_exception import EdkrepoManifestInvalidException, EdkrepoInvalidParametersException
-from edkrepo.common.edkrepo_exception import EdkrepoWorkspaceCorruptException
+from edkrepo.common.edkrepo_exception import EdkrepoWorkspaceCorruptException, EdkrepoManifestNotFoundException
 from edkrepo.common.humble import WRITING_PIN_FILE, GENERATING_PIN_DATA, GENERATING_REPO_DATA, BRANCH, COMMIT
 from edkrepo.common.humble import COMMIT_MESSAGE, PIN_PATH_NOT_PRESENT, PIN_FILE_ALREADY_EXISTS, PATH_AND_FILEPATH_USED
 from edkrepo.common.humble import MISSING_REPO
+from edkrepo.common.workspace_maintenance.humble.manifest_repos_maintenance_humble import SOURCE_MANIFEST_REPO_NOT_FOUND
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_workspace_manifest_repo
@@ -66,10 +67,13 @@ class CreatePinCommand(EdkrepoCommand):
             src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo)
             pull_workspace_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo, False)
             cfg, user_cfg, conflicts = list_available_manifest_repos(config['cfg_file'], config['user_cfg_file'])
+            manifest_repo_path = None
             if src_manifest_repo in cfg:
                 manifest_repo_path = config['cfg_file'].manifest_repo_abs_path(src_manifest_repo)
             elif src_manifest_repo in user_cfg:
                 manifest_repo_path = config['user_cfg_file'].manifest_repo_abs_path(src_manifest_repo)
+            if manifest_repo_path is None:
+                raise EdkrepoManifestNotFoundException(SOURCE_MANIFEST_REPO_NOT_FOUND.format(manifest.project_info.codename))
         # If the push flag is enabled use general_config.pin_path to determine global manifest relative location to save
         # pin file to.
         if args.push and manifest.general_config.pin_path is not None:

--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -397,6 +397,16 @@ class SyncCommand(EdkrepoCommand):
         os.remove(local_manifest_path)
         shutil.copy(global_manifest_path, local_manifest_path)
 
+        # Update the source manifest repository tag in the local copy of the manifest XML
+        new_manifest = ManifestXml(local_manifest_path)
+        try:
+            if 'source_manifest_repo' in vars(args).keys():
+                find_source_manifest_repo(new_manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo)
+            else:
+                find_source_manifest_repo(new_manifest, config['cfg_file'], config['user_cfg_file'], None)
+        except EdkrepoManifestNotFoundException:
+            pass
+
     def __check_combo_sha_tag_branch(self, workspace_path, initial_sources, new_sources):
         # Checks for changes in the defined SHAs, Tags or branches in the checked out combo. Returns
         # a list of repos to checkout. Checks to see if user is on appropriate SHA, tag or branch and

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -126,9 +126,9 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
 
         try:
             if 'source_manifest_repo' in vars(args).keys():
-                src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo)
+                src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo, False)
             else:
-                src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], None)
+                src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], None, False)
         except EdkrepoManifestNotFoundException:
             src_manifest_repo = None
         if src_manifest_repo:

--- a/edkrepo/common/workspace_maintenance/manifest_repos_maintenance.py
+++ b/edkrepo/common/workspace_maintenance/manifest_repos_maintenance.py
@@ -249,12 +249,15 @@ def find_source_manifest_repo(project_manifest, edkrepo_cfg, edkrepo_user_cfg, m
                 if found:
                     return source_manifest_repo
 
-    src_man_repo, _, _ = find_project_in_all_indices(project_manifest.project_info.codename,
-                                                     edkrepo_cfg,
-                                                     edkrepo_user_cfg,
-                                                     humble.PROJ_NOT_IN_REPO.format(project_manifest.project_info.codename),
-                                                     humble.SOURCE_MANIFEST_REPO_NOT_FOUND.format(project_manifest.project_info.codename),
-                                                     man_repo)
+    try:
+        src_man_repo, _, _ = find_project_in_all_indices(project_manifest.project_info.codename,
+                                                        edkrepo_cfg,
+                                                        edkrepo_user_cfg,
+                                                        humble.PROJ_NOT_IN_REPO.format(project_manifest.project_info.codename),
+                                                        humble.SOURCE_MANIFEST_REPO_NOT_FOUND.format(project_manifest.project_info.codename),
+                                                        man_repo)
+    except EdkrepoManifestNotFoundException:
+        src_man_repo = None
     if src_man_repo is not None and update_source_manifest_repo:
         project_manifest.write_source_manifest_repo(src_man_repo)
     return src_man_repo
@@ -277,5 +280,3 @@ def pull_workspace_manifest_repo(project_manifest, edkrepo_cfg, edkrepo_user_cfg
                                   reset_hard)
     elif src_man_repo in conflicts:
         raise EdkrepoInvalidParametersException(humble.CONFLICT_NO_CLONE.format(src_man_repo))
-
-

--- a/edkrepo/common/workspace_maintenance/manifest_repos_maintenance.py
+++ b/edkrepo/common/workspace_maintenance/manifest_repos_maintenance.py
@@ -229,7 +229,7 @@ def find_project_in_all_indices (project, edkrepo_cfg, edkrepo_user_cfg, except_
         raise EdkrepoManifestNotFoundException(humble.PROJ_NOT_IN_REPO.format(project))
 
 
-def find_source_manifest_repo(project_manifest, edkrepo_cfg, edkrepo_user_cfg, man_repo=None):
+def find_source_manifest_repo(project_manifest, edkrepo_cfg, edkrepo_user_cfg, man_repo=None, update_source_manifest_repo=True):
     '''
     Finds the source manifest repo for a given project.
     '''
@@ -255,7 +255,7 @@ def find_source_manifest_repo(project_manifest, edkrepo_cfg, edkrepo_user_cfg, m
                                                      humble.PROJ_NOT_IN_REPO.format(project_manifest.project_info.codename),
                                                      humble.SOURCE_MANIFEST_REPO_NOT_FOUND.format(project_manifest.project_info.codename),
                                                      man_repo)
-    if src_man_repo is not None:
+    if src_man_repo is not None and update_source_manifest_repo:
         project_manifest.write_source_manifest_repo(src_man_repo)
     return src_man_repo
 


### PR DESCRIPTION
If the project for a manifest file moves from one manifest repository to
another, then it is possible for the SourceManifestRepository under
GeneralConfig to refer to a manifest repository that no longer exists or
does not contain a project with the same codename.

This patch adds detection for this scenario. If it occurs, then a full
search of all known manifest repositories is conducted to attempt to
find the new location of the project's manifest. If the new manifest
directory is found, then the SourceManifestRepository is updated to
point to the new manifest repository.

In some scenarios, "edkrepo sync -uo" will need to clone a new git repository.
Specifically, if the new version of the project's manifest file adds a git
repository that did not exist before. In that scenario, updating from the
old manifest to the new manifest requires cloning the new git repository.

When sync clones a new git repository, the current implementation will write
a new SourceManifestRepository XML tag to the copy of the project manifest in
the global manifest repository instead of the copy in the workspace. This is
incorrect, the copy in the workspace should be modified, not the copy in the
global manifest repository.