### PR TITLE
EdkRepo: Deprecate create-pin --push

### DIFF
--- a/edkrepo/commands/arguments/create_pin_args.py
+++ b/edkrepo/commands/arguments/create_pin_args.py
@@ -15,7 +15,4 @@ COMMAND_DESCRIPTION = 'Creates a PIN file based on the current workspace state'
 NAME_HELP = ('The name of the PIN file. Extension must be .xml. File paths are '
              'supported only if the --push option is not used.')
 DESCRIPTION_HELP = 'A short summary of the PIN file contents. Must be contained in ""'
-PUSH_HELP = ('Automatically commit and push the PIN file to the global manifest '
-             'repository at the location specified by the Pin-Path field in '
-             'the project manifest file.')
 

--- a/edkrepo/commands/create_pin_command.py
+++ b/edkrepo/commands/create_pin_command.py
@@ -17,7 +17,7 @@ import edkrepo.commands.arguments.create_pin_args as arguments
 from edkrepo.common.edkrepo_exception import EdkrepoManifestInvalidException, EdkrepoInvalidParametersException
 from edkrepo.common.edkrepo_exception import EdkrepoWorkspaceCorruptException, EdkrepoManifestNotFoundException
 from edkrepo.common.humble import WRITING_PIN_FILE, GENERATING_PIN_DATA, GENERATING_REPO_DATA, BRANCH, COMMIT
-from edkrepo.common.humble import COMMIT_MESSAGE, PIN_PATH_NOT_PRESENT, PIN_FILE_ALREADY_EXISTS, PATH_AND_FILEPATH_USED
+from edkrepo.common.humble import COMMIT_MESSAGE, PIN_PATH_NOT_PRESENT, PIN_FILE_ALREADY_EXISTS
 from edkrepo.common.humble import MISSING_REPO
 from edkrepo.common.workspace_maintenance.humble.manifest_repos_maintenance_humble import SOURCE_MANIFEST_REPO_NOT_FOUND
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo
@@ -50,44 +50,19 @@ class CreatePinCommand(EdkrepoCommand):
                      'position' : 1,
                      'required' : True,
                      'help-text' : arguments.DESCRIPTION_HELP})
-        args.append({'name': 'push',
-                     'positional': False,
-                     'required': False,
-                     'help-text': arguments.PUSH_HELP})
         args.append(SourceManifestRepoArgument)
         return metadata
 
     def run_command(self, args, config):
-        # Check if --push and file path provided
-        if args.push and os.path.dirname(args.PinFileName):
-            raise EdkrepoInvalidParametersException(PATH_AND_FILEPATH_USED)
 
         workspace_path = get_workspace_path()
         manifest = get_workspace_manifest()
 
-        if args.push:
-            src_manifest_repo = find_source_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo)
-            pull_workspace_manifest_repo(manifest, config['cfg_file'], config['user_cfg_file'], args.source_manifest_repo, False)
-            cfg, user_cfg, conflicts = list_available_manifest_repos(config['cfg_file'], config['user_cfg_file'])
-            manifest_repo_path = None
-            if src_manifest_repo in cfg:
-                manifest_repo_path = config['cfg_file'].manifest_repo_abs_path(src_manifest_repo)
-            elif src_manifest_repo in user_cfg:
-                manifest_repo_path = config['user_cfg_file'].manifest_repo_abs_path(src_manifest_repo)
-            if manifest_repo_path is None:
-                raise EdkrepoManifestNotFoundException(SOURCE_MANIFEST_REPO_NOT_FOUND.format(manifest.project_info.codename))
-        # If the push flag is enabled use general_config.pin_path to determine global manifest relative location to save
-        # pin file to.
-        if args.push and manifest.general_config.pin_path is not None:
-            pin_dir = os.path.join(manifest_repo_path, os.path.normpath(manifest.general_config.pin_path))
-            pin_file_name = os.path.join(pin_dir, args.PinFileName)
-        elif args.push and manifest.general_config.pin_path is None:
-            raise EdkrepoManifestInvalidException(PIN_PATH_NOT_PRESENT)
-        # If not using the push flag ignore the local manifest's pin file field and set the pinname/path == to the file
-        # name provided. If a relative paths is provided save the file relative to the current working directory.
-        elif not args.push and os.path.isabs(os.path.normpath(args.PinFileName)):
+        # Set the pinname/path == to the file name provided.
+        # If a relative paths is provided save the file relative to the current working directory.
+        if os.path.isabs(os.path.normpath(args.PinFileName)):
             pin_file_name = os.path.normpath(args.PinFileName)
-        elif not args.push:
+        else:
             pin_file_name = os.path.abspath(os.path.normpath(args.PinFileName))
         # If the directory that the pin file is saved in does not exist create it and ensure pin file name uniqueness.
         if os.path.isfile(pin_file_name):
@@ -118,26 +93,3 @@ class CreatePinCommand(EdkrepoCommand):
         manifest.generate_pin_xml(args.Description, manifest.general_config.current_combo, updated_repo_sources,
                                   filename=pin_file_name)
 
-        # commit and push the pin file
-        if args.push:
-            manifest_repo = Repo(manifest_repo_path)
-            # Create a local branch with the same name as the pin file arg and check it out before attempting the push
-            # to master
-            master_branch = manifest_repo.active_branch
-            local_branch = manifest_repo.create_head(args.PinFileName)
-            manifest_repo.heads[local_branch.name].checkout()
-            manifest_repo.git.add(pin_file_name)
-            manifest_repo.git.commit(m=COMMIT_MESSAGE.format(manifest.project_info.codename, args.Description))
-            # Try to push if the push fails re update the manifest repo and rebase from master
-            try:
-                manifest_repo.git.push('origin', 'HEAD:master')
-            except:
-                manifest_repo.heads[master_branch.name].checkout()
-                origin = manifest_repo.remotes.origin
-                origin.pull()
-                manifest_repo.heads[local_branch.name].checkout()
-                manifest_repo.git.rebase('master')
-                manifest_repo.git.push('origin', 'HEAD:master')
-            finally:
-                manifest_repo.heads[master_branch.name].checkout()
-                manifest_repo.delete_head(local_branch, '-D')

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -150,7 +150,6 @@ GIT_CMD_ERROR = 'The git command: {} failed to complete successfully with the fo
 CREATE_PIN_EXIT = 'Exiting without creating pin file ...'
 PIN_PATH_NOT_PRESENT = 'Pin Path not present in Manifest.xml ' + CREATE_PIN_EXIT
 PIN_FILE_ALREADY_EXISTS = 'A pin file with that name already exists for this project. Please rerun the command with a new filename. ' + CREATE_PIN_EXIT
-PATH_AND_FILEPATH_USED = 'Providing a file path for the PinFileName argument is not supported when using the --push flag. ' + CREATE_PIN_EXIT
 MISSING_REPO = 'The {} repository is missing from your workspace. ' + CREATE_PIN_EXIT
 
 # Informational messages for create_pin_command.py


### PR DESCRIPTION
Direct push functionality is not supported by most
access controlled git environments and oftentimes creates
non-linear histories when not desired. As such remove the
direct push functionality until there is a defined requirement
or use case which warrants it.

Signed-off-by: Ashley E Desimone <ashley.e.desimone@intel.com>