### PR TITLE
EdkRepo: Account for CombinationList being present in a pin file

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -205,7 +205,11 @@ class ManifestXml(BaseXmlHelper):
         # requires RemoteList to be parsed first
         #
         if self._xml_type == 'Pin':
-            combos = self._tree.findall('Combination')
+            combos_list = self._tree.findall('CombinationList')
+            if len(combos_list) == 1:
+                combos = self._tree.find('CombinationList').findall('Combination')
+            else:
+                combos = self._tree.findall('Combination')
             if len(combos) != 1:
                 raise KeyError(PIN_COMB_ERROR.format(fileref))
 


### PR DESCRIPTION
CombinationList is not required but not prohibited in a pin file.
Account for its present when identifiying the number of combos in
a pin file.

Signed-off-by: Ashley E Desimone <ashley.e.desimone@intel.com>
Signed-off-by: Yuwei Chen <yuwei1.chen@intel.com>
Co-authored-by: Yuwei Chen <yuwei1.chen@intel.com>