### PR TITLE
EdkRepo: Adding support for cloning and generating JSON pin files

### DIFF
--- a/edkrepo/commands/clone_command.py
+++ b/edkrepo/commands/clone_command.py
@@ -118,7 +118,13 @@ class CloneCommand(EdkrepoCommand):
         local_manifest_dir = os.path.join(workspace_dir, "repo")
         os.makedirs(local_manifest_dir)
         local_manifest_path = os.path.join(local_manifest_dir, "Manifest.xml")
-        shutil.copy(global_manifest_path, local_manifest_path)
+        # If JSON, write to XML. Else, simple copy
+        file_ext = os.path.splitext(global_manifest_path)[1]
+        if file_ext == '.json':
+            json_manifest = ManifestXml(global_manifest_path)
+            json_manifest.write_tree(local_manifest_path)
+        else:
+            shutil.copy(global_manifest_path, local_manifest_path)
         manifest = ManifestXml(local_manifest_path)
 
         # Update the source manifest repository tag in the local copy of the manifest XML


### PR DESCRIPTION
Adds option to generate pin files in JSON format, as well as option to clone from a JSON pin file. Notably will skip validation if JSON file is given as input.

Signed-off-by: Kevin Sun <kevin.sun@intel.com>