### PR TITLE
Edkrepo: Collect environment variables in logs

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -52,6 +52,7 @@ from edkrepo.common.humble import ERROR_WRITING_INCLUDE, MULTIPLE_SOURCE_ATTRIBU
 from edkrepo.common.humble import VERIFY_GLOBAL, VERIFY_ARCHIVED, VERIFY_PROJ, VERIFY_PROJ_FAIL
 from edkrepo.common.humble import VERIFY_PROJ_NOT_IN_INDEX, VERIFY_GLOBAL_FAIL
 from edkrepo.common.humble import SUBMODULE_DEINIT_FAILED
+from edkrepo.common.humble import NETRC_NOT_FOUND
 from edkrepo.common.pathfix import get_actual_path, expanduser
 from project_utils.sparse import BuildInfo, process_sparse_checkout
 from edkrepo.config.config_factory import get_workspace_path
@@ -687,3 +688,14 @@ def find_curl():
     else:
         curl_path = get_full_path('curl')
         return curl_path
+
+def get_netrc_path():
+    netrc_path = None
+    home_dir = expanduser('~')
+    if os.path.isfile(os.path.join(home_dir, '.netrc')):
+        netrc_path = os.path.join(home_dir, '.netrc')
+    elif os.path.isfile(os.path.join(home_dir, '_netrc')):
+        netrc_path = os.path.join(home_dir, '_netrc')
+    if not netrc_path:
+        raise EdkrepoWarningException(NETRC_NOT_FOUND)
+    return netrc_path

--- a/edkrepo/common/edkrepo_exception.py
+++ b/edkrepo/common/edkrepo_exception.py
@@ -105,3 +105,8 @@ class EdkrepoCacheException(EdkrepoException):
 class EdkrepoAbortCherryPickException(EdkrepoException):
     def __init__(self, message):
         super().__init__(message, 134)
+
+class EdkrepoVersionException(EdkrepoException):
+    def __init__(self, message):
+        super().__init__(message, 135)
+

--- a/edkrepo/common/edkrepo_version.py
+++ b/edkrepo/common/edkrepo_version.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+#
+## @file
+# edkrepo_version.py
+#
+# Copyright (c) 2018 - 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import re
+
+from edkrepo.common.edkrepo_exception import EdkrepoVersionException
+
+class EdkrepoVersion():
+    """
+    Initialize, describe and provide comparision operators for an edkrepo version number.
+    """
+    def __init__(self, version_string):
+        version_pattern = re.compile(r'(\d+).(\d+).(\d+)')
+        valid_version = re.fullmatch(version_pattern, version_string)
+        if valid_version is None:
+            raise EdkrepoVersionException('{} is not a valid version number.'.format(version_string))
+        self.major = int(valid_version.group(1))
+        self.minor = int(valid_version.group(2))
+        self.patch = int(valid_version.group(3))
+
+    def __eq__(self, other):
+        if self.major != other.major:
+            return False
+        elif self.minor != other.minor:
+            return False
+        elif self.patch != other.patch:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        if self.major < other.major:
+            return True
+        elif self.major == other.major and self.minor < other.minor:
+            return True
+        elif self.minor == other.minor and self.patch < other.patch:
+            return True
+        else:
+            return False
+
+    def __le__(self, other):
+        if self.__lt__(other) or self.__eq__(other):
+            return True
+        else:
+            return False
+
+    def __gt__(self, other):
+        if self.major > other.major:
+            return True
+        elif self.major == other.major and self.minor > other.minor:
+            return True
+        elif self.minor == other.minor and self.patch > other.patch:
+            return True
+        else:
+            return False
+
+    def __ge__(self, other):
+        if self.__gt__(other) or self.__eq__(other):
+            return True
+        else:
+            return False
+
+    def version_string(self):
+        return '{}.{}.{}'.format(self.major, self.minor, self.patch)
+
+    def __str__(self):
+        return self.version_string()
+
+    def __repr__(self):
+        return "edkrepo_version: '{}'".format(self.version_string())

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -163,3 +163,13 @@ COMMIT_MESSAGE = 'Pin file for project: {0} \nPin Description: {1}'
 
 # Common submodule error messages
 SUBMODULE_DEINIT_FAILED = 'Warning: Unable to remove all submodule content'
+
+# Logging messages
+NETRC_PATH = "The netrc path is: {}"
+GIT_VERSION = "Git Version: {}"
+LFS_VERSION = "LFS Version: {}"
+EDKREPO_VERSION = "edkrepo Version: {}"
+PYTHON_VERSION = "Python Version: {}"
+ENVIRONMENT_VARIABLES = "Environment Variables: {}"
+GIT_CONFIG = "Git Config: {}"
+NETRC_NOT_FOUND = 'Path to netrc not found. Please ensure you have configured your netrc file properly according to your OS guide.'

--- a/edkrepo/common/logger.py
+++ b/edkrepo/common/logger.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+## @file
+# logger.py
+#
+# Copyright (c) 2018 - 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import re
+import sys
+import json
+import logging
+import subprocess
+import pkg_resources
+
+from colorama import init, Fore
+
+from edkrepo.common.edkrepo_version import EdkrepoVersion
+from edkrepo.common.common_repo_functions import get_netrc_path
+from edkrepo.common.humble import NETRC_PATH, PYTHON_VERSION, LFS_VERSION
+from edkrepo.common.humble import EDKREPO_VERSION, GIT_VERSION, ENVIRONMENT_VARIABLES, GIT_CONFIG
+
+
+
+init(autoreset=True)
+
+class ColorFormatter(logging.Formatter):
+    COLORS = {
+        "WARNING": Fore.YELLOW,
+        "ERROR": Fore.RED,
+    }
+
+    def format(self, record):
+        color = self.COLORS.get(record.levelname, "")
+        if color:
+            record.asctime = color + record.asctime
+            record.msg = color + record
+        return logging.Formatter.format(self, record)
+
+
+class CustomHandler(logging.StreamHandler):
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            if hasattr(record, 'verbose') and record.verbose:
+                stream.write(msg)
+            if hasattr(record, 'normal') and record.normal:
+                stream.write(msg)
+        except:
+            self.handleError(record)
+
+class fileFormatter(logging.Formatter):
+    def format(self, record):
+        if record.msg != "":
+            msg = logging.Formatter.format(self, record)
+            colorCodeEscape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+            plainMsg = colorCodeEscape.sub('', msg)
+            return plainMsg
+        return ""
+
+
+def get_logger():
+    return logger
+
+
+logFormatter = logging.Formatter("%(message)s\n")
+logger = logging.getLogger('log')
+logger.setLevel(logging.DEBUG)
+
+
+fileHandler = logging.FileHandler("log.log")
+
+formatter = fileFormatter("%(asctime)s.%(msecs)03d %(message)s", datefmt='%Y-%m-%d %H:%M:%S')
+fileHandler.setFormatter(formatter)
+logger.addHandler(fileHandler)
+
+git_version_output = subprocess.getoutput('git --version')
+lfs_version_output = subprocess.getoutput('git-lfs version')
+python_version_output = str(sys.version_info.major) + "." + str(sys.version_info.minor) + "." + str(sys.version_info.micro)
+edkrepo_version = EdkrepoVersion(pkg_resources.get_distribution('edkrepo').version)
+netrc = get_netrc_path()
+environment_info = json.dumps(dict(os.environ), indent=2)
+git_config_values = subprocess.getoutput('git config --list --show-scope --show-origin')
+
+logger.info(NETRC_PATH.format(netrc), extra = {'normal': False})
+logger.info(GIT_VERSION.format(git_version_output), extra = {'normal': False})
+logger.info(LFS_VERSION.format(lfs_version_output), extra = {'normal': False})
+logger.info(PYTHON_VERSION.format(python_version_output), extra = {'normal': False})
+logger.info(EDKREPO_VERSION.format(edkrepo_version.version_string()), extra = {'normal': False})
+logger.info(ENVIRONMENT_VARIABLES.format(environment_info), extra={'normal': False})
+logger.info(GIT_CONFIG.format(git_config_values), extra={'normal': False})
+
+consoleHandler = CustomHandler()
+consoleHandler.setFormatter(logFormatter)
+logger.addHandler(consoleHandler)


### PR DESCRIPTION
- Added edkrepo_version.py which fetches the edkrepo version.
- Added a get_netrc_path method in common_repo_functions to get the netrc_path.
- Updated tne humble and edkrepo_exception files accordingly.
- Updated the logger to include Python, Git, LFS, and Edkrepo version along with environment variables and git config --list output.

Signed-off-by: Harsh Vora harsh.vora@intel.com