### PR TITLE
EdkRepo: Update Error Codes in edkrepo_exception.py

### DIFF
--- a/edkrepo/common/edkrepo_exception.py
+++ b/edkrepo/common/edkrepo_exception.py
@@ -84,24 +84,24 @@ class EdkrepoWorkspaceCorruptException(EdkrepoException):
 
 class EdkrepoWarningException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 123)
+        super().__init__(message, 119)
 
 class EdkrepoGitException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 129)
+        super().__init__(message, 120)
 
 class EdkrepoHookNotFoundException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 130)
+        super().__init__(message, 121)
 
 class EdkrepoGitConfigSetupException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 131)
+        super().__init__(message, 122)
 
 class EdkrepoCacheException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 133)
+        super().__init__(message, 123)
 
 class EdkrepoAbortCherryPickException(EdkrepoException):
     def __init__(self, message):
-        super().__init__(message, 134)
+        super().__init__(message, 124)


### PR DESCRIPTION
Updates error codes in edkrepo_exception.py to consecutive order starting at 100x.

Resolves issue #84 

Signed-off-by: Shreeshan Panicker shreeshan.p@yahoo.com
Reviewed-by: Nate DeSimone nathaniel.l.desimone@intel.com
Reviewed-by: Ashley DeSimone ashley.e.desimone@intel.com