### PR TITLE
EdkRepo: Version-specific includeifs in .gitconfig

### DIFF
--- a/edkrepo/common/git_version.py
+++ b/edkrepo/common/git_version.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+#
+## @file
+# git_version.py
+#
+# Copyright (c) 2018 - 2022, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import re
+from edkrepo.common.edkrepo_exception import EdkrepoGitException
+
+class GitVersion():
+    """
+    Initialize, describe and provide comparision operators for a git version number.
+    """
+    def __init__(self, git_version_string):
+        version_pattern = re.compile(r'(\d+).(\d+).(\d+)')
+        valid_version = re.search(version_pattern, git_version_string)
+        if valid_version is None:
+            raise EdkrepoGitException('{} is not a valid Git version number.'.format(git_version_string))
+        self.major = int(valid_version.group(1))
+        self.minor = int(valid_version.group(2))
+        self.patch = int(valid_version.group(3))
+
+    def __eq__(self, other):
+        if self.major != other.major:
+            return False
+        elif self.minor != other.minor:
+            return False
+        elif self.patch != other.patch:
+            return False
+        else:
+            return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        if self.major < other.major:
+            return True
+        elif self.major == other.major and self.minor < other.minor:
+            return True
+        elif self.minor == other.minor and self.patch < other.patch:
+            return True
+        else:
+            return False
+
+    def __le__(self, other):
+        if self.__lt__(other) or self.__eq__(other):
+            return True
+        else:
+            return False
+
+    def __gt__(self, other):
+        if self.major > other.major:
+            return True
+        elif self.major == other.major and self.minor > other.minor:
+            return True
+        elif self.minor == other.minor and self.patch > other.patch:
+            return True
+        else:
+            return False
+
+    def __ge__(self, other):
+        if self.__gt__(other) or self.__eq__(other):
+            return True
+        else:
+            return False
+
+    def version_string(self):
+        return '{}.{}.{}'.format(self.major, self.minor, self.patch)
+
+    def __str__(self):
+        return self.version_string()
+
+    def __repr__(self):
+        return "Git Version: '{}'".format(self.version_string())

--- a/edkrepo/common/workspace_maintenance/git_config_maintenance.py
+++ b/edkrepo/common/workspace_maintenance/git_config_maintenance.py
@@ -14,17 +14,28 @@ import sys
 import git
 
 from edkrepo.common.pathfix import expanduser
+from edkrepo.common.common_repo_functions import find_git_version
+from edkrepo.common.git_version import GitVersion
 
 def clean_git_globalconfig():
     global_gitconfig_path = os.path.normpath(expanduser("~/.gitconfig"))
+    prefix_required = find_git_version() >= GitVersion('2.34.0')
     with git.GitConfigParser(global_gitconfig_path, read_only=False) as git_globalconfig:
-        includeif_regex = re.compile('^includeIf "gitdir:%\(prefix\)(/.+)/"$')
-        includeif_regex_old = re.compile('^includeIf "gitdir:(/.+)/"$')
+        if prefix_required:
+            includeif_regex = re.compile('^includeIf "gitdir:%\(prefix\)(/.+)/"$')
+            includeif_regex_old = re.compile('^includeIf "gitdir:(/.+)/"$')
+        else:
+            includeif_regex_old = re.compile('^includeIf "gitdir:%\(prefix\)(/.+)/"$')
+            includeif_regex = re.compile('^includeIf "gitdir:(/.+)/"$')
         for section in git_globalconfig.sections():
             data = includeif_regex.match(section)
             if data:
                 gitrepo_path = data.group(1)
                 gitconfig_path = git_globalconfig.get(section, 'path')
+                if _path_is_new_style(gitrepo_path):
+                    gitrepo_path = _remove_new_style_prefix(gitrepo_path)
+                if _path_is_new_style(gitconfig_path):
+                    gitconfig_path = _remove_new_style_prefix(gitconfig_path)
                 if sys.platform == "win32":
                     gitrepo_path = gitrepo_path[1:]
                     gitconfig_path = gitconfig_path[1:]
@@ -35,7 +46,6 @@ def clean_git_globalconfig():
                 if not os.path.isdir(gitrepo_path) and not os.path.isfile(gitconfig_path):
                     if not os.path.isfile(repo_manifest_path):
                         git_globalconfig.remove_section(section)
-            
             data_old = includeif_regex_old.match(section)
             if data_old:
                 git_globalconfig.remove_section(section)
@@ -46,3 +56,9 @@ def set_long_path_support():
         if 'core' not in git_globalconfig.sections():
             git_globalconfig.add_section('core')
         git_globalconfig.set('core', 'longpaths', 'true')
+
+def _path_is_new_style(path):
+    return path.startswith('%(prefix)')
+
+def _remove_new_style_prefix(path):
+    return path.split('%(prefix)')[1]


### PR DESCRIPTION
Includeif updates consist of adding "%(prefix)" to all includeif entries in .gitconfig file but caused some regressions. Updating to make this update Git-version-specific as the update is only needed for Git versions 2.34.0 and higher.

Signed-off-by: Kevin Sun <kevin.sun@intel.com>