### PR TITLE
EdkRepo: Remove Unimplemented Functions

### DIFF
--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -41,7 +41,6 @@ from edkrepo.common.common_repo_functions import reset_sparse_checkout, sparse_c
 from edkrepo.common.common_repo_functions import checkout_repos, check_dirty_repos
 from edkrepo.common.common_repo_functions import update_editor_config
 from edkrepo.common.common_repo_functions import update_repo_commit_template, get_latest_sha
-from edkrepo.common.common_repo_functions import has_primary_repo_remote, fetch_from_primary_repo, in_sync_with_primary
 from edkrepo.common.common_repo_functions import update_hooks, combinations_in_manifest
 from edkrepo.common.common_repo_functions import write_included_config, remove_included_config
 from edkrepo.common.workspace_maintenance.git_config_maintenance import clean_git_globalconfig
@@ -198,18 +197,13 @@ class SyncCommand(EdkrepoCommand):
                         repo.remotes.origin.fetch()
                     else:
                         raise
-                if has_primary_repo_remote(repo, args.verbose):
-                    fetch_from_primary_repo(repo, repo_to_sync, args.verbose)
+
                 if not args.override and not repo.is_ancestor(ancestor_rev='HEAD', rev='origin/{}'.format(repo_to_sync.branch)):
                     ui_functions.print_info_msg(SYNC_COMMITS_ON_TARGET.format(repo_to_sync.branch, repo_to_sync.root), header = False)
                     local_commits = True
                     sync_error = True
                 if not args.fetch and (not local_commits or args.override):
                     repo.head.reset(commit='origin/{}'.format(repo_to_sync.branch), working_tree=True)
-
-                # Check to see if mirror is up to date
-                if not in_sync_with_primary(repo, repo_to_sync, args.verbose):
-                    ui_functions.print_info_msg(MIRROR_BEHIND_PRIMARY_REPO, header = False)
 
                 # Switch back to the initially active branch before exiting
                 repo.heads[initial_active_branch.name].checkout()

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -99,11 +99,6 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
         # Fetch notes
         repo.remotes.origin.fetch("refs/notes/*:refs/notes/*")
 
-        # Add the primary remote so that a reference to the latest code is available when
-        # using a mirror.
-        if add_primary_repo_remote(repo, repo_to_clone, args.verbose):
-            fetch_from_primary_repo(repo, repo_to_clone, args.verbose)
-
         # Handle branch/commit/tag checkout if needed. If a combination of these are specified the
         # order of importance is 1)commit 2)tag 3)branch with only the higest priority being checked
         # out
@@ -149,9 +144,6 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
             # Add the commit template if it exists.
             update_repo_commit_template(workspace_dir, repo, repo_to_clone, config, global_manifest_directory)
 
-        # Check to see if mirror is in sync with primary repo
-        if not in_sync_with_primary(repo, repo_to_clone, args.verbose):
-            ui_functions.print_warning_msg(MIRROR_BEHIND_PRIMARY_REPO)
 
 def write_included_config(remotes, submodule_alt_remotes, repo_directory):
     included_configs = []
@@ -590,33 +582,6 @@ def update_repo_commit_template(workspace_dir, repo, repo_info, config, global_m
 def update_editor_config(config, global_manifest_directory):
     return
 
-def has_primary_repo_remote(repo, verbose=False):
-    """
-    Checks to see if the repo has a primary remote.
-    """
-    return False
-
-def add_primary_repo_remote(repo, repo_data, verbose=False):
-    """
-    Adds a primary remote if a mirror is being used.
-    Returns:
-      True - Primary remote added
-      False - Primary remote not added
-    """
-    return True
-
-def fetch_from_primary_repo(repo, repo_data, verbose=False):
-    """
-    Performs a fetch from the primary remote.
-    """
-    return
-
-def in_sync_with_primary(repo, repo_data, verbose=False):
-    """
-    Checks to see if the current branch of the mirror is in sync with the
-    primary repo branch.
-    """
-    return True
 
 def check_single_remote_connection(remote_url):
     """


### PR DESCRIPTION
Remove the stub implementations and uses of the
following functions:
in_sync_with_primary()
fetch_from_primary_repo()
add_primary_repo_remote()
has_primary_repo_remote()

Signed-off-by: Ashley E Desimone <ashley.e.desimone@intel.com>