### PR TITLE
EdkRepo: Remove '.' from CfgProp Definitions

### DIFF
--- a/edkrepo/config/config_factory.py
+++ b/edkrepo/config/config_factory.py
@@ -92,9 +92,9 @@ class BaseConfig():
 
         if self.cfg.has_section('manifest-repos'):
             for option in self.cfg.options('manifest-repos'):
-                self.prop_list.append(CfgProp('{}'.format(option), 'URL', '{}-manifest_repo_url.'.format(option), None, False))
+                self.prop_list.append(CfgProp('{}'.format(option), 'URL', '{}-manifest_repo_url'.format(option), None, False))
                 self.prop_list.append(CfgProp('{}'.format(option), 'Branch', '{}-manifest_repo_branch'.format(option), None, False))
-                self.prop_list.append(CfgProp('{}'.format(option), 'LocalPath', '{}-manifest_repo_local_path.'.format(option), None, False))
+                self.prop_list.append(CfgProp('{}'.format(option), 'LocalPath', '{}-manifest_repo_local_path'.format(option), None, False))
 
         # Create properties defined by the prop_list
         cfg_updated = False


### PR DESCRIPTION
In the definition of BaseConfig an extra '.' was
present in the definition of the CfgProp.name entry for URL and LocalPath.

Signed-off-by: Ashley E Desimone <ashley.e.desimone@intel.com>