### PR TITLE
EdkRepo: Further sync fixes

### DIFF
--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -522,6 +522,8 @@ class SyncCommand(EdkrepoCommand):
                                 section = 'includeIf "gitdir:%(prefix){}/"'.format(gitdir)
                             else:
                                 section = 'includeIf "gitdir:{}/"'.format(gitdir)
+                            if gitglobalconfig.has_section(section):
+                                gitglobalconfig.remove_section(section)
                             gitglobalconfig.add_section(section)
                             gitglobalconfig.set(section, 'path', path)
                             gitglobalconfig.release()


### PR DESCRIPTION
ConfigParser does not support overwriting a gitconfig entry so we are manually deleting it if it exists to write over it.

Signed-off-by: Kevin Sun <kevin.sun@intel.com>