### PR TITLE
Edkrepo: file access failure during branch name conflict

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -427,6 +427,8 @@ def is_branch_name_collision(json_path, patchset_obj, repo, global_manifest_path
     BRANCH_IN_JSON = False
     for branch in repo.branches:
         if str(branch) == patchset_name:
+            if not os.path.isfile(json_path):
+                break
             with open(json_path, 'r+') as f:
                 data = json.load(f)
                 patchset_data = data[repo_name]


### PR DESCRIPTION
Issue:
When using a manifest with PatchSet implemented, json files are created to track edkrepo PatchSet branch information. If edkrepo has not created any PatchSet branches yet, there is no json file created. If edkrepo detects a branch name collision with a local user branch before creating a json file, edkrepo command will fail.

Solution:
When a branch name collision is detected, check for the json file before attempting to open the json file. When no json file exists yet, treat the branch name collision as a user-made local branch collision. Notify user with an error message, then attempt to revert to previous combo.

Signed-off-by: Nathaniel Haller <nathaniel.d.haller@intel.com>