### PR TITLE
Edkrepo fails to install with Python3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Git 2.27.0 is the version that has received the most validation, though any vers
 - [Direct Link - Git for Windows 2.27.0 - 64 Bit](https://github.com/git-for-windows/git/releases/download/v2.27.0.windows.1/Git-2.27.0-64-bit.exe)
 - [Direct Link - Git for Windows 2.27.0 - 32 Bit](https://github.com/git-for-windows/git/releases/download/v2.27.0.windows.1/Git-2.27.0-32-bit.exe)
 
-Python 3.8.8 or later is recommended due to performance improvements and [CVE-2021-3177](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3177). You can get Python from here: https://www.python.org/
-
+Python 3.8.8 or later is recommended due to performance improvements and [CVE-2021-3177](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3177). You can get Python from here: https://www.python.org/  
+Windows installer .exe will fail if Python 3.8.8 or later is not detected.  
+  
 ### Install Process
 1. Run the installer .exe
 2. Click Install

--- a/edkrepo/commands/command_factory.py
+++ b/edkrepo/commands/command_factory.py
@@ -29,14 +29,14 @@ def _is_command(CommandClass):
     has_get_metadata = False
     has_run_command = False
     for func in funcs:
-        if func[0] == 'get_metadata' and len(inspect.getargspec(func[1])[0]) == 1:
+        if func[0] == 'get_metadata' and len(inspect.getfullargspec(func[1])[0]) == 1:
             try:
                 cmd.get_metadata()
                 has_get_metadata = True
             except:
                 has_get_metadata = False
         if func[0] == 'run_command':
-            arg_spec = inspect.getargspec(func[1])
+            arg_spec = inspect.getfullargspec(func[1])
             if len(arg_spec[0]) == 3 and arg_spec[0][1] == "args" and arg_spec[0][2] == "config":
                 has_run_command = True
     if has_get_metadata and has_run_command:


### PR DESCRIPTION
https://github.com/tianocore/edk2-edkrepo/issues/120 
Replace deprecated inspect.getargspec with inspect.getfullargspec

Signed-off-by: Nathaniel Haller <nathaniel.d.haller@intel.com>