### PR TITLE
dynamic branch json file corruption during edkrepo sync

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -433,6 +433,9 @@ def is_branch_name_collision(json_path, patchset_obj, repo, global_manifest_path
                 data = json.load(f)
                 patchset_data = data[repo_name]
                 for patchset in patchset_data:
+                    if patchset_name == patchset['parent_sha']:
+                        # Do not match a patchset branch name against a daisy-chained-patchset parent_sha value
+                        continue
                     if patchset_name in patchset.values():
                         BRANCH_IN_JSON = True
 


### PR DESCRIPTION
https://github.com/tianocore/edk2-edkrepo/issues/123

When determining branch collision, the patchset parent_sha value should not match the branch name. If the patchset parent_sha value matches the branch name, continue testing the remaining patchsets.

Signed-off-by: Nathaniel Haller <nathaniel.d.haller@intel.com>