### PR TITLE
edkrepo checkout with SparseData combination can have wrong sparse fi…

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -586,8 +586,9 @@ def checkout(combination, global_manifest_path, verbose=False, override=False, l
             sparse_diff = True
         if sparse_diff:
             break
-    if set([combo, manifest.general_config.current_combo]).issubset(set([data.combination for data in manifest.sparse_data])):
-        sparse_diff =  True
+    if set([combo, manifest.general_config.current_combo]).isdisjoint(set([data.combination for data in manifest.sparse_data])) == False :
+        if combo != manifest.general_config.current_combo:
+            sparse_diff =  True
 
     # Recompute the sparse checkout if the dynamic sparse list is being used or
     # there is a difference in the sparse settings / static sparse definition


### PR DESCRIPTION
…les checked out.

https://github.com/tianocore/edk2-edkrepo/issues/131

If either the current-combo or the combo-to-checkout use a combination-specific SparseData, re-initialize sparse data during checkout combo.

Do not re-initialize sparse data if the current-combo and combo-to-checkout are the same combo.