### PR TITLE
EdkRepo: Audit strings

### DIFF
--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -80,7 +80,7 @@ class CheckoutPinCommand(EdkrepoCommand):
         try:
             deinit_full(workspace_path, manifest, args.verbose)
         except Exception as e:
-            ui_functions.print_error_msg(SUBMODULE_DEINIT_FAILED, header = False)
+            ui_functions.print_error_msg(SUBMODULE_DEINIT_FAILED, header=False)
             if args.verbose:
                 ui_functions.print_error_msg(e, header = False)
         pin_repo_sources = pin.get_repo_sources(pin.general_config.current_combo)
@@ -121,7 +121,7 @@ class CheckoutPinCommand(EdkrepoCommand):
         elif not set(pin.remotes).issubset(set(manifest.remotes)):
             raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
         elif pin.general_config.current_combo not in combinations_in_manifest(manifest):
-            ui_functions.print_warning_msg(humble.COMBO_NOT_FOUND.format(pin.general_config.current_combo), header = False)
+            ui_functions.print_warning_msg(humble.COMBO_NOT_FOUND.format(pin.general_config.current_combo), header=True)
         combo_name = pin.general_config.current_combo
         pin_sources = pin.get_repo_sources(combo_name)
         pin_root_remote = {source.root:source.remote_name for source in pin_sources}

--- a/edkrepo/commands/humble/checkout_pin_humble.py
+++ b/edkrepo/commands/humble/checkout_pin_humble.py
@@ -11,7 +11,7 @@ CHP_EXIT = 'Exiting without checkout out PIN data.'
 NOT_FOUND = 'The selected PIN file was not found.'
 MANIFEST_MISMATCH = ('The selected PIN file does not refer to the same project '
                      'as the local manifest file. {}'.format(CHP_EXIT))
-COMMIT_NOT_FOUND = 'The commit referenced by the PIN file does not exist. {}'.format(CHP_EXIT) 
+COMMIT_NOT_FOUND = 'The commit referenced by the PIN file does not exist. {}'.format(CHP_EXIT)
 PIN_COMBO = 'Pin: {}'
-COMBO_NOT_FOUND = ('Warning: The combo listed in PIN file: {} is no longer '
+COMBO_NOT_FOUND = ('The combo listed in PIN file: {} is no longer '
                    'listed in the project manifest file.')

--- a/edkrepo/commands/humble/sync_humble.py
+++ b/edkrepo/commands/humble/sync_humble.py
@@ -37,5 +37,3 @@ It is likely that {new_dir} contains your original code now.
 Please close any open editors to reconcile this problem.
 You may need to manually rename {new_dir} to {initial_dir} in some circumstances.\n'''
 SYNC_AUTOMATIC_REMOTE_PRUNE = 'Performing automatic remote prune...'
-
-

--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -388,12 +388,12 @@ class SyncCommand(EdkrepoCommand):
             for source in sources_to_move:
                 old_dir = os.path.join(workspace_path, source.root)
                 new_dir = generate_name_for_obsolete_backup(old_dir)
-                ui_functions.print_warning_msg(humble.SYNC_SOURCE_MOVE_WARNING.format(source.root, new_dir), header = False)
+                ui_functions.print_warning_msg(humble.SYNC_SOURCE_MOVE_WARNING.format(source.root, new_dir), header=True)
                 new_dir = os.path.join(workspace_path, new_dir)
                 try:
                     shutil.move(old_dir, new_dir)
                 except:
-                    ui_functions.print_error_msg(humble.SYNC_MOVE_FAILED.format(initial_dir=source.root, new_dir=new_dir), header=False)
+                    ui_functions.print_error_msg(humble.SYNC_MOVE_FAILED.format(initial_dir=source.root, new_dir=new_dir), header=True)
                     raise
             # Tell the user about any Git repositories that are no longer used.
             if len(sources_to_remove) > 0:
@@ -506,7 +506,7 @@ class SyncCommand(EdkrepoCommand):
         global_manifest_path = os.path.join(global_manifest_directory, os.path.normpath(ci_index_xml_rel_path))
         global_manifest = ManifestXml(global_manifest_path)
         if not initial_manifest.equals(global_manifest, True):
-            ui_functions.print_warning_msg(humble.SYNC_MANIFEST_DIFF_WARNING, header=False)
+            ui_functions.print_warning_msg(humble.SYNC_MANIFEST_DIFF_WARNING, header=True)
             ui_functions.print_info_msg(humble.SYNC_MANIFEST_UPDATE, header = False)
 
     def __check_submodule_config(self, workspace_path, manifest, repo_sources):

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -9,9 +9,6 @@
 
 '''Contains informational and error messages outputted by the run_command functions of Edkrepo commands'''
 
-from colorama import Fore
-from colorama import Style
-
 # General error messages used by commands
 UNSUPPORTED_COMBO = 'The selected COMBINATION/SHA is not present in the project manifest file or does not exist. '
 UNCOMMITED_CHANGES = 'Uncommited changes present in {0} repo. '
@@ -32,7 +29,6 @@ NOT_GIT_REPO = 'The current directory does not appear to be a git repository'
 MULTIPLE_SOURCE_ATTRIBUTES_SPECIFIED = 'BRANCH or TAG name present with COMMIT ID in combination field for {} repo. Using COMMIT ID.\n'
 TAG_AND_BRANCH_SPECIFIED = 'BRANCH AND TAG name present in combination field for {} repo. Using TAG.\n'
 CHECKING_CONNECTION = 'Checking connection to remote url: {}\n'
-
 
 #error messages for clone_command.py
 CLONE_EXIT = '\nExiting without performing clone operation.'


### PR DESCRIPTION
With the refactor and use of ui_functions to print some strings, we need to audit their use of the headers parameter and remove explicit use of "warning", "error", etc. from humble files