### PR TITLE
EdkRepo: Fix stack trace in List Pins

### DIFF
--- a/edkrepo/commands/list_pins_command.py
+++ b/edkrepo/commands/list_pins_command.py
@@ -102,8 +102,9 @@ class ListPinsCommand(EdkrepoCommand):
                     pin = ManifestXml(pin_file)
                 except TypeError:
                     continue
-                parse_output = sys.stdout.getvalue()
-                sys.stdout = stdout
+                finally:
+                    parse_output = sys.stdout.getvalue()
+                    sys.stdout = stdout
                 if pin.project_info.codename == manifest.project_info.codename:
                     if not use_less:
                         print('Pin File: {}'.format(file))
@@ -121,6 +122,6 @@ class ListPinsCommand(EdkrepoCommand):
                             output_string = separator.join((output_string, 'Parsing Errors: {}'.format(parse_output.strip())))
                         if args.description:
                             output_string = separator.join((output_string, 'Description: {}\n'.format(pin.project_info.description)))
+
         if less_path:
-            less_output = subprocess.Popen([str(less_path), '-F', '-R', '-S', '-X', '-K'], stdin=subprocess.PIPE, stdout=sys.stdout, universal_newlines=True)
-            less_output.communicate(input=output_string)
+            subprocess.run([str(less_path), '-F', '-R', '-S', '-X', '-K'], stdout=sys.stdout, input=output_string, universal_newlines=True)


### PR DESCRIPTION
When use_less == true std_out was redirected to capture manifest parser output but never reset preventing subsequent print operations from being visible on the console.

Additionally switch from using subprocess.communitcate() to subprocess.run() to eliminate the stack trace reported in #148

Fixes #148