### PR TITLE
EdkRepo: Add --tags flag to sync command

### DIFF
--- a/edkrepo/commands/arguments/sync_args.py
+++ b/edkrepo/commands/arguments/sync_args.py
@@ -14,4 +14,5 @@ sync command meta data.
 COMMAND_DESCRIPTION = 'Updates the local copy of the current combination\'s target branches by pulling the latest changes from the server. Does not update local branches.'
 FETCH_HELP = 'Performs a fetch only sync, no changes will be made to the local workspace.'
 UPDATE_LOCAL_MANIFEST_HELP = 'Updates the local copy of the project manifest file prior to performing sync operations.'
-OVERRIDE_HELP = 'Ignore warnings and proceed with sync operations.'
+OVERRIDE_HELP = 'Ignore warnings and proceed with sync operations.'
+TAG_HELP = 'Enables tags to be pulled'


### PR DESCRIPTION
Add support for fetching tags.

Additionally move messages indicating that the sync is starting for a repo to the begining of that process to improve messaging.

Fixes #134