### PR TITLE
EdkRepo Linux Installer Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,16 @@
 
 EdkRepo is the multi-repository tool for EDK II firmware development. EdkRepo is built on top of git. It is intended to automate common developer workflows for projects that use more than one git repository. For example many of the new projects in the edk2-platforms repository require the user to clone several git repositories. EdkRepo makes it easier to set up and upstream changes for these projects. EdkRepo does not replace git, rather it provides higher level extensions that make it easier to work with git. EdkRepo is written in Python and is compatible with Python 3.5 or later.
 
-# Build and Installation
-## Linux Instructions
-### Pre-Requisites
+# Linux Build and Installation
+## Install Pre-Requisites
 - Git 2.13.x or later
 - Python 3.5 or later
 - Python SetupTools
 - Python Pip
 ### Ubuntu Specific Instructions
-Tested versions: 20.04 LTS, 18.04 LTS, 16.04 LTS
-#### Install Dependencies (Ubuntu 20.04, 18.04, 16.04)
+Tested versions: 22.04 LTS, 20.04 LTS, 18.04 LTS, 16.04 LTS
 `sudo apt-get install git python3 python3-setuptools python3-pip`
-#### Upgrade git (Ubuntu 16.04 LTS Only)
+### Upgrade git (Ubuntu 16.04 LTS Only)
 The version of git that is installed by default in Ubuntu 16.04 is too old for EdkRepo (16.04 includes git 2.7.4, the minimum is 2.13+). To upgrade git, run the following commands:
 
 `sudo apt-add-repository ppa:git-core/ppa`
@@ -26,19 +24,31 @@ Press [ENTER] to confirm that you want to add the new repository.
 
 `sudo apt-get install git`
 
-### OpenSUSE
+### OpenSUSE Specific Instructions
 `sudo zipper install git python3 python3-setuptools python3-pip`
 
-### Install Process
+### Red Hat/Fedora/Rocky Specific Instructions
+`sudo dnf install git python3-pip`
+
+## Install EdkRepo
 Installing EdkRepo on Linux requires one to extract the tarball and run the included installer script.
 1. Extract the archive using the following command
   `tar -xzvf edkrepo-<version>.tar.gz`
-2. Run the installer script with elevated privileges
-  `sudo ./install.py --user <username>`
+2. Run the installer script `./install.py` and follow the on-screen prompts.
 
 The -v flag can be added for more verbose output if desired.
 
-### Build Process
+### Automated Installation
+
+For an automated non-interactive install, one must provide at least 2 arguments: `--local` or `--system` and `--prompt` or `--no-prompt`.
+
+`--local` requests installation to the current user's home directory. Root access is not required and no system wide changes are made. This is the recommended installation method.
+
+`--system` request a system-wide installation. Root access is required. This method is useful for systems where multiple users will be running EdkRepo as it saves disk space in that scenario.
+
+For system level installations, one must provide the `--user` parameter and run the installation script as root.
+
+## Build Process
 To build a EdkRepo distribution tarball, the Python wheel package is required in addition to the above dependencies. On Ubuntu, one can install it using:
 
 `sudo apt-get install python3-wheel`
@@ -46,16 +56,16 @@ To build a EdkRepo distribution tarball, the Python wheel package is required in
 1. `cd build-scripts`
 2. `./build_linux_installer.py`
 
-### Install From Source
+## Install From Source
 To install from source, one must have installed using the tarball method above at least once in order to setup the EdkRepo configuration files. One this is done, one may use the standard distutils method to install EdkRepo from source:
 
 `./setup.py install`
 
-## macOS Instructions
+# macOS Build and Installation
 
-### Install Pre-Requisites
+## Install Pre-Requisites
 
-#### 1. Install the Xcode Command Line Tools
+### 1. Install the Xcode Command Line Tools
 
 a) Open a Terminal and type the following command:
 
@@ -65,7 +75,7 @@ b) A new window will appear, click Install.
 c) Accept the license agreement.
 d) Wait for the installation to complete.
 
-#### 2. Install Homebrew
+### 2. Install Homebrew
 
 Install [Homebrew](https://brew.sh/) if it has not been installed already. Homebrew is a package manager for macOS that has become the most common method of installing command line software on macOS that was not originally provided by Apple. EdkRepo has several dependencies that are distributed via Homebrew.
 
@@ -75,19 +85,19 @@ Type the following command to install Homebrew:
 
 Follow the on-screen prompts.
 
-#### 3. Install Dependencies
+### 3. Install Dependencies
 
 Run the following commands to install EdkRepo's dependencies:
 
-`brew install bash-completion git git-gui pyenv`
+`brew install bash-completion git git-gui xz pyenv`
 
-`pyenv install 3.8.8`
+`pyenv install 3.8.16`
 
-`pyenv global 3.8.8`
+`pyenv global 3.8.16`
 
 During installation, you may be prompted to enter your password.
 
-#### 4. Configure Shell for Pyenv and Git
+### 4. Configure Shell for Pyenv and Git
 
 To enable usage of Pyenv installed Python interpreters and Git command completions, run the following command:
 
@@ -97,7 +107,7 @@ Restart your shell so the Pyenv changes can take effect:
 
 `exec $SHELL`
 
-### Install EdkRepo
+## Install EdkRepo
 
 Extract the archive:
 
@@ -117,8 +127,8 @@ Restart your shell so the new Pyenv shim for EdkRepo can take effect:
 
 `exec $SHELL`
 
-## Windows Instructions
-### Pre-Requisites
+# Windows Build and Installation
+## Pre-Requisites
 - Git 2.13.x or later
 - Python 3.8.8 or later
 
@@ -129,17 +139,17 @@ Git 2.27.0 is the version that has received the most validation, though any vers
 Python 3.8.8 or later is recommended due to performance improvements and [CVE-2021-3177](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3177). You can get Python from here: https://www.python.org/  
 Windows installer .exe will fail if Python 3.8.8 or later is not detected.  
   
-### Install Process
+## Install Process
 1. Run the installer .exe
 2. Click Install
 
-### Install From Source
+## Install From Source
 To install from source, one must build and run the installer .exe using the instructions below at least once in order to setup the EdkRepo configuration files. One this is done, one may use the standard distutils method to install EdkRepo from source:
 
 `py -3 setup.py install`
 
-### Build Process
-#### Build Pre-Requisites
+## Build Process
+### Build Pre-Requisites
 - Visual Studio 2015 or later with the C# language and C++ compiler installed
 - Python Wheel
 


### PR DESCRIPTION
REF: #163

- If bash-completion is available then it will now be used on Linux systems. This resolves an issue on Raspberry Pi OS where installing EdkRepo will cause the X11 server to crash during startup. The reason this occurs is because the X11 startup scripts on Raspberry Pi blindly runs all scripts in /etc/profile.d using /bin/sh
- Adds support for user local installs on Linux and makes that the recommended method.
- Adds interactive installation mode to aid users in setting the installation options correctly.
- Fixes shell integration on Raspberry Pi OS.
- Some of the shell initialization script additions made by the installer are typically only needed on macOS. Moved those to only be added if the current OS is macOS.
- Update README.md to document the new Linux installation script arguments.
- Updates README.md to change the recommended macOS Python interpreter from 3.8.8 to 3.8.16.

Signed-off-by: Nate DeSimone <nathaniel.l.desimone@intel.com>