### PR TITLE
EdkRepo: Unmask errors from __update_local_manifest() method.

### DIFF
--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -128,9 +128,8 @@ class SyncCommand(EdkrepoCommand):
             try:
                 self.__update_local_manifest(args, config, initial_manifest, workspace_path, global_manifest_directory)
             except EdkrepoException as e:
-                if args.verbose:
-                    print(e)
-                print(humble.SYNC_MANIFEST_UPDATE_FAILED)
+                ui_functions.print_error_msg(e, header=True)
+                ui_functions.print_error_msg(humble.SYNC_MANIFEST_UPDATE_FAILED, header=True)
         manifest = get_workspace_manifest()
         if args.update_local_manifest:
             try:


### PR DESCRIPTION
Currently all errors from the __update_local_manifest() method in the sync command are only visible when using the -v flag. This prevents users from knowing why the manifest update was not completed succesfully and that in many cases it can be re-run and complete if the -o flag is used.

Fixes #166