### PR TITLE
EdkRepo: Add Tags and Commits to Combo -V output

### DIFF
--- a/edkrepo/commands/combo_command.py
+++ b/edkrepo/commands/combo_command.py
@@ -54,5 +54,9 @@ class ComboCommand(EdkrepoCommand):
                 for source in sources:
                     if source.branch:
                         ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.branch), header=False)
+                    elif source.commit:
+                        ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.commit), header=False)
+                    elif source.tag:
+                        ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.tag), header=False)
                     elif source.patch_set:
                         ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.patch_set), header=False)


### PR DESCRIPTION
When a commit or tag are referenced in a combo list them in the output of combo -v like branch names or patchsets.