### PR TITLE
EdkRepo: Maintenance command should remove unused 'insteadOf's from c…

### DIFF
--- a/edkrepo/commands/maintenance_command.py
+++ b/edkrepo/commands/maintenance_command.py
@@ -45,6 +45,7 @@ class MaintenanceCommande(EdkrepoCommand):
 
         # Remove unneeded instead of entries from git global config
         ui_functions.print_info_msg(humble.CLEAN_INSTEAD_OFS, header = False)
+        clean_git_globalconfig()
         print()
 
         # If in a valid workspace run the following for each repo:


### PR DESCRIPTION
…onfig

The mainenance command would print an entry indicating that unused 'insteadOf' entries were being removed from the users global Git config without removing them. This commit adds a call to clean_git_globalconfig() following that print statement.

Fixes #174