### PR TITLE
Selective Caching Does Not Function When Default Remote Name is Used

### DIFF
--- a/project_utils/cache.py
+++ b/project_utils/cache.py
@@ -229,7 +229,7 @@ class RepoCache(object):
             for remote in repo.remotes:
                 if verbose:
                     print(CACHE_FETCH_REMOTE.format(dir_name, remote.url))
-                if sha_or_branch is not None and remote.name == dir_name:
+                if sha_or_branch is not None and ((remote.name == dir_name) or (remote.url == url_or_name)):
                     print('Fetching ref {}'.format(sha_or_branch))
                     remote.fetch(refspec=sha_or_branch, progress=GitProgressHandler())
                     try:


### PR DESCRIPTION
When the default remote name 'origin' is used for a cached repository the cache's directory name will be the repository name not the remote name; when this occurs the url_or_name parameter will match the value of remote.name. This commit updates the conditional in update_cache() to handle this case by checking for both possibilities.

Fixes #184