### PR TITLE
EdkRepo: Process Refs By Priority Order in List-Repos and Combo

### DIFF
--- a/edkrepo/commands/combo_command.py
+++ b/edkrepo/commands/combo_command.py
@@ -52,11 +52,11 @@ class ComboCommand(EdkrepoCommand):
                 sources = manifest.get_repo_sources(combo)
                 length = len(max([source.root for source in sources], key=len))
                 for source in sources:
-                    if source.branch:
-                        ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.branch), header=False)
-                    elif source.commit:
+                    if source.commit:
                         ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.commit), header=False)
-                    elif source.tag:
+                    elif source.tag and not source.commit:
                         ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.tag), header=False)
+                    elif source.branch and not (source.commit or source.tag) :
+                        ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.branch), header=False)
                     elif source.patch_set:
                         ui_functions.print_info_msg("    {} : {}".format(source.root.ljust(length), source.patch_set), header=False)

--- a/edkrepo/commands/list_repos_command.py
+++ b/edkrepo/commands/list_repos_command.py
@@ -186,9 +186,9 @@ class ListReposCommand(EdkrepoCommand):
                         if self.get_repo_url(source.remote_url) == repo:
                             if source.branch:
                                 branches.add(source.branch)
-                            elif source.tag:
+                            if source.tag:
                                 tags.add(source.tag)
-                            elif source.commit:
+                            if source.commit:
                                 commits.add(source.commit)
 
             #Sort the branch names so they will be displayed alphabetically


### PR DESCRIPTION
In the List-Repos command a combo referencing a combination of tag, sha, and branch would only have the branch listed. Update if / elif block to ensure that all ref types are listed

In the combo commmand a combo containing a combination of tag, sha and branch would only show the branch. Update the conditionals such that the printed ref follows EdkRepo's priority order of ref usage (SHA > Tag > Branch)

Fixes #182