### PR TITLE
EdkRepo: Use FIPs Certified SHA256 Implementation

### DIFF
--- a/edkrepo_installer/EdkRepoInstaller/InstallWorker.cs
+++ b/edkrepo_installer/EdkRepoInstaller/InstallWorker.cs
@@ -163,7 +163,7 @@ namespace TianoCore.EdkRepoInstaller
         public string ComputeSha256(byte[] data)
         {
             StringBuilder hashstring = new StringBuilder();
-            SHA256Managed hasher = new SHA256Managed();
+            SHA256CryptoServiceProvider hasher = new SHA256CryptoServiceProvider();
             byte[] hash = hasher.ComputeHash(data);
             foreach (byte b in hash)
             {


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-edkrepo/issues/189

If the DWORD FIPSAlgorithmPolicy under
HKLM\System\CurrentControlSet\Control\Lsa
is set to 1, then the edkrepo installer fails because it is using a SHA256 implementation that was not certified for FIPS. The fix is to switch from SHA256Managed to
SHA256CryptoServiceProvider.