### PR TITLE
EdkRepo: Add option to skip garbage collection during maintenance

### DIFF
--- a/edkrepo/commands/arguments/maintenance_args.py
+++ b/edkrepo/commands/arguments/maintenance_args.py
@@ -8,5 +8,6 @@
 #
 
 COMMAND_DESCRIPTION = 'Performs workspace wide maintenance operations'
+NO_GC = 'Skips garbage collection operations. Performs all other workspace maintenance operations.'
 
 


### PR DESCRIPTION
Add the --no-gc flag to enable the user to skip garbage collection operations while performing other maintenance operations.

Fixes #196