### PR TITLE
EdkRepo: install.py uses wrong installation mode

### DIFF
--- a/edkrepo_installer/linux-scripts/install.py
+++ b/edkrepo_installer/linux-scripts/install.py
@@ -136,10 +136,10 @@ def get_install_to_local(args):
         return __install_to_local
     if args.local:
         __install_to_local = True
-        return False
+        return True
     elif args.system:
         __install_to_local = False
-        return True
+        return False
 
     #If there is an existing installation of EdkRepo, install using the same mode
     edkrepo_path = shutil.which('edkrepo')


### PR DESCRIPTION
REF: #198

If the linux installer is passed the --system or --local flags then it will attempt to do the opposite of what the user requests.

If the user installs in interactive mode, then this issue is not seen.