### PR TITLE
Fixing default cache path restoration issue

### DIFF
--- a/edkrepo/commands/arguments/cache_args.py
+++ b/edkrepo/commands/arguments/cache_args.py
@@ -18,5 +18,5 @@ COMMAND_UPDATE_HELP = 'Update the repo cache for all cached projects. Will enabl
 COMMAND_INFO_HELP = 'Display the current cache information.'
 COMMAND_FORMAT_HELP = 'Change the format that the cache information is displayed in.'
 COMMAND_PROJECT_HELP = 'Project or manifest/pin file to add to the cache.'
-COMMAND_PATH_HELP = 'Path where cache will be created'
+COMMAND_PATH_HELP = 'Path where cache will be created or "default" to restore the default path.'
 SELECTIVE_HELP = 'Only update the cache with the objects referenced by Project or the current workspace manifest'

--- a/edkrepo/commands/cache_command.py
+++ b/edkrepo/commands/cache_command.py
@@ -23,6 +23,7 @@ from edkrepo.common.common_repo_functions import get_latest_sha
 from edkrepo.common.edkrepo_exception import EdkrepoCacheException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_project_in_all_indices
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_all_manifest_repos
+from edkrepo.common.workspace_maintenance.workspace_maintenance import case_insensitive_equal
 import edkrepo.common.ui_functions as ui_functions
 from edkrepo.config.config_factory import get_workspace_manifest
 from edkrepo_manifest_parser.edk_manifest import ManifestXml
@@ -77,16 +78,18 @@ class CacheCommand(EdkrepoCommand):
 
     def run_command(self, args, config):
         if not args.info:
-        # Process enable disable requests
+            # Process enable disable requests
             if args.disable:
                 config['user_cfg_file'].set_caching_state(False)
             elif args.enable or args.update:
                 config['user_cfg_file'].set_caching_state(True)
             # Write the cache location to the user_cfg
-            if not args.path:
-                config['user_cfg_file'].set_cache_path(cache_path=None, default=True)
-            elif args.path:
-                config['user_cfg_file'].set_cache_path(cache_path=os.path.normpath(os.path.normcase(args.path)), default=False)
+            if args.path:
+                if case_insensitive_equal(args.path, 'default'):
+                    config['user_cfg_file'].set_cache_path(cache_path=None, default=True)
+                else:
+                    config['user_cfg_file'].set_cache_path(cache_path=os.path.normpath(os.path.normcase(args.path)),
+                                                           default=False)
 
         # Get the current state now that we have processed enable/disable
         cache_state = config['user_cfg_file'].caching_state


### PR DESCRIPTION
When running cache commands with a custom path defined the default path will be restored. This was due to the handling of cache commands when the --path flag was not specified.

Updated the --path flag handling logic to do noting if not present. The default path can be restored by passing 'default' as the PATH parameter.