### PR TITLE
Fix f2f-cherry-pick failure when merge conflicts occur

### DIFF
--- a/edkrepo/commands/f2f_cherry_pick_command.py
+++ b/edkrepo/commands/f2f_cherry_pick_command.py
@@ -491,7 +491,7 @@ def _perform_cherry_pick(commit, repo, verbose):
     if not isinstance(stdout, str):
         stdout = stdout.decode("utf-8")
     if p.returncode != 0:
-        if stdout.find('after resolving the conflicts') != -1:
+        if 'after resolving the conflicts'.casefold() in stdout.casefold():
             merge_conflict = True
             stdout = stdout.replace("hint: and commit the result with 'git commit'",'')
             sys.stdout.write(stdout)


### PR DESCRIPTION
In git version 2.39 and newer, the text indicating a cherry-pick merge conflict changed from:

"after resolving the conflicts"

to:

"After resolving the conflicts"

Changed the string comparison to be case insensitive.