### PR TITLE
EdkRepo: Address logical error in generate_clone_cmd

### DIFF
--- a/edkrepo/common/clone_utilities.py
+++ b/edkrepo/common/clone_utilities.py
@@ -35,7 +35,8 @@ def generate_clone_cmd(repo_to_clone, workspace_dir, args=None, cache_path=None)
 
     if repo_to_clone.branch:
         clone_cmd_args['target_branch'] = '-b {}'.format(repo_to_clone.branch)
-    elif args:
+    
+    if args:
         try:
             if args.treeless:
                 clone_cmd_args['treeless'] = '--filter=tree:0'


### PR DESCRIPTION
Change an elif to an if to ensure that both the -b <branch> flag and any command line flags are added to the generated git command.

Co-authored-by:Zhen Gong <zhen.gong@intel.com>