### PR TITLE
combo command verbose current combo fix.

### DIFF
--- a/edkrepo/commands/combo_command.py
+++ b/edkrepo/commands/combo_command.py
@@ -45,6 +45,7 @@ class ComboCommand(EdkrepoCommand):
             all_combos.extend(manifest.archived_combinations)
         if manifest.general_config.current_combo not in combo_list:
             combo_list.append(manifest.general_config.current_combo)
+            all_combos.extend(c for c in manifest.archived_combinations if c.name == manifest.general_config.current_combo)
         for combo in sorted(combo_list):
             if args.verbose:
                 description = [c.description for c in all_combos if c.name == combo]


### PR DESCRIPTION
When current combo is not in the combo_list, update both combo_list and all_combos.

verbose combo error while archived combo is checked out https://github.com/tianocore/edk2-edkrepo/issues/231