### PR TITLE
Add optional CherryPick and Revert mergeStrategy option for PatchSet …

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -29,7 +29,7 @@ Combination = namedtuple('Combination', ['name', 'description', 'venv_enable'])
 RepoSource = namedtuple('RepoSource', ['root', 'remote_name', 'remote_url', 'branch', 'commit', 'sparse',
                                        'enable_submodule', 'tag', 'venv_cfg', 'patch_set'])
 PatchSet = namedtuple('PatchSet', ['remote', 'name', 'parent_sha', 'fetch_branch'])
-PatchOperation = namedtuple('PatchOperation',['type', 'file', 'sha', 'source_remote', 'source_branch'])
+PatchOperation = namedtuple('PatchOperation',['type', 'file', 'sha', 'source_remote', 'source_branch', 'merge_strategy'])
 SparseSettings = namedtuple('SparseSettings', ['sparse_by_default'])
 SparseData = namedtuple('SparseData', ['combination', 'remote_name', 'always_include', 'always_exclude'])
 
@@ -906,10 +906,14 @@ class _PatchSetOperations():
             self.source_branch = element.attrib['sourceBranch']
         except KeyError as k:
             self.source_branch = None
+        try:
+            self.merge_strategy = element.attrib['mergeStrategy']
+        except KeyError as k:
+            self.merge_strategy = None
 
     @property
     def tuple(self):
-        return PatchOperation(self.type, self.file, self.sha, self.source_remote, self.source_branch)
+        return PatchOperation(self.type, self.file, self.sha, self.source_remote, self.source_branch, self.merge_strategy)
 
 class _ProjectInfo():
     def __init__(self, element):


### PR DESCRIPTION
…recipe

CherryPick and Revert in an edkrepo manifest PatchSet can include: 
mergeStrategy="ort_ignore-all-space"
mergeStrategy="ort_theirs"
mergeStrategy="ort_ours"

This can help with PatchSet merge issues.
e.g. using Patch followed by CherryPick where the host system's git am.keepcr setting is unknown during the Patch "git am" step. https://github.com/tianocore/edk2-edkrepo/issues/244