### PR TITLE
Add filter configurations at a per-Source granularity

### DIFF
--- a/edkrepo/commands/arguments/clone_args.py
+++ b/edkrepo/commands/arguments/clone_args.py
@@ -23,11 +23,16 @@ NO_SPARSE_HELP = 'Disables sparse checkout if the project manifest file enables 
 TREELESS_HELP = ('Creates a partial "treeless" clone; all reachable commits will be downloaded with additional blobs and trees being '
                  'downloaded on demand by future Git operations as needed.\n'
                  'Treeless clones result in significantly faster initial clone times and minimize the amount of content downloaded.\n'
-                 'Workspaces created with this option are best used for one time workspaces that will be discarded.')
+                 'Workspaces created with this option are best used for one time workspaces that will be discarded.\n'
+                 'Any project manifest partial clone settings are ignored.')
 BLOBLESS_HELP = ('Creates a partial "blobless" clone; all reachable commits and trees will be downloaded with additional blobs being '
                  'downloaded on demand by future Git operations as needed.\n'
                  'Blobless clones result in significantly faster initial clone times and minimize the amount of content downloaded.\n'
-                 'Workspaces created with this option are best used for persistent development environments')
+                 'Workspaces created with this option are best used for persistent development environments.\n'
+                 'Any project manifest partial clone settings are ignored.')
+FULL_HELP = ('Creates a "full" clone; all reachable commits, trees, and blobs will be downloaded.\n'
+                 'Full clones have the greatest initial clone times and amount of content downloaded.\n'
+                 'Any project manifest partial clone settings are ignored.')
 SINGLE_BRANCH_HELP = ('Clone only the history leading to the tip of a single branch for each repository in the workspace.\n'
                       'The branch is determined by the default combination or by the Combination parameter.')
 NO_TAGS_HELP = ('Skips download of tags and updates config settings to ensure that future pull and fetch operations do not follow tags.\n'

--- a/edkrepo/commands/clone_command.py
+++ b/edkrepo/commands/clone_command.py
@@ -76,6 +76,10 @@ class CloneCommand(EdkrepoCommand):
                      'positional': False,
                      'required': False,
                      'help-text': arguments.BLOBLESS_HELP})
+        args.append({'name': 'full',
+                     'positional': False,
+                     'required': False,
+                     'help-text': arguments.FULL_HELP})
         args.append(({'name': 'single-branch',
                      'positional': False,
                      'required': False,

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -37,6 +37,9 @@ CLONE_INVALID_PROJECT_ARG = 'The PROJECT NAME OR MANIFEST argument must refer to
 CLONE_INVALID_COMBO_ARG = UNSUPPORTED_COMBO + CLONE_EXIT
 CLONE_INVALID_LOCAL_ROOTS = 'The selected combination is invalid; it contains duplicate local roots.' + CLONE_EXIT
 
+#error messages for clone_utilities.py
+CONFLICTING_PARTIAL_CLONE = 'Multiple partial clone arguments were provided.'
+
 # General sparse checkout messages
 SPARSE_CHECKOUT = 'Performing sparse checkout...'
 SPARSE_RESET = 'Resetting sparse checkout state...'

--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -27,7 +27,7 @@ RemoteRepo = namedtuple('RemoteRepo', ['name', 'url'])
 RepoHook = namedtuple('RepoHook', ['source', 'dest_path', 'dest_file', 'remote_url'])
 Combination = namedtuple('Combination', ['name', 'description', 'venv_enable'])
 RepoSource = namedtuple('RepoSource', ['root', 'remote_name', 'remote_url', 'branch', 'commit', 'sparse',
-                                       'enable_submodule', 'tag', 'venv_cfg', 'patch_set'])
+                                       'enable_submodule', 'tag', 'venv_cfg', 'patch_set', 'blobless', 'treeless'])
 PatchSet = namedtuple('PatchSet', ['remote', 'name', 'parent_sha', 'fetch_branch'])
 PatchOperation = namedtuple('PatchOperation',['type', 'file', 'sha', 'source_remote', 'source_branch'])
 SparseSettings = namedtuple('SparseSettings', ['sparse_by_default'])
@@ -1074,6 +1074,14 @@ class _RepoSource():
             self.venv_cfg = (element.attrib['venv_cfg'])
         except:
             self.venv_cfg = None
+        try:
+            self.blobless = (element.attrib['blobless'].lower() == 'true')
+        except Exception:
+            self.blobless = False
+        try:
+            self.treeless = (element.attrib['treeless'].lower() == 'true')
+        except Exception:
+            self.treeless = False
 
         if self.branch is None and self.commit is None and self.tag is None and self.patch_set is None:
             raise KeyError(ATTRIBUTE_MISSING_ERROR)
@@ -1084,7 +1092,7 @@ class _RepoSource():
     @property
     def tuple(self):
         return RepoSource(self.root, self.remote_name, self.remote_url, self.branch,
-                          self.commit, self.sparse, self.enableSub, self.tag, self.venv_cfg, self.patch_set)
+                          self.commit, self.sparse, self.enableSub, self.tag, self.venv_cfg, self.patch_set, self.blobless, self.treeless)
 
 
 class _SparseSettings():

--- a/project_utils/submodule.py
+++ b/project_utils/submodule.py
@@ -73,6 +73,14 @@ def _update(repo, submodules=None, verbose=False, recursive=False, cache_path=No
     """
     # Now perform the update of the submodules.  For a fully recursive submodule init
     # this code will update and initialize at the same time.
+    repo_filter = repo.git.execute(['git', 'config', 'remote.origin.partialclonefilter'])
+    if repo_filter == "tree:0":
+        submodule_filter = '--filter=tree:0'
+    elif repo_filter == "blob:none":
+        submodule_filter = '--filter=blob:none'
+    else:
+        submodule_filter = None
+
     if submodules is None:
         cmd = ['git', 'submodule', 'sync']
         if recursive:
@@ -84,6 +92,8 @@ def _update(repo, submodules=None, verbose=False, recursive=False, cache_path=No
             cmd.append('--recursive')
         if cache_path is not None:
             cmd.extend(['--reference', cache_path])
+        if submodule_filter != None:
+            cmd.append(submodule_filter)
         output_data = repo.git.execute(cmd, with_extended_output=True, with_stdout=True)
         ui_functions.display_git_output(output_data, verbose)
     else:
@@ -104,6 +114,8 @@ def _update(repo, submodules=None, verbose=False, recursive=False, cache_path=No
             if cache_path is not None:
                 cmd.extend(['--reference', cache_path])
             cmd.extend(['--', sub.path])
+            if submodule_filter != None:
+                cmd.append(submodule_filter)
             output_data = repo.git.execute(cmd, with_extended_output=True, with_stdout=True)
             ui_functions.display_git_output(output_data, verbose)
     return


### PR DESCRIPTION
Adds treeless="true" and blobless="true" as attributes to a Combination Source. 
During edkrepo clone and checkout, if enableSubmodule="true" on the Combination Source, the filter setting applies to the submodules as well.

--treeless and treeless="true" have priority over --blobless and blobless="true" if multiple are used.

During edkrepo clone, --treeless and --blobless do not apply to the submodule filter settings.

Related issues:

https://github.com/tianocore/edk2-edkrepo/issues/239  
add filter configurations at a per-Source or per-Remote granularity

https://github.com/tianocore/edk2-edkrepo/issues/247  
clone with both --treeless and --blobless encounter git error