### PR TITLE
SyntaxWarning on three regex expressions.

### DIFF
--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -514,7 +514,7 @@ class SyncCommand(EdkrepoCommand):
         try:
             local_manifest_dir = os.path.join(workspace_path, "repo")
             prefix_required = find_git_version() >= GitVersion('2.34.0')
-            includeif_regex = re.compile('^includeIf "gitdir:{}(/.+)/"$'.format('%\(prefix\)' if prefix_required else ''))
+            includeif_regex = re.compile('^includeIf "gitdir:{}(/.+)/"$'.format('%\\(prefix\\)' if prefix_required else ''))
             rewrite_everything = False
             #Generate list of .gitconfig files that should be present in the workspace
             included_configs = []

--- a/edkrepo/common/workspace_maintenance/git_config_maintenance.py
+++ b/edkrepo/common/workspace_maintenance/git_config_maintenance.py
@@ -22,10 +22,10 @@ def clean_git_globalconfig():
     prefix_required = find_git_version() >= GitVersion('2.34.0')
     with git.GitConfigParser(global_gitconfig_path, read_only=False) as git_globalconfig:
         if prefix_required:
-            includeif_regex = re.compile('^includeIf "gitdir:%\(prefix\)(/.+)/"$')
+            includeif_regex = re.compile('^includeIf "gitdir:%\\(prefix\\)(/.+)/"$')
             includeif_regex_old = re.compile('^includeIf "gitdir:(/.+)/"$')
         else:
-            includeif_regex_old = re.compile('^includeIf "gitdir:%\(prefix\)(/.+)/"$')
+            includeif_regex_old = re.compile('^includeIf "gitdir:%\\(prefix\\)(/.+)/"$')
             includeif_regex = re.compile('^includeIf "gitdir:(/.+)/"$')
         for section in git_globalconfig.sections():
             data = includeif_regex.match(section)


### PR DESCRIPTION
To resolve "SyntaxWarning: invalid escape sequence '\('" with Python 3.12.4. https://github.com/tianocore/edk2-edkrepo/issues/251

Test system: git version 2.43.0.windows.1 , Python 3.5.4 / Python 3.12.4, 

Tested "edkrepo sync -u" command with Python 3.5.4 and Python 3.12.4 on Windows, and both located the new regex expression during sync.

Tested "edkrepo maintenance" command with Python 3.5.4 and Python 3.12.4 on Windows, and both located the new regex expression during maintenance.

SyntaxWarning messages not seen when running with python 3.12.4.

Did not test on non-Windows systems.