### PR TITLE
EdkRepo: Organize import statements

### DIFF
--- a/edkrepo/commands/clean_command.py
+++ b/edkrepo/commands/clean_command.py
@@ -11,7 +11,6 @@ import os
 
 from git import Repo
 
-
 from edkrepo.commands.edkrepo_command import EdkrepoCommand
 import edkrepo.commands.arguments.clean_args as arguments
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest

--- a/edkrepo/commands/command_factory.py
+++ b/edkrepo/commands/command_factory.py
@@ -11,6 +11,7 @@ import importlib
 import inspect
 import os
 import sys
+
 from edkrepo.commands.edkrepo_command import EdkrepoCommand
 from edkrepo.commands.composite_command import CompositeCommand
 from edkrepo.config.config_factory import GlobalConfig

--- a/edkrepo/commands/f2f_cherry_pick_command.py
+++ b/edkrepo/commands/f2f_cherry_pick_command.py
@@ -29,7 +29,6 @@ from edkrepo.common.squash import get_git_repo_root, split_commit_range, get_sta
 from edkrepo.common.squash import commit_list_to_message, squash_commits
 from edkrepo.common.workspace_maintenance.workspace_maintenance import case_insensitive_equal
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest
-
 import edkrepo.commands.arguments.f2f_cherry_pick_args as arguments
 import edkrepo.commands.humble.f2f_cherry_pick_humble as humble
 import edkrepo.common.ui_functions as ui_functions

--- a/edkrepo/commands/list_repos_command.py
+++ b/edkrepo/commands/list_repos_command.py
@@ -13,8 +13,6 @@ import json
 import os
 import sys
 
-from colorama import Fore, Style
-
 from edkrepo.commands.edkrepo_command import EdkrepoCommand
 import edkrepo.commands.arguments.list_repos_args as arguments
 import edkrepo.commands.humble.list_repos_humble as humble

--- a/edkrepo/commands/log_command.py
+++ b/edkrepo/commands/log_command.py
@@ -10,7 +10,6 @@
 import os
 import subprocess
 import sys
-
 from datetime import datetime
 
 from colorama import Fore

--- a/edkrepo/commands/maintenance_command.py
+++ b/edkrepo/commands/maintenance_command.py
@@ -10,7 +10,6 @@
 import os
 import sys
 
-import git
 from git import Repo
 
 from edkrepo.commands.edkrepo_command import EdkrepoCommand

--- a/edkrepo/commands/reset_command.py
+++ b/edkrepo/commands/reset_command.py
@@ -26,6 +26,7 @@ from edkrepo.commands.edkrepo_command import EdkrepoCommand
 import edkrepo.commands.arguments.reset_args as arguments
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest
 import edkrepo.common.ui_functions as ui_functions
+
 class ResetCommand(EdkrepoCommand):
     def __init__(self):
         super().__init__()

--- a/edkrepo/common/git_version.py
+++ b/edkrepo/common/git_version.py
@@ -8,6 +8,7 @@
 #
 
 import re
+
 from edkrepo.common.edkrepo_exception import EdkrepoGitException
 
 class GitVersion():

--- a/edkrepo/common/ui_functions.py
+++ b/edkrepo/common/ui_functions.py
@@ -13,7 +13,6 @@ import string
 
 import git
 import colorama
-
 from colorama import Fore
 from colorama import Style
 from colorama import init

--- a/edkrepo/git_automation/commit_msg.py
+++ b/edkrepo/git_automation/commit_msg.py
@@ -9,6 +9,7 @@
 
 import sys
 import os
+
 def main():
     if 'COMMIT_MESSAGE_NO_EDIT' in os.environ:
         return

--- a/edkrepo/git_automation/rebase_squash.py
+++ b/edkrepo/git_automation/rebase_squash.py
@@ -9,6 +9,7 @@
 
 import sys
 import re
+
 def main():
     with open(sys.argv[1], 'r', errors="surrogateescape") as f:
         lines = f.readlines()


### PR DESCRIPTION
Edkrepo scripts must follow the PEP 8 Style Guide for Python code. This change organizes the import statements for edkrepo scripts into three blocks:
- Standard Python imports
- Third-party imports
- Edkrepo imports