### PR TITLE
EdkRepo: Add Combo Details to Manifest -v

### DIFF
--- a/edkrepo/commands/humble/manifest_humble.py
+++ b/edkrepo/commands/humble/manifest_humble.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+#
+## @file
+# manifest_humble.py
+#
+# Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+'''
+Contains user visible strings printed by the list-repos command.
+'''
+
+from colorama import Fore
+from colorama import Style
+
+CURRENT_PROJECT = '{}{}  * {{}}{}'.format(Fore.GREEN, Style.BRIGHT, Fore.RESET)
+CURRENT_PROJECT_ARCHIVED = '{}{}  *ARCHIVED: {{}}{}'.format(Fore.GREEN, Style.BRIGHT, Fore.RESET)
+MANIFEST_REPO = '{}Manifest Directory:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
+MANIFEST_REPO_PATH = '{}Manifest Directory Path:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
+MANIFEST_REPO_URL = '{}Manifest Repository URL:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
+MANIFEST_REPO_BRANCH = '{}Manifest Repository Branch:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
+PROJECTS = '{}Projects:{}'.format(Style.BRIGHT, Style.RESET_ALL)
+ARCHIVED_PROJECT = '{}  Archived: {{}}{}'.format(Fore.YELLOW, Fore.RESET)
+SINGLE_PROJECT = '  {}'
+MANIFEST_FILE_PATH = '    - Manifest File Path: {}'
+DEV_LEAD = '    - DevLead(s): {}'
+COMBOS = '    - Combos: {}'
+DUPLICATE_PROJECTS_DETECTED = '  {}WARNING: Multiple entries for Project {{}} found listed in this manifest repository{}'.format(Fore.RED, Fore.RESET)
+BAD_MANIFEST = '    {}ERROR: Unable to parse manifest file{}'.format(Fore.RED, Fore.RESET)

--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1001,7 +1001,6 @@ class _RepoHook():
             self.remote_url = remotes[element.attrib['remote']].url
         except Exception:
             self.remote_url = None
-            print(NO_ASSOCIATED_REMOTE.format(self.source, self.dest_path))
         try:
             self.dest_file = element.attrib['destination_file']
         except Exception:

--- a/edkrepo_manifest_parser/edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/edk_manifest_validation.py
@@ -41,11 +41,14 @@ class ValidateManifest:
                 return ("CODENAME", True, None)
 
     def validate_case_insensitive_single_match(self, project, project_list, ci_index_filename):
-        matches = [x for x in project_list if self.case_insensitive_equal(project, x)]
+        matches = self.list_entries(self, project, project_list)
         if len(matches) == 0 or len(matches) > 1:
             return ("DUPLICATE", False, INDEX_DUPLICATE_NAMES.format(project, ci_index_filename))
         else:
             return ("DUPLICATE", True, None)
+    
+    def list_entries(self, project, project_list):
+        return [x for x in project_list if self.case_insensitive_equal(project, x)]
 
     def case_insensitive_equal(self, str1, str2):
         return unicodedata.normalize("NFKD", str1.casefold()) == unicodedata.normalize("NFKD", str2.casefold())


### PR DESCRIPTION
Improve the output and readability of the
manifest command.

Adds a list of combos to the verbose output.

Removes print from manifest parser.

Fixes #205