### PR TITLE
EdkRepo: Fix Combo Verbose Output When a Pin File is Checked Out

### DIFF
--- a/edkrepo/commands/combo_command.py
+++ b/edkrepo/commands/combo_command.py
@@ -48,8 +48,11 @@ class ComboCommand(EdkrepoCommand):
             all_combos.extend(c for c in manifest.archived_combinations if c.name == manifest.general_config.current_combo)
         for combo in sorted(combo_list):
             if args.verbose:
-                description = [c.description for c in all_combos if c.name == combo]
-                description = description[0]
+                if 'pin:' in combo.lower():
+                    description = None
+                else:
+                    description = [c.description for c in all_combos if c.name == combo]
+                    description = description[0]
                 if description is None:
                     description = humble.NO_DESCRIPTION
             if combo == manifest.general_config.current_combo:


### PR DESCRIPTION
When a Pin file is checked out the value of the current cloned combo is a custom string that indicates a pin file is in use; however, a combo with this name is not present in the workspace's local manifest file resulting in an error when accessing the combo's description.

In this case the error can be avoided by setting the value of the description to None.