### PR TITLE
EdkRepo: Enhance verbose combo output.

### DIFF
--- a/edkrepo/commands/humble/combo_humble.py
+++ b/edkrepo/commands/humble/combo_humble.py
@@ -19,4 +19,5 @@ ARCHIVED_COMBO = "{}{}- {{}}{}".format(Fore.YELLOW, Style.BRIGHT, Style.RESET_AL
 COMBO = "  {}{{}}{}".format(Style.BRIGHT, Style.RESET_ALL)
 COMBO_DESCRIPTION = "    {}Description: {{}}{}".format(Style.BRIGHT, Style.RESET_ALL)
 NO_DESCRIPTION = "{}no description included in combo definition{}".format(Fore.RED, Style.RESET_ALL)
+PIN_DESCRIPTION = "{}Currently checked out to a Pin file. The current references are listed below.{}".format(Fore.RED, Style.RESET_ALL)
 REPO_DETAILS = "    {}{}{{}}{} : {}{}{{}}{}".format(Style.BRIGHT, Fore.CYAN, Style.RESET_ALL, Style.BRIGHT, Fore.BLUE, Style.RESET_ALL)


### PR DESCRIPTION
When checked out onto a pin file the combo details are not present in the local manifest file. In this case use a message should be displayed indicating that the that the currently checked out references are being shown and git status should be used to determine those references.