### PR TITLE
EdkRepo: Fix sync -u failure when manifest contains patchsets

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -312,7 +312,8 @@ def sparse_checkout(workspace_dir, repo_list, manifest):
 
 
 def check_dirty_repos(manifest, workspace_path):
-    repos = manifest.get_repo_sources(manifest.general_config.current_combo)
+    combo = manifest.general_config.current_combo or manifest.general_config.default_combo
+    repos = manifest.get_repo_sources(combo)
     for repo_to_check in repos:
         local_repo_path = os.path.join(workspace_path, repo_to_check.root)
         repo = Repo(local_repo_path)


### PR DESCRIPTION
When attempting to run a sync -u with a manifest file that contains one or more patchsets, a AttributeError is currently generated by the check_dirty_repos() function because the new manifest file does not have a current_combo initialized yet.

The fix is to use the default_combo if the current_combo is None.