### PR TITLE
EdkRepo: Fix Intermittent Installer Hang

### DIFF
--- a/edkrepo_installer/EdkRepoInstaller/InstallWorker.cs
+++ b/edkrepo_installer/EdkRepoInstaller/InstallWorker.cs
@@ -597,12 +597,15 @@ namespace TianoCore.EdkRepoInstaller
             Environment.SetEnvironmentVariable("PYTHONPATH", null);
             Environment.SetEnvironmentVariable("PIP_INDEX_URL", null);
             Environment.SetEnvironmentVariable("PIP_TARGET", null);
+            Environment.SetEnvironmentVariable("PYLAUNCHER_ALLOW_INSTALL", null);
+            Environment.SetEnvironmentVariable("PYLAUNCHER_ALWAYS_INSTALL", null);
             if (VendorCustomizer.Instance != null)
             {
                 VendorCustomizer.Instance.WriteToInstallLog = new Action<string>(InstallLogger.Log);
             }
             EdkRepoConfig config = XmlConfigParser.ParseEdkRepoInstallerConfig();
-            List<PythonVersion> PythonVersions = PythonOperations.GetInstalledPythonVersions();
+            InstallLogger.Log("Detecting Installed Python Interpreters...");
+            List <PythonVersion> PythonVersions = PythonOperations.GetInstalledPythonVersions();
 
             //
             // Step 2 - Determine the set of Python Wheels to be installed.


### PR DESCRIPTION
On some systems, the EdkRepo installer hangs forever without any log output. This has been root caused to the Python interpreter detection logic. If the user has the environment variable PYLAUNCHER_ALLOW_INSTALL or PYLAUNCHER_ALWAYS_INSTALL set globally in their Windows registry, then attempting to run "py --version" could cause the Python Launcher for Windows to attempt to install Python from the Windows Store. The installation process prompts the user interactively to ask if they wish to proceed. Since this is a background process, the result is a hang.

The fix is to unset those environment variables so the Python Launcher for Windows skips its automatic installation behavior.