### PR TITLE
EdkRepo: Fix Argparse Program Name

### DIFF
--- a/edkrepo/edkrepo_cli.py
+++ b/edkrepo/edkrepo_cli.py
@@ -35,7 +35,7 @@ from edkrepo.common.humble import KEYBOARD_INTERRUPT, GIT_CMD_ERROR
 from edkrepo.common.pathfix import get_actual_path
 
 def generate_command_line(command):
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog='edkrepo')
     subparsers = parser.add_subparsers(dest='subparser_name')
     try:
         current_version = version("edkrepo")


### PR DESCRIPTION
There appears to have been some changes to argparse in Python 3.14 that causes the program name to be reported as "python.exe C:\Python314\Scripts\edkrepo" instead of "edkrepo". The fix is to explicitly set the program name.