### PR TITLE
EdkRepo: Fix failure in checkout-pin

### DIFF
--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -144,9 +144,11 @@ class CheckoutPinCommand(EdkrepoCommand):
 
 
     def __pin_matches_project(self, pin, manifest, workspace_path):
+        manifest_remotes = [(x.name, x.url) for x in manifest.remotes]
+        pin_remotes = [(x.name, x.url) for x in pin.remotes]
         if pin.project_info.codename != manifest.project_info.codename:
             raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
-        elif not set(pin.remotes).issubset(set(manifest.remotes)):
+        elif not set(pin_remotes).issubset(set(manifest_remotes)):
             raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
         elif pin.general_config.current_combo not in combinations_in_manifest(manifest):
             ui_functions.print_warning_msg(humble.COMBO_NOT_FOUND.format(pin.general_config.current_combo), header=True)


### PR DESCRIPTION
Checkout-pin currently fails with the following error:

The selected PIN file does not refer to the same project as the local manifest file. Exiting without checkout out PIN data.

This is because it is comparing the entire RemoteRepo() tuple instead of just the name and URL. The other fields of the RemoteRepo() tuple are currently owner, review_type, and pr_strategy. These fields are inmaterial to the compatibility of a pin file with a manifest file and should therefore be excluded from the comparison.

Tracker-link: https://github.com/tianocore/edk2-edkrepo/issues/301