### PR TITLE
EdkRepo: EdkRepo Checkout 'Go Back'

### DIFF
--- a/docs/command_references/checkout.md
+++ b/docs/command_references/checkout.md
@@ -14,7 +14,7 @@ edkrepo checkout [-h] [-o] [--performance] [-v] [-c] Combination
 
 ### Combination
 
-**Type:** Required
+**Type:** Optional
 
 The name of the branch combination to checkout as defined in the project manifest file.
 

--- a/edkrepo/commands/arguments/checkout_args.py
+++ b/edkrepo/commands/arguments/checkout_args.py
@@ -12,5 +12,5 @@ checkout command meta data.
 '''
 
 COMMAND_DESCRIPTION = 'Enables checking out a specific branch combination defined in the project manifest file.'
-COMBINATION_DESCRIPTION = 'edkrepo checkout <combination>'
-COMBINATION_HELP = 'The name of the branch combination to checkout as defined in the project manifest file.'
+COMBINATION_DESCRIPTION = 'edkrepo checkout [combination]'
+COMBINATION_HELP = 'The name of the branch combination to checkout as defined in the project manifest file. If not specified, re-checks out the current combination.'

--- a/edkrepo/commands/checkout_command.py
+++ b/edkrepo/commands/checkout_command.py
@@ -31,7 +31,7 @@ class CheckoutCommand(EdkrepoCommand):
         args.append({'name' : 'Combination',
                      'positional' : True,
                      'position' : 0,
-                     'required': True,
+                     'required': False,
                      'description' : arguments.COMBINATION_DESCRIPTION,
                      'help-text' : arguments.COMBINATION_HELP})
         args.append(OverrideArgument)

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -556,7 +556,8 @@ def checkout(combination, global_manifest_path, verbose=False, override=False, l
 
     # Create combo so we have original input and do not introduce any
     # unintended behavior by messing with parameters.
-    combo = combination
+    # If no combination is provided, use the current combo.
+    combo = combination if combination else manifest.general_config.current_combo
     submodule_combo = manifest.general_config.current_combo
     try:
         # Try to handle normalize combo name to match the manifest file.


### PR DESCRIPTION
Make checkout combination argument optional

Allow `edkrepo checkout` to be called without specifying a combination, which will re-checkout the current combination. This is useful for resetting the workspace to match the current combination definition.

- Changed 'Combination' argument from required to optional in checkout_command.py
- Updated help text and description to reflect optional behavior
- Modified checkout() function to use current combo when none specified
- Updated documentation to mark combination parameter as Optional

Fixes #312