### PR TITLE
EdkRepo: When checked out on a pin, edkrepo combo -v doesn't show the…

### DIFF
--- a/edkrepo/commands/unit_tests/ComboCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/ComboCommand_TestCases.md
@@ -1,0 +1,36 @@
+# Test Cases for `combo_command` Module
+
+## Test Cases
+
+### TestIdentifyComboSources
+Tests the `_identify_combo_sources` method of the ComboCommand class which identifies and returns the sources for a given combo, handling both regular combos and pin files.
+
+#### 1. With Pin File
+- **Description**: When a pin file is checked out (combo name format: "Pin: test_pin.xml").
+- **Expected Outcome**: The method loads the pin file and returns a list of source objects with commit SHAs from the pin manifest's first combination.
+
+#### 2. With Regular Combo
+- **Description**: When a regular combo is checked out (combo name does not contain "pin").
+- **Expected Outcome**: The method retrieves sources directly from the workspace manifest without loading a pin file.
+
+#### 3. Pin File Not Found
+- **Description**: When a pin file cannot be found or loaded.
+- **Expected Outcome**: The method prints a warning message and falls back to getting sources from the workspace manifest.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - `edkrepo_manifest_parser`
+   - `colorama`
+   - `GitPython`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_combo_command.py
+++ b/edkrepo/commands/unit_tests/test_combo_command.py
@@ -1,0 +1,103 @@
+﻿import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest import ManifestXml, RepoSource
+from edkrepo.commands.combo_command import ComboCommand
+from edkrepo.common.edkrepo_exception import EdkrepoPinFileNotFoundException
+
+
+class TestIdentifyComboSources:
+    """Unit tests for the ComboCommand._identify_combo_sources method"""
+
+    @pytest.fixture
+    def combo_cmd(self):
+        """Provide a ComboCommand instance for testing"""
+        return ComboCommand()
+
+    @pytest.fixture
+    def mock_config(self):
+        """Provide a fresh mock config for each test"""
+        return {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+
+    @pytest.fixture
+    def mock_manifest(self):
+        """Provide a mock ManifestXml object"""
+        return MagicMock(spec=ManifestXml)
+
+    @pytest.fixture
+    def mock_repo_source(self):
+        """Factory fixture for creating mock RepoSource objects"""
+        def _create_source(root='repo1', commit=None, branch=None, tag=None, patch_set=None):
+            source = MagicMock(spec=RepoSource)
+            source.root = root
+            source.commit = commit
+            source.branch = branch
+            source.tag = tag
+            source.patch_set = patch_set
+            return source
+        return _create_source
+
+    @patch('edkrepo.commands.combo_command.get_checked_out_pin_file')
+    @patch('edkrepo.commands.combo_command.get_workspace_path')
+    def test_identify_combo_sources_with_pin(self, mock_workspace_path, mock_get_pin_file, 
+                                            combo_cmd, mock_manifest, mock_config, mock_repo_source):
+        """Test _identify_combo_sources when a pin file is checked out"""
+        mock_workspace_path.return_value = '/path/to/workspace'
+        
+        mock_pin_manifest = MagicMock(spec=ManifestXml)
+        mock_pin_combo = MagicMock()
+        mock_pin_combo.name = 'combo1'
+        mock_pin_manifest.combinations = [mock_pin_combo]
+        
+        mock_source1 = mock_repo_source(root='repo1', commit='abc123')
+        mock_source2 = mock_repo_source(root='repo2', commit='def456')
+        
+        mock_pin_manifest.get_repo_sources = MagicMock(return_value=[mock_source1, mock_source2])
+        mock_get_pin_file.return_value = mock_pin_manifest
+        
+        result = combo_cmd._identify_combo_sources('Pin: test_pin.xml', mock_manifest, mock_config)
+        
+        assert result == [mock_source1, mock_source2]
+        mock_get_pin_file.assert_called_once_with('test_pin.xml', mock_manifest, mock_config, '/path/to/workspace')
+        mock_pin_manifest.get_repo_sources.assert_called_once_with('combo1')
+
+    def test_identify_combo_sources_with_regular_combo(self, combo_cmd, mock_manifest, 
+                                                       mock_config, mock_repo_source):
+        """Test _identify_combo_sources when a regular combo is checked out"""
+        mock_source1 = mock_repo_source(root='repo1', branch='main')
+        mock_source2 = mock_repo_source(root='repo2', branch='development')
+        
+        mock_manifest.get_repo_sources = MagicMock(return_value=[mock_source1, mock_source2])
+        
+        result = combo_cmd._identify_combo_sources('combo1', mock_manifest, mock_config)
+        
+        assert result == [mock_source1, mock_source2]
+        mock_manifest.get_repo_sources.assert_called_once_with('combo1')
+
+    @patch('edkrepo.commands.combo_command.get_checked_out_pin_file')
+    @patch('edkrepo.commands.combo_command.get_workspace_path')
+    @patch('edkrepo.commands.combo_command.ui_functions.print_warning_msg')
+    def test_identify_combo_sources_pin_not_found(self, mock_print_warning, mock_workspace_path, 
+                                                  mock_get_pin_file, combo_cmd, mock_manifest, 
+                                                  mock_config, mock_repo_source):
+        """Test _identify_combo_sources when a pin file cannot be found"""
+        mock_workspace_path.return_value = '/path/to/workspace'
+        
+        mock_source1 = mock_repo_source(root='repo1', branch='main')
+        
+        mock_manifest.get_repo_sources = MagicMock(return_value=[mock_source1])
+        
+        mock_get_pin_file.side_effect = EdkrepoPinFileNotFoundException("Pin file 'test_pin.xml' not found")
+        
+        result = combo_cmd._identify_combo_sources('Pin: test_pin.xml', mock_manifest, mock_config)
+        
+        assert result == [mock_source1]
+        mock_get_pin_file.assert_called_once_with('test_pin.xml', mock_manifest, mock_config, '/path/to/workspace')
+        mock_print_warning.assert_called_once()
+        assert "Failed to load pin file 'test_pin.xml'" in str(mock_print_warning.call_args)
+
+        mock_manifest.get_repo_sources.assert_called_once_with('Pin: test_pin.xml')

--- a/edkrepo/common/edkrepo_exception.py
+++ b/edkrepo/common/edkrepo_exception.py
@@ -166,5 +166,9 @@ class EdkRepoGitEmailNotFoundException(EdkrepoException):
     def __init__(self, message):
         super().__init__(message, 139)
 
+class EdkrepoPinFileNotFoundException(EdkrepoException):
+    def __init__(self, message):
+        super().__init__(message, 140)
+
 
 

--- a/edkrepo/config/config_factory.py
+++ b/edkrepo/config/config_factory.py
@@ -19,8 +19,10 @@ import edkrepo.config.humble.config_factory_humble as humble
 from edkrepo.common.edkrepo_exception import EdkrepoGlobalConfigNotFoundException, EdkrepoConfigFileInvalidException
 from edkrepo.common.edkrepo_exception import EdkrepoWorkspaceInvalidException, EdkrepoGlobalDataDirectoryNotFoundException
 from edkrepo.common.edkrepo_exception import EdkrepoConfigFileReadOnlyException, EdkrepoInvalidConfigOptionException
+from edkrepo.common.edkrepo_exception import EdkrepoPinFileNotFoundException
 from edkrepo.common.humble import MIRROR_PRIMARY_REPOS_MISSING, MIRROR_DECODE_WARNING, MAX_PATCH_SET_INVALID
 from edkrepo.common.pathfix import get_subst_drive_dict
+from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo, get_manifest_repo_path
 from edkrepo_manifest_parser import edk_manifest
 from edkrepo.common.pathfix import expanduser
 
@@ -283,3 +285,27 @@ def get_workspace_manifest_file():
 def get_workspace_manifest():
     manifest_path = get_workspace_manifest_file()
     return edk_manifest.ManifestXml(manifest_path)
+
+def get_checked_out_pin_file(pin_filename, workspace_manifest, config, workspace_path):
+    '''
+    Loads a pin file and returns the ManifestXml object with commit SHAs.
+    Searches for the pin file in the manifest repository pin folder first,
+    then falls back to the workspace root if not found.
+    '''
+    man_repo = find_source_manifest_repo(workspace_manifest, config['cfg_file'], config['user_cfg_file'])
+    manifest_repo_path = get_manifest_repo_path(man_repo, config)
+
+    # Try manifest repo pin folder first
+    pin_path = None
+    if workspace_manifest.general_config.pin_path:
+        pin_path = os.path.join(manifest_repo_path, workspace_manifest.general_config.pin_path, pin_filename)
+    
+    # If not found or no pin_path, try workspace root
+    if not pin_path or not os.path.isfile(pin_path):
+        pin_path = os.path.join(workspace_path, pin_filename)
+    
+    # Load and return pin manifest if found
+    if os.path.isfile(pin_path):
+        return edk_manifest.ManifestXml(pin_path)
+    
+    raise EdkrepoPinFileNotFoundException(f"Pin file '{pin_filename}' not found in manifest repository or workspace root")

--- a/edkrepo/config/unit_tests/ConfigFactory_TestCases.md
+++ b/edkrepo/config/unit_tests/ConfigFactory_TestCases.md
@@ -1,0 +1,42 @@
+# Test Cases for `config_factory` Module
+
+## Test Cases
+
+### TestGetCheckedOutPinFile
+Loads a pin file and returns the ManifestXml object with commit SHAs.
+
+#### 1. From Manifest Repo Pin Folder
+- **Description**: When a pin file exists in the manifest repository's pin folder.
+- **Expected Outcome**: The function returns the pin file from the manifest repo pin folder.
+
+#### 2. From Workspace Root
+- **Description**: When a pin file does not exist in the manifest repo but exists in the workspace root.
+- **Expected Outcome**: The function returns the pin file from the workspace root.
+
+#### 3. Pin File Not Found
+- **Description**: When the pin file does not exist in either location.
+- **Expected Outcome**: The function raises an `EdkrepoPinFileNotFoundException`.
+
+#### 4. No Pin Path in Config
+- **Description**: When the pin_path is not configured in the manifest's general_config.
+- **Expected Outcome**: The function loads the pin file from the workspace root.
+
+#### 5. Prefers Manifest Repo Over Workspace
+- **Description**: When a pin file exists in both locations.
+- **Expected Outcome**: The function returns the pin file from the manifest repo pin folder.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - `edkrepo_manifest_parser`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\config\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/config/unit_tests/test_config_factory.py
+++ b/edkrepo/config/unit_tests/test_config_factory.py
@@ -1,0 +1,158 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest import ManifestXml, GeneralConfig
+from edkrepo.config.config_factory import get_checked_out_pin_file
+
+
+class TestGetCheckedOutPinFile:
+    """Unit tests for the get_checked_out_pin_file function"""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Provide a fresh mock config for each test"""
+        return {
+            'cfg_file': MagicMock(),
+            'user_cfg_file': MagicMock()
+        }
+
+    @pytest.fixture
+    def mock_workspace_manifest(self):
+        """Factory fixture for creating mock workspace manifests"""
+        def _create_manifest(pin_path='pins'):
+            manifest = MagicMock(spec=ManifestXml)
+            general_config = MagicMock(spec=GeneralConfig)
+            general_config.pin_path = pin_path
+            manifest.general_config = general_config
+            return manifest
+        return _create_manifest
+
+    @pytest.fixture
+    def mock_pin_manifest(self):
+        """Provide a mock pin manifest object"""
+        return MagicMock(spec=ManifestXml)
+
+    def test_get_checked_out_pin_file_from_manifest_repo_pin_folder(self, mock_config, 
+                                                                    mock_workspace_manifest, 
+                                                                    mock_pin_manifest):
+        """Test loading pin file from manifest repo pin folder"""
+        mock_manifest = mock_workspace_manifest(pin_path='pins')
+
+        manifest_repo_path = '/path/to/manifest_repo'
+        workspace_path = '/path/to/workspace'
+        pin_file_path = os.path.join(manifest_repo_path, 'pins', 'test_pin.xml')
+        
+        with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo') as mock_find:
+            with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.get_manifest_repo_path') as mock_get_path:
+                with patch('edkrepo.config.config_factory.os.path.isfile') as mock_isfile:
+                    with patch('edkrepo.config.config_factory.edk_manifest.ManifestXml', return_value=mock_pin_manifest) as mock_manifest_xml:
+                        mock_find.return_value = 'test_repo'
+                        mock_get_path.return_value = manifest_repo_path
+                        mock_isfile.return_value = True
+                        
+                        result = get_checked_out_pin_file('test_pin.xml', mock_manifest, mock_config, workspace_path)
+                        
+                        assert result is not None
+                        assert result == mock_pin_manifest
+                        mock_manifest_xml.assert_called_once_with(pin_file_path)
+
+    def test_get_checked_out_pin_file_from_workspace_root(self, mock_config, 
+                                                          mock_workspace_manifest, 
+                                                          mock_pin_manifest):
+        """Test loading pin file from workspace root when not in manifest repo"""
+        mock_manifest = mock_workspace_manifest(pin_path='pins')
+
+        manifest_repo_path = '/path/to/manifest_repo'
+        workspace_path = '/path/to/workspace'
+        pin_file_path = os.path.join(workspace_path, 'test_pin.xml')
+        
+        def isfile_side_effect(path):
+            return path == pin_file_path
+        
+        with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo') as mock_find:
+            with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.get_manifest_repo_path') as mock_get_path:
+                with patch('edkrepo.config.config_factory.os.path.isfile', side_effect=isfile_side_effect) as mock_isfile:
+                    with patch('edkrepo.config.config_factory.edk_manifest.ManifestXml', return_value=mock_pin_manifest) as mock_manifest_xml:
+                        mock_find.return_value = 'test_repo'
+                        mock_get_path.return_value = manifest_repo_path
+                        
+                        result = get_checked_out_pin_file('test_pin.xml', mock_manifest, mock_config, workspace_path)
+                        
+                        assert result is not None
+                        assert result == mock_pin_manifest
+                        mock_manifest_xml.assert_called_once_with(pin_file_path)
+
+    def test_get_checked_out_pin_file_not_found(self, mock_config, mock_workspace_manifest):
+        """Test get_checked_out_pin_file raises exception when pin file doesn't exist"""
+        from edkrepo.common.edkrepo_exception import EdkrepoPinFileNotFoundException
+        
+        mock_manifest = mock_workspace_manifest(pin_path='pins')
+
+        manifest_repo_path = '/path/to/manifest_repo'
+        workspace_path = '/path/to/workspace'
+
+        with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo') as mock_find:
+            with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.get_manifest_repo_path') as mock_get_path:
+                with patch('edkrepo.config.config_factory.os.path.isfile', return_value=False) as mock_isfile:
+                    mock_find.return_value = 'test_repo'
+                    mock_get_path.return_value = manifest_repo_path
+                    
+                    try:
+                        result = get_checked_out_pin_file('nonexistent_pin.xml', mock_manifest, mock_config, workspace_path)
+                        assert False, "Expected EdkrepoPinFileNotFoundException to be raised"
+                    except EdkrepoPinFileNotFoundException as e:
+                        assert 'nonexistent_pin.xml' in str(e)
+
+    def test_get_checked_out_pin_file_no_pin_path_in_config(self, mock_config, 
+                                                            mock_workspace_manifest, 
+                                                            mock_pin_manifest):
+        """Test loading pin file when pin_path is not configured"""
+        mock_manifest = mock_workspace_manifest(pin_path=None)
+
+        manifest_repo_path = '/path/to/manifest_repo'
+        workspace_path = '/path/to/workspace'
+        pin_file_path = os.path.join(workspace_path, 'test_pin.xml')
+        
+        with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo') as mock_find:
+            with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.get_manifest_repo_path') as mock_get_path:
+                with patch('edkrepo.config.config_factory.os.path.isfile', return_value=True) as mock_isfile:
+                    with patch('edkrepo.config.config_factory.edk_manifest.ManifestXml', return_value=mock_pin_manifest) as mock_manifest_xml:
+                        mock_find.return_value = 'test_repo'
+                        mock_get_path.return_value = manifest_repo_path
+                        
+                        result = get_checked_out_pin_file('test_pin.xml', mock_manifest, mock_config, workspace_path)
+                        
+                        assert result is not None
+                        assert result == mock_pin_manifest
+                        mock_manifest_xml.assert_called_once_with(pin_file_path)
+
+    def test_get_checked_out_pin_file_prefers_manifest_repo_over_workspace(self, mock_config, 
+                                                                          mock_workspace_manifest, 
+                                                                          mock_pin_manifest):
+        """Test that manifest repo pin folder is checked before workspace root"""
+        mock_manifest = mock_workspace_manifest(pin_path='pins')
+
+        manifest_repo_path = '/path/to/manifest_repo'
+        workspace_path = '/path/to/workspace'
+        pin_file_manifest_repo = os.path.join(manifest_repo_path, 'pins', 'test_pin.xml')
+        pin_file_workspace = os.path.join(workspace_path, 'test_pin.xml')
+        
+        def isfile_side_effect(path):
+            return path in [pin_file_manifest_repo, pin_file_workspace]
+        
+        with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo') as mock_find:
+            with patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.get_manifest_repo_path') as mock_get_path:
+                with patch('edkrepo.config.config_factory.os.path.isfile', side_effect=isfile_side_effect) as mock_isfile:
+                    with patch('edkrepo.config.config_factory.edk_manifest.ManifestXml', return_value=mock_pin_manifest) as mock_manifest_xml:
+                        mock_find.return_value = 'test_repo'
+                        mock_get_path.return_value = manifest_repo_path
+                        
+                        result = get_checked_out_pin_file('test_pin.xml', mock_manifest, mock_config, workspace_path)
+                        
+                        assert result is not None
+                        assert result == mock_pin_manifest
+                        mock_manifest_xml.assert_called_once_with(pin_file_manifest_repo)


### PR DESCRIPTION
… SHAs

Modified the combo command to load pin files and display actual commit SHAs when showing verbose output for pin combinations. Previously, the command attempted to execute git status on repository paths, which was incorrect for pins.

Changes:
- Extracted _identify_combo_sources() method in combo_command.py for better testability
- Added get_checked_out_pin_file() function in config_factory.py
- Added EdkrepoPinFileNotFoundException exception class in edkrepo_exception.py
- Pin file loading falls back to manifest sources on error with warning message
- Added unit tests for _identify_combo_sources() in test_combo_command.py
- Added unit tests for get_checked_out_pin_file() in test_config_factory.py
- Created test case documentation (ComboCommand_TestCases.md, ConfigFactory_TestCases.md)
- All tests use mocked dependencies without filesystem operations

Fixes: #314