### PR TITLE
EdkRepo: Update Create-Pin Command to Include Patchsets

### DIFF
--- a/edkrepo/commands/create_pin_command.py
+++ b/edkrepo/commands/create_pin_command.py
@@ -3,28 +3,19 @@
 ## @file
 # create_pin_command.py
 #
-# Copyright (c) 2017 - 2021, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
 import os
-from collections import namedtuple
 
 from git import Repo
 
 from edkrepo.commands.edkrepo_command import EdkrepoCommand, SourceManifestRepoArgument
 import edkrepo.commands.arguments.create_pin_args as arguments
-from edkrepo.common.edkrepo_exception import EdkrepoManifestInvalidException, EdkrepoInvalidParametersException
-from edkrepo.common.edkrepo_exception import EdkrepoWorkspaceCorruptException, EdkrepoManifestNotFoundException
-from edkrepo.common.humble import WRITING_PIN_FILE, GENERATING_PIN_DATA, GENERATING_REPO_DATA, BRANCH, COMMIT
-from edkrepo.common.humble import COMMIT_MESSAGE, PIN_PATH_NOT_PRESENT, PIN_FILE_ALREADY_EXISTS
-from edkrepo.common.humble import MISSING_REPO
-from edkrepo.common.workspace_maintenance.humble.manifest_repos_maintenance_humble import SOURCE_MANIFEST_REPO_NOT_FOUND
-from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo
-from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
-from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_workspace_manifest_repo
+import edkrepo.common.edkrepo_exception as edkrepo_exception
+import edkrepo.common.humble as humble
 from edkrepo.config.config_factory import get_workspace_manifest, get_workspace_path
-from edkrepo_manifest_parser.edk_manifest import ManifestXml
 import edkrepo.common.ui_functions as ui_functions
 
 
@@ -66,30 +57,40 @@ class CreatePinCommand(EdkrepoCommand):
             pin_file_name = os.path.abspath(os.path.normpath(args.PinFileName))
         # If the directory that the pin file is saved in does not exist create it and ensure pin file name uniqueness.
         if os.path.isfile(pin_file_name):
-            raise EdkrepoInvalidParametersException(PIN_FILE_ALREADY_EXISTS)
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.PIN_FILE_ALREADY_EXISTS)
         if not os.path.exists(os.path.dirname(pin_file_name)):
             os.mkdir(os.path.dirname(pin_file_name))
 
-        repo_sources = manifest.get_repo_sources(manifest.general_config.current_combo)
+        updated_repo_sources = []
+        updated_repo_sources = self._generate_pin_data(args, manifest, workspace_path)
 
-        # get the repo sources and commit ids for the pin
-        ui_functions.print_info_msg(GENERATING_PIN_DATA.format(manifest.project_info.codename, manifest.general_config.current_combo), header = False)
+        # create the pin
+        ui_functions.print_info_msg(humble.WRITING_PIN_FILE.format(pin_file_name), header = False)
+        manifest.generate_pin_xml(args.Description, manifest.general_config.current_combo, updated_repo_sources,
+                                  filename=pin_file_name)
+
+    def _generate_pin_data(self, args, manifest, workspace_path):
+        repo_sources = manifest.get_repo_sources(manifest.general_config.current_combo)
+        ui_functions.print_info_msg(humble.GENERATING_PIN_DATA.format(manifest.project_info.codename, manifest.general_config.current_combo), header = False)
         updated_repo_sources = []
         for repo_source in repo_sources:
             local_repo_path = os.path.join(workspace_path, repo_source.root)
             if not os.path.exists(local_repo_path):
-                raise EdkrepoWorkspaceCorruptException(MISSING_REPO.format(repo_source.root))
-            repo = Repo(local_repo_path)
-            commit_id = repo.head.commit.hexsha
-            if args.verbose:
-                ui_functions.print_info_msg(GENERATING_REPO_DATA.format(repo_source.root), header = False)
-                ui_functions.print_info_msg(BRANCH.format(repo_source.branch), header = False)
-                ui_functions.print_info_msg(COMMIT.format(commit_id), header = False)
-            updated_repo_source = repo_source._replace(commit=commit_id)
-            updated_repo_sources.append(updated_repo_source)
-
-        # create the pin
-        ui_functions.print_info_msg(WRITING_PIN_FILE.format(pin_file_name), header = False)
-        manifest.generate_pin_xml(args.Description, manifest.general_config.current_combo, updated_repo_sources,
-                                  filename=pin_file_name)
-
+                raise edkrepo_exception.EdkrepoWorkspaceCorruptException(humble.MISSING_REPO.format(repo_source.root))
+            if repo_source.patch_set:
+                updated_repo_source = repo_source
+                if args.verbose:
+                    ui_functions.print_info_msg(humble.GENERATING_REPO_DATA.format(repo_source.root), header = False)
+                    ui_functions.print_info_msg(humble.BRANCH.format(repo_source.branch), header = False)
+                    ui_functions.print_info_msg(humble.PATCHSET.format(repo_source.patch_set), header = False)
+                updated_repo_sources.append(updated_repo_source)
+            else:
+                repo = Repo(local_repo_path)
+                commit_id = repo.head.commit.hexsha
+                if args.verbose:
+                    ui_functions.print_info_msg(humble.GENERATING_REPO_DATA.format(repo_source.root), header = False)
+                    ui_functions.print_info_msg(humble.BRANCH.format(repo_source.branch), header = False)
+                    ui_functions.print_info_msg(humble.COMMIT.format(commit_id), header = False)
+                updated_repo_source = repo_source._replace(commit=commit_id)
+                updated_repo_sources.append(updated_repo_source)
+        return updated_repo_sources

--- a/edkrepo/commands/unit_tests/CreatePin_TestCases.md
+++ b/edkrepo/commands/unit_tests/CreatePin_TestCases.md
@@ -1,0 +1,73 @@
+# Test Cases for `create_pin_command` Module
+
+## Test Cases
+
+### TestGeneratePinData
+Tests the `_generate_pin_data` method of the `CreatePinCommand` class, which generates pin data for repositories in a workspace by capturing their current state (commit SHAs for regular repositories or patchset information for repositories with patchsets).
+
+#### 1. Repositories Without Patchset
+- **Description**: With repositories that do not have patchsets defined.
+- **Expected Outcome**: The method retrieves the current commit SHA from each Git repository and returns updated repo sources with the commit field populated. All repository attributes are preserved except for the commit field which is updated with the current HEAD commit SHA.
+
+#### 2. Repositories With Patchset
+- **Description**: With repositories that have patchsets defined.
+- **Expected Outcome**: The method returns the repo sources as-is without querying Git repositories or modifying the commit field. Repositories with patchsets are added to the result list with their original patchset information preserved and commit field remaining None.
+
+#### 3. Mixed Repositories (With and Without Patchset)
+- **Description**: With a combination of repositories where some have patchsets and others do not.
+- **Expected Outcome**: Repositories with patchsets are returned as-is, while repositories without patchsets have their commit field updated with the current HEAD commit SHA. All repositories are included in the result list in their original order.
+
+#### 4. Missing Repository
+- **Description**: When a repository specified in the manifest is missing from the workspace.
+- **Expected Outcome**: The method raises an `EdkrepoWorkspaceCorruptException` indicating which repository is missing from the workspace. The exception is raised when `os.path.exists()` returns False for the local repository path.
+
+#### 5. Verbose Mode for Repositories Without Patchset
+- **Description**: With verbose mode enabled for repositories without patchsets.
+- **Expected Outcome**: The method prints verbose information messages including the repository root, branch, and commit SHA for each repository being processed. The `ui_functions.print_info_msg` is called multiple times to output this information.
+
+#### 6. Verbose Mode for Repositories With Patchset
+- **Description**: With verbose mode enabled for repositories with patchsets.
+- **Expected Outcome**: The method prints verbose information messages including the repository root, branch, and patchset name for each repository with a patchset. The `ui_functions.print_info_msg` is called multiple times to output this information.
+
+## Test Implementation Details
+
+### Mock Data Structures
+
+- **MOCK_REPO_SOURCES_NO_PATCHSET**: Two repository sources without patchsets (repo1 on main branch, repo2 on develop branch).
+- **MOCK_REPO_SOURCES_WITH_PATCHSET**: Two repository sources with patchsets (repo1 with patchset1, repo2 with patchset2).
+- **MOCK_REPO_SOURCES_MIXED**: Three repository sources with mixed configuration (repo1 with patchset1, repo2 and repo3 without patchsets).
+
+### Fixtures
+
+- **create_pin_command**: Creates an instance of `CreatePinCommand` for testing.
+- **mock_args**: Provides mock arguments with verbose mode disabled.
+- **mock_args_verbose**: Provides mock arguments with verbose mode enabled.
+- **mock_manifest**: Creates a mock manifest with test project information and current combo.
+- **workspace_path**: Provides a temporary workspace path for testing.
+
+### Mocking Strategy
+
+- Git repository objects are mocked using `unittest.mock.patch` to avoid dependency on actual Git repositories.
+- The `os.path.exists` method is mocked to simulate missing repositories.
+- The `ui_functions.print_info_msg` is mocked to verify verbose output without actual console output.
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - `GitPython` (for RepoSource and Git-related types)
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python -m pytest test_create_pin.py
+   ```
+   
+   To run with verbose output:
+   ```bash
+   python -m pytest test_create_pin.py -v
+   ```
+   
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_create_pin.py
+++ b/edkrepo/commands/unit_tests/test_create_pin.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_create_pin.py
+#
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest import RepoSource, ManifestXml
+from edkrepo.commands.create_pin_command import CreatePinCommand
+import edkrepo.common.edkrepo_exception as edkrepo_exception
+
+
+class TestGeneratePinData:
+    """
+    Test suite for CreatePinCommand._generate_pin_data() method
+    """
+
+    # Mock repo sources without patchset (commit-based)
+    MOCK_REPO_SOURCES_NO_PATCHSET = [
+        RepoSource(
+            root="repo1",
+            remote_name="origin",
+            remote_url="https://example.com/repo1.git",
+            branch="main",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set=None,
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        ),
+        RepoSource(
+            root="repo2",
+            remote_name="origin",
+            remote_url="https://example.com/repo2.git",
+            branch="develop",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set=None,
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        )
+    ]
+
+    # Mock repo sources with patchset
+    MOCK_REPO_SOURCES_WITH_PATCHSET = [
+        RepoSource(
+            root="repo1",
+            remote_name="origin",
+            remote_url="https://example.com/repo1.git",
+            branch="main",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set="patchset1",
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        ),
+        RepoSource(
+            root="repo2",
+            remote_name="origin",
+            remote_url="https://example.com/repo2.git",
+            branch="develop",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set="patchset2",
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        )
+    ]
+
+    # Mixed repo sources (some with patchset, some without)
+    MOCK_REPO_SOURCES_MIXED = [
+        RepoSource(
+            root="repo1",
+            remote_name="origin",
+            remote_url="https://example.com/repo1.git",
+            branch="main",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set="patchset1",
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        ),
+        RepoSource(
+            root="repo2",
+            remote_name="origin",
+            remote_url="https://example.com/repo2.git",
+            branch="develop",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set=None,
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        ),
+        RepoSource(
+            root="repo3",
+            remote_name="origin",
+            remote_url="https://example.com/repo3.git",
+            branch="feature",
+            commit=None,
+            sparse=False,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=None,
+            patch_set=None,
+            blobless=False,
+            treeless=False,
+            nested_repo=False
+        )
+    ]
+
+    @pytest.fixture
+    def create_pin_command(self):
+        """Fixture to create a CreatePinCommand instance"""
+        return CreatePinCommand()
+
+    @pytest.fixture
+    def mock_args(self):
+        """Fixture to create mock arguments"""
+        args = MagicMock()
+        args.verbose = False
+        return args
+
+    @pytest.fixture
+    def mock_args_verbose(self):
+        """Fixture to create mock arguments with verbose enabled"""
+        args = MagicMock()
+        args.verbose = True
+        return args
+
+    @pytest.fixture
+    def mock_manifest(self):
+        """Fixture to create a mock manifest"""
+        manifest = MagicMock(spec=ManifestXml)
+        manifest.project_info.codename = "TestProject"
+        manifest.general_config.current_combo = "main"
+        return manifest
+
+    @pytest.fixture
+    def workspace_path(self, tmp_path):
+        """Fixture to create a temporary workspace path"""
+        return str(tmp_path)
+
+    def test_generate_pin_data_no_patchset(self, create_pin_command, mock_args, mock_manifest, workspace_path):
+        """
+        Test _generate_pin_data with repositories that have no patchset.
+        Should retrieve commit SHA from Git repo and update repo sources.
+        """
+        # Setup
+        manifest_clone = mock_manifest
+        manifest_clone.get_repo_sources.return_value = self.MOCK_REPO_SOURCES_NO_PATCHSET
+
+        # Create temporary repo directories
+        for repo_source in self.MOCK_REPO_SOURCES_NO_PATCHSET:
+            repo_path = os.path.join(workspace_path, repo_source.root)
+            os.makedirs(repo_path, exist_ok=True)
+
+        # Mock Git Repo objects with different commit SHAs
+        with patch('edkrepo.commands.create_pin_command.Repo') as mock_repo_class:
+            mock_repo1 = MagicMock()
+            mock_repo1.head.commit.hexsha = "abc123def456"
+            
+            mock_repo2 = MagicMock()
+            mock_repo2.head.commit.hexsha = "789ghi012jkl"
+            
+            mock_repo_class.side_effect = [mock_repo1, mock_repo2]
+
+            # Execute
+            result = create_pin_command._generate_pin_data(mock_args, manifest_clone, workspace_path)
+
+            # Verify
+            assert len(result) == 2
+            assert result[0].root == "repo1"
+            assert result[0].commit == "abc123def456"
+            assert result[1].root == "repo2"
+            assert result[1].commit == "789ghi012jkl"
+
+    def test_generate_pin_data_with_patchset(self, create_pin_command, mock_args, mock_manifest, workspace_path):
+        """
+        Test _generate_pin_data with repositories that have patchset.
+        Should return repo sources as-is without querying Git repo.
+        """
+        # Setup
+        manifest_clone = mock_manifest
+        manifest_clone.get_repo_sources.return_value = self.MOCK_REPO_SOURCES_WITH_PATCHSET
+
+        # Create temporary repo directories
+        for repo_source in self.MOCK_REPO_SOURCES_WITH_PATCHSET:
+            repo_path = os.path.join(workspace_path, repo_source.root)
+            os.makedirs(repo_path, exist_ok=True)
+
+        # Execute
+        result = create_pin_command._generate_pin_data(mock_args, manifest_clone, workspace_path)
+
+        # Verify - Both repos with patchset should be added as-is to the result list
+        assert len(result) == 2  # Both repos have patchset and should be added as-is
+        assert result[0].root == "repo1"
+        assert result[0].patch_set == "patchset1"
+        assert result[0].commit is None  # Commit should not be modified for patchset repos
+        assert result[1].root == "repo2"
+        assert result[1].patch_set == "patchset2"
+        assert result[1].commit is None  # Commit should not be modified for patchset repos
+
+    def test_generate_pin_data_mixed_patchset(self, create_pin_command, mock_args, mock_manifest, workspace_path):
+        """
+        Test _generate_pin_data with mixed repositories (some with patchset, some without).
+        """
+        # Setup
+        manifest_clone = mock_manifest
+        manifest_clone.get_repo_sources.return_value = self.MOCK_REPO_SOURCES_MIXED
+
+        # Create temporary repo directories
+        for repo_source in self.MOCK_REPO_SOURCES_MIXED:
+            repo_path = os.path.join(workspace_path, repo_source.root)
+            os.makedirs(repo_path, exist_ok=True)
+
+        # Mock Git Repo objects for repos without patchset
+        with patch('edkrepo.commands.create_pin_command.Repo') as mock_repo_class:
+            mock_repo2 = MagicMock()
+            mock_repo2.head.commit.hexsha = "commit2sha"
+            
+            mock_repo3 = MagicMock()
+            mock_repo3.head.commit.hexsha = "commit3sha"
+            
+            mock_repo_class.side_effect = [mock_repo2, mock_repo3]
+
+            # Execute
+            result = create_pin_command._generate_pin_data(mock_args, manifest_clone, workspace_path)
+
+            # Verify - All repos should be in result:
+            # repo1 with patchset (as-is), repo2 and repo3 with updated commits
+            assert len(result) == 3
+            assert result[0].root == "repo1"
+            assert result[0].patch_set == "patchset1"
+            assert result[0].commit is None
+            assert result[1].root == "repo2"
+            assert result[1].commit == "commit2sha"
+            assert result[2].root == "repo3"
+            assert result[2].commit == "commit3sha"
+
+
+    def test_generate_pin_data_verbose_mode_no_patchset(self, create_pin_command, mock_args_verbose, mock_manifest, workspace_path):
+        """
+        Test _generate_pin_data with verbose mode enabled for repos without patchset.
+        Should print verbose information messages.
+        """
+        # Setup
+        manifest_clone = mock_manifest
+        manifest_clone.get_repo_sources.return_value = self.MOCK_REPO_SOURCES_NO_PATCHSET
+
+        # Create temporary repo directories
+        for repo_source in self.MOCK_REPO_SOURCES_NO_PATCHSET:
+            repo_path = os.path.join(workspace_path, repo_source.root)
+            os.makedirs(repo_path, exist_ok=True)
+
+        # Mock Git Repo objects
+        with patch('edkrepo.commands.create_pin_command.Repo') as mock_repo_class:
+            mock_repo1 = MagicMock()
+            mock_repo1.head.commit.hexsha = "abc123"
+            
+            mock_repo2 = MagicMock()
+            mock_repo2.head.commit.hexsha = "def456"
+            
+            mock_repo_class.side_effect = [mock_repo1, mock_repo2]
+
+            # Mock ui_functions to verify verbose output
+            with patch('edkrepo.commands.create_pin_command.ui_functions') as mock_ui:
+                # Execute
+                result = create_pin_command._generate_pin_data(mock_args_verbose, manifest_clone, workspace_path)
+
+                # Verify ui_functions.print_info_msg was called (for verbose output)
+                assert mock_ui.print_info_msg.call_count > 0
+
+    def test_generate_pin_data_verbose_mode_with_patchset(self, create_pin_command, mock_args_verbose, mock_manifest, workspace_path):
+        """
+        Test _generate_pin_data with verbose mode enabled for repos with patchset.
+        Should print verbose information about patchset.
+        """
+        # Setup
+        manifest_clone = mock_manifest
+        manifest_clone.get_repo_sources.return_value = self.MOCK_REPO_SOURCES_WITH_PATCHSET
+
+        # Create temporary repo directories
+        for repo_source in self.MOCK_REPO_SOURCES_WITH_PATCHSET:
+            repo_path = os.path.join(workspace_path, repo_source.root)
+            os.makedirs(repo_path, exist_ok=True)
+
+        # Mock ui_functions to verify verbose output
+        with patch('edkrepo.commands.create_pin_command.ui_functions') as mock_ui:
+            with patch('edkrepo.commands.create_pin_command.Repo') as mock_repo_class:
+                mock_repo = MagicMock()
+                mock_repo.head.commit.hexsha = "abc123"
+                mock_repo_class.return_value = mock_repo
+
+                # Execute
+                result = create_pin_command._generate_pin_data(mock_args_verbose, manifest_clone, workspace_path)
+
+                # Verify ui_functions.print_info_msg was called (for verbose output)
+                assert mock_ui.print_info_msg.call_count > 0

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -3,7 +3,7 @@
 ## @file
 # humble.py
 #
-# Copyright (c) 2017 - 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -129,6 +129,7 @@ GENERATING_PIN_DATA = 'Generating pin data for {0} project based on {1} combinat
 GENERATING_REPO_DATA = 'Generating pin data for {0} repo:'
 BRANCH = '    Branch : {0}'
 COMMIT = '    Commit Id: {0}'
+PATCHSET = '    Patchset: {}'
 WRITING_PIN_FILE = 'Writing pin file to {0} ...'
 COMMIT_MESSAGE = 'Pin file for project: {0} \nPin Description: {1}'
 


### PR DESCRIPTION
Update the create pin command to use the repo_source tuple as is when a patch_set is present; when this data is not present cloning or checking out a pin file will fail as the dynamically generated branch is not present in any remote repository.

Removes un-used imports.

Refactors the create pin command so that the flow for generating pin file data is in a separate method. Adds unit tests for this new method.

Fixes #316