### PR TITLE
EdkRepo: Implement Branch Name Fallback to Determine PR Create/Update…

### DIFF
--- a/edkrepo/commands/humble/send_review_humble.py
+++ b/edkrepo/commands/humble/send_review_humble.py
@@ -42,6 +42,8 @@ NO_TITLE = 'The title argument is required for GitHub pull requests'
 MULTIPLE_OPEN_PRS = 'You currently have {pr_count} pull requests open on branch "{branch_name}". All {pr_count} of them will be updated with this review.'
 CURRENT_BRANCH_NOT_FOUND = 'Could not find current branch "{}" on GitHub.'
 REST_CALL_ERROR = 'There was a problem in attempting to contact GitHub: {}'
+GITHUB_RESPONSE_PARSE_ERROR = 'Received invalid JSON from GitHub API: {}'
+GITHUB_UNEXPECTED_RESPONSE = 'GitHub API returned unexpected data format'
 GIT_EMAIL_NOT_FOUND = 'Email not found or configured in git config. Please set your git email using "git config --global user.email " \n' + SEND_REVIEW_EXIT
 
 # informational messages for send_review_command.py
@@ -63,3 +65,5 @@ ADD_REVIEWERS = 'Adding reviewers to pull request.'
 SEND_REVIEW_INVALID_PR_STRATEGY = 'The specified PR strategy "{}" is invalid. Valid strategies are "branch" and "fork".'
 SEND_REVIEW_PR_FORK_NOT_IMPLEMENTED = 'Sending reviews via the "fork" PR strategy is not yet supported.'
 INVALID_REVIEWER = "Reviews may only be requested from collaborators. {} is not a collaborator of the {} repository."
+LOCAL_BRANCH_UPDATE_EXISTING_PR = 'Local branch not found on GitHub. Based on the branch name, an existing pull request will be updated.'
+LOCAL_BRANCH_CREATE_NEW_PR = 'Local branch not found on GitHub. Based on the branch name, a new pull request branch will be created.'

--- a/edkrepo/commands/send_review_command.py
+++ b/edkrepo/commands/send_review_command.py
@@ -182,32 +182,43 @@ class SendReviewCommand(EdkrepoCommand):
         pr_number = None
         title_string = None
 
-        # Get all active PRs by their PR number in remote, else None if no active PRs
-        active_prs = self.__get_active_prs_on_branch(args, current_branch, modified_repo, manifest, netrc_path)
-        if active_prs:
+        try:
+            # Get all active PRs by their PR number in remote, else raise if no PRs or bad data
+            active_prs = self.__get_active_prs_on_branch(args, current_branch, modified_repo, manifest, netrc_path)
             amend_existing = True
             pr_branch_name = str(current_branch)
-        else:
-            if not args.title:
-                # If there is only one commit to on the branch, then we can use the title of that commit as the title
-                # of the PR if the user did not otherwise specify a title.
-                commit_shas = modified_repo.git.git.rev_list('{}/{}..HEAD'.format(common_repo_functions.DEFAULT_REMOTE_NAME, target_branch))
-                commit_shas = commit_shas.splitlines()
-                if len(commit_shas) != 1:
-                    raise edkrepo_exception.EdkrepoInvalidParametersException(humble.NO_TITLE)
-                commit_message = modified_repo.git.commit(commit_shas[0]).message.splitlines()
-                if len(commit_message) < 1:
-                    raise edkrepo_exception.EdkrepoInvalidParametersException(humble.NO_TITLE)
-                title_string = commit_message[0]
+        except edkrepo_exception.EdkrepoGithubApiFailException as e:
+            # GitHub API failed or returned no data 
+            ui_functions.print_error_msg(str(e), header=True)
+            
+            # Use local branch name to infer whether to update existing PR or create new one
+            if str(current_branch).startswith('pull_request'):
+                ui_functions.print_info_msg(humble.LOCAL_BRANCH_UPDATE_EXISTING_PR, header=False)
+                amend_existing = True
+                pr_branch_name = str(current_branch)
+                active_prs = {}
             else:
-                title_string = ' '.join(args.title)
+                ui_functions.print_info_msg(humble.LOCAL_BRANCH_CREATE_NEW_PR, header=False)
+                if not args.title:
+                    # If there is only one commit to on the branch, then we can use the title of that commit as the title
+                    # of the PR if the user did not otherwise specify a title.
+                    commit_shas = modified_repo.git.git.rev_list('{}/{}..HEAD'.format(common_repo_functions.DEFAULT_REMOTE_NAME, target_branch))
+                    commit_shas = commit_shas.splitlines()
+                    if len(commit_shas) != 1:
+                        raise edkrepo_exception.EdkrepoInvalidParametersException(humble.NO_TITLE)
+                    commit_message = modified_repo.git.commit(commit_shas[0]).message.splitlines()
+                    if len(commit_message) < 1:
+                        raise edkrepo_exception.EdkrepoInvalidParametersException(humble.NO_TITLE)
+                    title_string = commit_message[0]
+                else:
+                    title_string = ' '.join(args.title)
 
-            pr_branch_name = self.__create_pr_branch(config, modified_repo.git, title_string)
+                pr_branch_name = self.__create_pr_branch(config, modified_repo.git, title_string)
 
-            # Only check out the PR branch if we are not in dry-run mode
-            if not args.dry_run:
-                modified_repo.git.heads[pr_branch_name].checkout()
-
+                # Only check out the PR branch if we are not in dry-run mode
+                if not args.dry_run:
+                    modified_repo.git.heads[pr_branch_name].checkout()        
+        
         pr_branch_str = '{}:{}'.format(pr_branch_name, pr_branch_name)
 
         if not amend_existing:
@@ -432,24 +443,36 @@ class SendReviewCommand(EdkrepoCommand):
         curl_process = subprocess.Popen(curl_args, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = curl_process.communicate()
         if stdout:
-            results = json.loads(stdout)
+            try:
+                results = json.loads(stdout)
+            except (json.JSONDecodeError, ValueError) as e:
+                raise edkrepo_exception.EdkrepoGithubApiFailException(humble.GITHUB_RESPONSE_PARSE_ERROR.format(e))
+            
+            # Handle case where API returns an error object instead of an array
+            if isinstance(results, dict) and 'message' in results:
+                raise edkrepo_exception.EdkrepoGithubApiFailException(humble.GITHUB_UNEXPECTED_RESPONSE)
+            
+            # Handle case where results is not iterable or is empty
+            if not isinstance(results, list):
+                raise edkrepo_exception.EdkrepoGithubApiFailException(humble.GITHUB_UNEXPECTED_RESPONSE)
+                
             pr_count = len(results)
             if pr_count >= 1:
                 try:
                     active_prs = {results[i]['number']: results[i]['html_url'] for i in range(pr_count)}
-                except KeyError as e:
+                except (KeyError, IndexError, TypeError) as e:
                     if args.verbose:
-                        ui_functions.print_error_msg(results)
-                        ui_functions.print_info_msg(curl_args)
+                        ui_functions.print_error_msg(str(results), header=False)
                     raise edkrepo_exception.EdkrepoGithubApiFailException(humble.REST_CALL_ERROR.format(e))
                 if pr_count > 1:
                     print()
                     ui_functions.print_info_msg(humble.MULTIPLE_OPEN_PRS.format(pr_count=pr_count, branch_name=current_branch))
                 return active_prs
             else:
-                return None
+                # API returned empty list, no PRs found for this branch
+                raise edkrepo_exception.EdkrepoGithubApiFailException(humble.CURRENT_BRANCH_NOT_FOUND.format(current_branch))
         else:
-            raise edkrepo_exception.EdkrepoWarningException(humble.CURRENT_BRANCH_NOT_FOUND.format(current_branch))
+            raise edkrepo_exception.EdkrepoGithubApiFailException(humble.CURRENT_BRANCH_NOT_FOUND.format(current_branch))
 
     def __get_review_type(self, manifest, repo):
         remote_review_dest = manifest.get_remote(repo.manifest.remote_name)

--- a/edkrepo/commands/unit_tests/SendReviewCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/SendReviewCommand_TestCases.md
@@ -1,0 +1,55 @@
+# Test Cases for `send_review_command` Module
+
+## Test Cases
+
+### TestGetActivePrsOnBranch
+Tests the `__get_active_prs_on_branch` method to ensure it raises `EdkrepoGithubApiFailException` instead of crashing when encountering bad API data. This allows the caller to catch the exception and use local branch-name inference as a fallback.
+
+#### 1. Empty Array Response
+- **Description**: When the GitHub API returns an empty array.
+- **Expected Outcome**: The method raises `EdkrepoGithubApiFailException` with a descriptive message.
+
+#### 2. Missing Fields in Response
+- **Description**: When the GitHub API returns PR data but is missing required fields (e.g., `html_url`).
+- **Expected Outcome**: The method catches the KeyError and raises `EdkrepoGithubApiFailException`.
+
+#### 3. Malformed JSON Response
+- **Description**: When the GitHub API returns invalid JSON that cannot be parsed.
+- **Expected Outcome**: The method catches the JSONDecodeError and raises `EdkrepoGithubApiFailException`.
+
+#### 4. Error Dict Response
+- **Description**: When the GitHub API returns an error object (dict with `message` key) instead of an array.
+- **Expected Outcome**: The method detects the error format and raises `EdkrepoGithubApiFailException`.
+
+#### 5. Non-List Response
+- **Description**: When the GitHub API returns a non-list type such as a string.
+- **Expected Outcome**: The method validates the type and raises `EdkrepoGithubApiFailException`.
+
+### TestBranchNameInference
+Tests the branch name inference fallback logic added to `__send_github_pr_branch_mode` method. When `__get_active_prs_on_branch` raises an exception, the caller uses local branch name starting with 'pull_request' to determine whether to update an existing PR or create a new one.
+
+#### 1. API Success Triggers Update Flow
+- **Description**: When the GitHub API returns valid PR data (dict of PR number to URL).
+- **Expected Outcome**: The method uses the update flow without branch inference. `__create_pr_branch` is not called.
+
+#### 2. Pull Request Branch Name Triggers Update When API Raises Exception
+- **Description**: When the GitHub API raises `EdkrepoGithubApiFailException` and the local branch name starts with 'pull_request'.
+- **Expected Outcome**: The method catches the exception, infers this is an existing PR branch, and uses the update flow. `__create_pr_branch` is not called.
+
+#### 3. Non-Pull Request Branch Name Triggers Create When API Raises Exception
+- **Description**: When the GitHub API raises `EdkrepoGithubApiFailException` and the local branch name does not start with 'pull_request'.
+- **Expected Outcome**: The method catches the exception, infers this is a new feature branch, and uses the create flow. `__create_pr_branch` is called once.
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_send_review_command.py
+++ b/edkrepo/commands/unit_tests/test_send_review_command.py
@@ -1,0 +1,233 @@
+import sys
+import os
+import json
+import pytest
+from unittest.mock import patch, Mock
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.commands.send_review_command import SendReviewCommand
+from edkrepo.common import edkrepo_exception
+
+
+class TestGetActivePrsOnBranch:
+    """Unit tests for the __get_active_prs_on_branch method"""
+
+    @pytest.fixture
+    def command(self):
+        """Provide SendReviewCommand instance"""
+        return SendReviewCommand()
+    
+    @pytest.fixture
+    def mock_args(self):
+        """Provide mock args with common defaults"""
+        args = Mock()
+        args.verbose = False
+        return args
+    
+    @pytest.fixture
+    def mock_manifest(self):
+        """Provide mock manifest with remote configuration"""
+        manifest = Mock()
+        remote = Mock()
+        remote.owner = "test_owner"
+        remote.name = "test_repo"
+        manifest.get_remote = Mock(return_value=remote)
+        return manifest
+    
+    @pytest.fixture
+    def mock_modified_repo(self):
+        """Provide mock repository object"""
+        repo = Mock()
+        repo.manifest = Mock()
+        repo.manifest.remote_name = "origin"
+        return repo
+
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.find_curl')
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.get_proxy_str')
+    @patch('edkrepo.commands.send_review_command.subprocess.Popen')
+    def test_empty_array_response(self, mock_popen, mock_proxy, mock_curl,
+                                  command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that method raises EdkrepoGithubApiFailException when API returns empty array"""
+        mock_curl.return_value = "/usr/bin/curl"
+        mock_proxy.return_value = None
+        
+        mock_process = Mock()
+        mock_process.communicate.return_value = (json.dumps([]).encode(), b'')
+        mock_popen.return_value = mock_process
+        
+        with pytest.raises(edkrepo_exception.EdkrepoGithubApiFailException):
+            command._SendReviewCommand__get_active_prs_on_branch(
+                mock_args, "test_branch", mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.find_curl')
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.get_proxy_str')
+    @patch('edkrepo.commands.send_review_command.subprocess.Popen')
+    def test_missing_fields_in_response(self, mock_popen, mock_proxy, mock_curl,
+                                       command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that method raises EdkrepoGithubApiFailException when API response is missing required fields"""
+        mock_curl.return_value = "/usr/bin/curl"
+        mock_proxy.return_value = None
+        
+        api_response = [{"number": 123}]
+        mock_process = Mock()
+        mock_process.communicate.return_value = (json.dumps(api_response).encode(), b'')
+        mock_popen.return_value = mock_process
+        
+        with pytest.raises(edkrepo_exception.EdkrepoGithubApiFailException):
+            command._SendReviewCommand__get_active_prs_on_branch(
+                mock_args, "test_branch", mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.find_curl')
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.get_proxy_str')
+    @patch('edkrepo.commands.send_review_command.subprocess.Popen')
+    def test_malformed_json_response(self, mock_popen, mock_proxy, mock_curl,
+                                    command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that method raises EdkrepoGithubApiFailException when API returns malformed JSON"""
+        mock_curl.return_value = "/usr/bin/curl"
+        mock_proxy.return_value = None
+        
+        mock_process = Mock()
+        mock_process.communicate.return_value = (b'invalid json{[}', b'')
+        mock_popen.return_value = mock_process
+        
+        with pytest.raises(edkrepo_exception.EdkrepoGithubApiFailException):
+            command._SendReviewCommand__get_active_prs_on_branch(
+                mock_args, "test_branch", mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.find_curl')
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.get_proxy_str')
+    @patch('edkrepo.commands.send_review_command.subprocess.Popen')
+    def test_error_dict_response(self, mock_popen, mock_proxy, mock_curl,
+                                command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that method raises EdkrepoGithubApiFailException when API returns error object"""
+        mock_curl.return_value = "/usr/bin/curl"
+        mock_proxy.return_value = None
+        
+        error_response = {"message": "Not Found"}
+        mock_process = Mock()
+        mock_process.communicate.return_value = (json.dumps(error_response).encode(), b'')
+        mock_popen.return_value = mock_process
+        
+        with pytest.raises(edkrepo_exception.EdkrepoGithubApiFailException):
+            command._SendReviewCommand__get_active_prs_on_branch(
+                mock_args, "test_branch", mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.find_curl')
+    @patch('edkrepo.commands.send_review_command.common_repo_functions.get_proxy_str')
+    @patch('edkrepo.commands.send_review_command.subprocess.Popen')
+    def test_non_list_response(self, mock_popen, mock_proxy, mock_curl,
+                              command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that method raises EdkrepoGithubApiFailException when API returns non-list type"""
+        mock_curl.return_value = "/usr/bin/curl"
+        mock_proxy.return_value = None
+        
+        mock_process = Mock()
+        mock_process.communicate.return_value = (json.dumps("string response").encode(), b'')
+        mock_popen.return_value = mock_process
+        
+        with pytest.raises(edkrepo_exception.EdkrepoGithubApiFailException):
+            command._SendReviewCommand__get_active_prs_on_branch(
+                mock_args, "test_branch", mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+
+
+class TestBranchNameInference:
+    """Unit tests for branch name inference fallback logic"""
+
+    @pytest.fixture
+    def command(self):
+        """Provide SendReviewCommand instance"""
+        return SendReviewCommand()
+    
+    @pytest.fixture
+    def mock_args(self):
+        """Provide mock args with common test defaults"""
+        args = Mock()
+        args.verbose = False
+        args.dry_run = False
+        args.title = ['Test', 'PR']
+        args.draft = False
+        args.reviewers = None
+        args.noweb = True
+        return args
+    
+    @pytest.fixture
+    def mock_manifest(self):
+        """Provide mock manifest with remote configuration"""
+        manifest = Mock()
+        remote = Mock()
+        remote.owner = "test_owner"
+        remote.name = "test_repo"
+        manifest.get_remote = Mock(return_value=remote)
+        return manifest
+    
+    @pytest.fixture
+    def mock_modified_repo(self):
+        """Provide mock repository object with git configuration"""
+        repo = Mock()
+        repo.manifest = Mock()
+        repo.manifest.remote_name = "origin"
+        repo.git = Mock()
+        repo.git.git = Mock()
+        repo.git.git.execute = Mock(return_value=(0, "Success", ""))
+        return repo
+
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__get_active_prs_on_branch')
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__create_pr_branch')
+    def test_api_success_triggers_update_flow(self, mock_create_branch, mock_get_prs,
+                                             command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that valid API response triggers update flow without branch inference"""
+        mock_get_prs.return_value = {123: 'https://github.com/test_owner/test_repo/pull/123'}
+        
+        try:
+            command._SendReviewCommand__send_github_pr_branch_mode(
+                mock_args, Mock(), "feature/my-branch", "main",
+                mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+        except Exception:
+            pass
+        
+        mock_create_branch.assert_not_called()
+
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__get_active_prs_on_branch')
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__create_pr_branch')
+    def test_pull_request_branch_name_triggers_update_when_api_returns_none(self, mock_create_branch, mock_get_prs,
+                                                                           command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that branches starting with pull_request use update flow when API fails"""
+        mock_get_prs.side_effect = edkrepo_exception.EdkrepoGithubApiFailException("Branch not found")
+        
+        try:
+            command._SendReviewCommand__send_github_pr_branch_mode(
+                mock_args, Mock(), "pull_request/user/2025-02-01/test_pr", "main",
+                mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+        except Exception:
+            pass
+        
+        mock_create_branch.assert_not_called()
+
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__get_active_prs_on_branch')
+    @patch('edkrepo.commands.send_review_command.SendReviewCommand._SendReviewCommand__create_pr_branch')
+    def test_non_pull_request_branch_name_triggers_create_when_api_returns_none(self, mock_create_branch, mock_get_prs,
+                                                                                command, mock_args, mock_manifest, mock_modified_repo):
+        """Test that branches not starting with pull_request use create flow when API fails"""
+        mock_get_prs.side_effect = edkrepo_exception.EdkrepoGithubApiFailException("Branch not found")
+        mock_create_branch.return_value = "pull_request/user/2025-02-01/new_pr"
+        
+        # Add heads attribute for branch checkout
+        mock_modified_repo.git.heads = {"pull_request/user/2025-02-01/new_pr": Mock()}
+        
+        try:
+            command._SendReviewCommand__send_github_pr_branch_mode(
+                mock_args, Mock(), "feature/my-branch", "main",
+                mock_modified_repo, mock_manifest, "/path/to/.netrc"
+            )
+        except Exception:
+            pass
+        
+        mock_create_branch.assert_called_once()


### PR DESCRIPTION
… Flow When GitHub API Returns Invalid or Empty Data

Modified the send-review command to handle GitHub REST API failures by raising specific exceptions and using local branch name inference as a fallback. Previously, the command would crash with unhandled exceptions when the API returned empty arrays, malformed JSON, error objects, or responses with missing fields.

Changes:

- Updated __get_active_prs_on_branch() in send_review_command.py to raise EdkrepoGithubApiFailException on:
  - JSON parsing errors (JSONDecodeError, ValueError) with new GITHUB_RESPONSE_PARSE_ERROR message
  - API error responses (dict with 'message' field)
  - Unexpected response types (non-list)
  - Empty arrays (no PRs found)
  - Missing required fields (KeyError, IndexError, TypeError)
- Updated __send_github_pr_branch_mode() in send_review_command.py to catch EdkrepoGithubApiFailException
  - Branches starting with 'pull_request' prefix trigger update flow when API raises exception
  - Other branches trigger create new PR flow when API raises exception
- Added GITHUB_RESPONSE_PARSE_ERROR and GITHUB_UNEXPECTED_RESPONSE constant messages to send_review_humble.py
- Added unit tests for API error handling in test_send_review_command.py
- Added unit tests for branch inference logic in test_send_review_command.py
- Created test case documentation in SendReviewCommand_TestCases.md

Fixes: #321