### PR TITLE
EdkRepo: Create unit tests for the class BaseXmlHelper() and modulari…

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -65,26 +65,20 @@ INVALID_PATCHSET_NAME_ERROR = "The Patchset cannot be named: {}. Please rename t
 PATCHSET_PARENT_CIRCULAR_DEPENDENCY = "The PatchSet parent failed to be determined through recursion.  Check manifest for circular dependencies in daisy-chained PatchSet"
 NO_PARENT_REPO_ERROR = "No parent repository found for the nested repository at '{0}'."
 INVALID_REPO_PATH_ERROR = "The provided repo_local_root '{0}' is not a valid path with multiple sections."
+UNSUPPORTED_EXTENSION_ERROR = "Unsupported file extension: {}"
 
 class BaseXmlHelper():
     def __init__(self, fileref, xml_types):
+        """Load and validate the file (XML or JSON), raising TypeError if the file is invalid or its root tag is not in xml_types."""
         self._fileref = fileref
-        try:
-            file_ext = os.path.splitext(fileref)[1]
-            if file_ext == '.xml':
-                self._tree = ET.ElementTree(file=fileref)  # fileref can be a filename or filestream
-            elif file_ext == '.json':
-                self._tree = self._json_to_xml(fileref)
-            else:
-                raise TypeError(INVALID_XML_ERROR.format(fileref, et_error))
-        except Exception as et_error:
-            raise TypeError(INVALID_XML_ERROR.format(fileref, et_error))
+        self._tree = self._load_tree(fileref)
 
         self._xml_type = self._tree.getroot().tag
         if self._xml_type not in xml_types:
             raise TypeError(UNSUPPORTED_TYPE_ERROR.format(fileref, self._xml_type))
 
     def _json_to_xml(self, fileref):
+        """Read a JSON file, convert it to an ElementTree using _build_etree_node and _pretty_format, and return the tree."""
         with open(fileref, 'r') as f:
             json_in = json.load(f)
 
@@ -99,9 +93,7 @@ class BaseXmlHelper():
 
 
     def _build_etree_node(self, current_dict, parent):
-        '''
-        Build ElementTree node as a subelement of parent node.
-        '''
+        """Build an ElementTree SubElement from current_dict and attach it as a child of parent; recurse into children."""
         node_tag = current_dict['name']
 
         # attribs
@@ -129,11 +121,27 @@ class BaseXmlHelper():
 
 
     def _pretty_format(self, current, parent=None, index=-1, depth=0):
+        """Recursively add indentation whitespace to all nodes in the ElementTree for human-readable formatting."""
         for i, node in enumerate(current):
             self._pretty_format(node, current, i, depth + 1)
         if parent is not None:
             if index == 0:
                 parent.text = '\n' + ('  ' * depth)
+
+    def _load_tree(self, fileref):
+        """Load an ElementTree from a .xml file or a .json file via self._json_to_xml; raise TypeError if the file is invalid or the extension is unsupported."""
+        try:
+            file_ext = os.path.splitext(fileref)[1]
+            if file_ext == '.xml':
+                return ET.ElementTree(file=fileref)  # fileref can be a filename or filestream
+            elif file_ext == '.json':
+                return self._json_to_xml(fileref)
+            else:
+                raise TypeError(INVALID_XML_ERROR.format(fileref, UNSUPPORTED_EXTENSION_ERROR.format(file_ext)))
+        except TypeError:
+            raise
+        except Exception as et_error:
+            raise TypeError(INVALID_XML_ERROR.format(fileref, et_error))
 
 #
 #  This class will parse and the Index XML file and provide the data to the caller

--- a/edkrepo_manifest_parser/unit_tests/BaseXmlHelper_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/BaseXmlHelper_TestCases.md
@@ -1,0 +1,97 @@
+# Test Cases for `BaseXmlHelper` Class
+
+## Test Cases
+
+### TestInit
+Tests `BaseXmlHelper.__init__` which loads and validates the file (XML or JSON), raising `TypeError` if the file is invalid or its root tag is not in `xml_types`.
+
+#### 1. Valid File — Root Tag in xml_types (Manifest)
+- **Description**: `_load_tree` returns a tree whose root tag (`Manifest`) is a member of the provided `xml_types` list.
+- **Expected Outcome**: Instance is created successfully; `_fileref`, `_tree`, and `_xml_type` are set correctly.
+
+#### 2. Root Tag Not in xml_types Raises TypeError
+- **Description**: `_load_tree` returns a tree whose root tag is not in the provided `xml_types` list.
+- **Expected Outcome**: `TypeError` is raised.
+
+#### 3. _load_tree Raises TypeError — Propagates
+- **Description**: `_load_tree` raises a `TypeError` (e.g., the file cannot be parsed).
+- **Expected Outcome**: The `TypeError` propagates out of `__init__` unchanged.
+
+#### 4. Valid File — Root Tag in xml_types (Pin)
+- **Description**: `_load_tree` returns a tree whose root tag (`Pin`) is in `xml_types`.
+- **Expected Outcome**: Instance is created successfully with `_xml_type` set to `Pin`.
+
+### TestJsonToXml
+Tests `_json_to_xml` which reads a JSON file, converts it to an `ElementTree` via `_build_etree_node` and `_pretty_format`, and returns the tree.
+
+#### 5. Valid JSON File — Returns Converted ElementTree and Calls Pretty Format
+- **Description**: `open` and `json.load` are mocked to supply a valid JSON dict; `_build_etree_node` appends a real `SubElement`; `_pretty_format` is a no-op mock.
+- **Expected Outcome**: The returned tree's root tag matches the element appended by the mock `_build_etree_node` and `_pretty_format` is called exactly once.
+
+### TestBuildEtreeNode
+Tests `_build_etree_node` which builds an `ElementTree SubElement` from a dict and attaches it as a child of parent, recursing into children.
+
+#### 6. Dict With All Optional Fields
+- **Description**: The input dict contains `name`, `attrib`, `text`, `tail`, and a single child dict with `name` only.
+- **Expected Outcome**: The `SubElement` is created with the correct tag, attributes, text, and tail; a nested `SubElement` is created for the child.
+
+#### 7. Dict With Name Only
+- **Description**: The input dict contains only the `name` key.
+- **Expected Outcome**: The `SubElement` is created with the correct tag, empty `attrib` dict, `None` text, `None` tail, and no children.
+
+### TestPrettyFormat
+Tests `_pretty_format` which recursively adds indentation whitespace to all nodes in the `ElementTree` for human-readable formatting.
+
+#### 8. Called With Parent and index=0 — Sets parent.text
+- **Description**: A leaf element is passed along with its parent and `index=0` at a specific depth.
+- **Expected Outcome**: `parent.text` is set to a newline followed by the correct number of two-space indents for the given depth.
+
+#### 9. Called With Parent and index != 0 — Does Not Modify parent.text
+- **Description**: A leaf element is passed along with its parent and `index=1`.
+- **Expected Outcome**: `parent.text` is not modified.
+
+#### 10. Called Without Parent — Completes Without Error
+- **Description**: `_pretty_format` is called on the root element with the default `parent=None`.
+- **Expected Outcome**: The call completes without raising any exception.
+
+#### 11. Recurses Into Children — Sets Indentation at Every Level
+- **Description**: `_pretty_format` is called on a root that has a child which itself has a grandchild.
+- **Expected Outcome**: `root.text` and `child.text` are each set to the correct newline-plus-indent string for their respective depths.
+
+### TestLoadTree
+Tests `_load_tree` which loads an `ElementTree` from a `.xml` or `.json` file, raising `TypeError` if the extension is unsupported or parsing fails.
+
+#### 12. XML Extension — Returns ElementTree
+- **Description**: `fileref` has a `.xml` extension; `ET.ElementTree` is patched to return a mock tree.
+- **Expected Outcome**: `ET.ElementTree` is called with `file=fileref` and its return value is returned.
+
+#### 13. JSON Extension — Delegates to _json_to_xml
+- **Description**: `fileref` has a `.json` extension; `_json_to_xml` is mocked on the instance.
+- **Expected Outcome**: `self._json_to_xml` is called with `fileref` and its return value is returned.
+
+#### 14. Unsupported Extension — Raises TypeError
+- **Description**: `fileref` has an extension other than `.xml` or `.json` (e.g., `.xyz`).
+- **Expected Outcome**: `TypeError` is raised.
+
+#### 15. File Parse Error — Raises TypeError
+- **Description**: `ET.ElementTree` is patched to raise an `Exception` during parsing.
+- **Expected Outcome**: The exception is caught and re-raised as a `TypeError`.
+
+#### 16. JSON Parse Error — Raises TypeError
+- **Description**: `_json_to_xml` is mocked to raise an `Exception` during JSON parsing.
+- **Expected Outcome**: The exception is caught and re-raised as a `TypeError`.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_base_xml_helper.py
+++ b/edkrepo_manifest_parser/unit_tests/test_base_xml_helper.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_base_xml_helper.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import xml.etree.ElementTree as ET
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest import BaseXmlHelper
+
+MANIFEST_XML      = '/fake/path/manifest.xml'
+PIN_XML           = '/fake/path/pin.xml'
+MANIFEST_JSON     = '/fake/path/manifest.json'
+MANIFEST_XYZ      = '/fake/path/manifest.xyz'
+MANIFEST_ROOT_TAG = 'Manifest'
+PIN_ROOT_TAG      = 'Pin'
+UNKNOWN_ROOT_TAG  = 'Unknown'
+NODE_SOLO         = 'Solo'
+NODE_PARENT       = 'Parent'
+NODE_CHILD        = 'Child'
+NODE_KEY_NAME     = 'name'
+NODE_KEY_ATTRIB   = 'attrib'
+NODE_KEY_TEXT     = 'text'
+NODE_KEY_TAIL     = 'tail'
+NODE_KEY_CHILDREN = 'children'
+ELEMENT_ROOT_TAG  = 'root'
+ELEMENT_CHILD_TAG = 'child'
+ATTRIB_KEY        = 'key'
+ATTRIB_VAL        = 'val'
+TEXT_VALUE        = 'hello'
+TAIL_VALUE        = ' world'
+ORIGINAL_TEXT     = 'original'
+PARSE_ERROR_MSG            = 'parse error'
+INVALID_FILE_MSG           = 'invalid file'
+PRETTY_FORMAT_INDEX_FIELDS = 'index,expected'
+ID_INDEX_ZERO              = 'index_zero'
+ID_INDEX_NONZERO           = 'index_nonzero'
+INIT_SUCCESS_FIELDS        = 'tag,fileref,xml_types'
+ID_MANIFEST_TYPE           = 'manifest_type'
+ID_PIN_TYPE                = 'pin_type'
+INDENT_DEPTH_1             = '\n  '
+INDENT_DEPTH_2             = '\n    '
+
+
+class TestBaseXmlHelper:
+
+    @staticmethod
+    def _make_mock_tree(tag):
+        """Return a mock ElementTree whose getroot().tag equals tag."""
+        mock_tree = MagicMock()
+        mock_tree.getroot.return_value.tag = tag
+        return mock_tree
+
+    @staticmethod
+    def _build_node(current_dict):
+        """Build an ET node from current_dict via _build_etree_node and return the first child of the parent."""
+        instance = object.__new__(BaseXmlHelper)
+        parent = ET.Element(ELEMENT_ROOT_TAG)
+        instance._build_etree_node(current_dict, parent)
+        return parent[0]
+
+    @staticmethod
+    def _assert_init_raises_typeerror(xml_types):
+        """Assert that BaseXmlHelper(MANIFEST_XML, xml_types) raises TypeError."""
+        with pytest.raises(TypeError):
+            BaseXmlHelper(MANIFEST_XML, xml_types)
+
+    @pytest.fixture
+    def mock_et(self):
+        """Patch ET.ElementTree for the duration of a test; yields the mock class."""
+        with patch('edkrepo_manifest_parser.edk_manifest.ET.ElementTree') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_load_tree(self):
+        """Patch BaseXmlHelper._load_tree for the duration of a test; yields the mock."""
+        with patch.object(BaseXmlHelper, '_load_tree') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_json_open(self):
+        """Patch builtins.open and json.load for the duration of a test; yields (mock_open, mock_json_load)."""
+        with patch('builtins.open') as mock_open, \
+             patch('edkrepo_manifest_parser.edk_manifest.json.load') as mock_json_load:
+            yield mock_open, mock_json_load
+
+    @pytest.fixture
+    def bare_instance(self):
+        """Return a bare BaseXmlHelper instance bypassing __init__."""
+        return object.__new__(BaseXmlHelper)
+
+    @pytest.mark.parametrize(INIT_SUCCESS_FIELDS, [
+        pytest.param(MANIFEST_ROOT_TAG, MANIFEST_XML, [MANIFEST_ROOT_TAG, PIN_ROOT_TAG], id=ID_MANIFEST_TYPE),
+        pytest.param(PIN_ROOT_TAG,      PIN_XML,      [PIN_ROOT_TAG],                    id=ID_PIN_TYPE),
+    ])
+    def test_init_valid_root_tag_sets_attributes(self, mock_load_tree, tag, fileref, xml_types):
+        """When _load_tree returns a tree whose root tag is in xml_types, __init__ must set _fileref, _tree, and _xml_type."""
+        mock_load_tree.return_value = self._make_mock_tree(tag)
+
+        instance = BaseXmlHelper(fileref, xml_types)
+
+        assert instance._fileref == fileref
+        assert instance._tree is mock_load_tree.return_value
+        assert instance._xml_type == tag
+
+    def test_root_tag_not_in_xml_types_raises_typeerror(self, mock_load_tree):
+        """When the root tag is not in xml_types, __init__ must raise TypeError."""
+        mock_load_tree.return_value = self._make_mock_tree(UNKNOWN_ROOT_TAG)
+        self._assert_init_raises_typeerror([MANIFEST_ROOT_TAG, PIN_ROOT_TAG])
+
+    def test_load_tree_raises_typeerror_propagates(self, mock_load_tree):
+        """When _load_tree raises TypeError, the exception must propagate out of __init__ unchanged."""
+        mock_load_tree.side_effect = TypeError(INVALID_FILE_MSG)
+        self._assert_init_raises_typeerror([MANIFEST_ROOT_TAG])
+
+    def test_valid_json_returns_converted_element_tree(self, bare_instance, mock_json_open):
+        """When open and json.load succeed, _json_to_xml must return a tree whose root tag matches the JSON node name and call _pretty_format and _build_etree_node each exactly once."""
+        mock_open, mock_json_load = mock_json_open
+        mock_json_load.return_value = {NODE_KEY_NAME: MANIFEST_ROOT_TAG}
+
+        def mock_build_node(d, p):
+            return ET.SubElement(p, MANIFEST_ROOT_TAG)
+
+        bare_instance._build_etree_node = MagicMock(side_effect=mock_build_node)
+        bare_instance._pretty_format = MagicMock()
+
+        result = bare_instance._json_to_xml(MANIFEST_JSON)
+
+        assert result.getroot().tag == MANIFEST_ROOT_TAG
+        bare_instance._pretty_format.assert_called_once()
+        bare_instance._build_etree_node.assert_called_once()
+
+    def test_dict_with_all_optional_fields(self):
+        """When the dict contains name, attrib, text, tail, and children, _build_etree_node must set all fields and recurse."""
+        node = self._build_node({
+            NODE_KEY_NAME:     NODE_PARENT,
+            NODE_KEY_ATTRIB:   {ATTRIB_KEY: ATTRIB_VAL},
+            NODE_KEY_TEXT:     TEXT_VALUE,
+            NODE_KEY_TAIL:     TAIL_VALUE,
+            NODE_KEY_CHILDREN: [{NODE_KEY_NAME: NODE_CHILD}],
+        })
+
+        assert node.tag == NODE_PARENT
+        assert node.attrib == {ATTRIB_KEY: ATTRIB_VAL}
+        assert node.text == TEXT_VALUE
+        assert node.tail == TAIL_VALUE
+        assert node[0].tag == NODE_CHILD
+
+    def test_dict_with_name_only(self):
+        """When the dict contains only the name key, _build_etree_node must create a SubElement with empty attrib, None text, None tail, and no children."""
+        node = self._build_node({NODE_KEY_NAME: NODE_SOLO})
+
+        assert node.tag == NODE_SOLO
+        assert node.attrib == {}
+        assert node.text is None
+        assert node.tail is None
+        assert len(node) == 0
+
+    @pytest.mark.parametrize(PRETTY_FORMAT_INDEX_FIELDS, [
+        pytest.param(0, INDENT_DEPTH_2, id=ID_INDEX_ZERO),
+        pytest.param(1, ORIGINAL_TEXT,  id=ID_INDEX_NONZERO),
+    ])
+    def test_pretty_format_parent_text_by_index(self, bare_instance, index, expected):
+        """When called with a given index and depth=2, _pretty_format must set parent.text to the expected value."""
+        parent = ET.Element(ELEMENT_ROOT_TAG)
+        parent.text = ORIGINAL_TEXT
+        child = ET.SubElement(parent, ELEMENT_CHILD_TAG)
+
+        bare_instance._pretty_format(child, parent, index, 2)
+
+        assert parent.text == expected
+
+    def test_no_parent_completes_without_error(self, bare_instance):
+        """When called without a parent argument, _pretty_format must complete without raising any exception."""
+        root = ET.Element(ELEMENT_ROOT_TAG)
+
+        bare_instance._pretty_format(root)
+
+    def test_pretty_format_recurses_into_children(self, bare_instance):
+        """When current has nested children, _pretty_format must recursively set indentation on each ancestor's text."""
+        root = ET.Element(ELEMENT_ROOT_TAG)
+        child = ET.SubElement(root, NODE_CHILD)
+        ET.SubElement(child, NODE_CHILD)
+
+        bare_instance._pretty_format(root)
+
+        assert root.text == INDENT_DEPTH_1
+        assert child.text == INDENT_DEPTH_2
+
+    def test_xml_extension_returns_element_tree(self, bare_instance, mock_et):
+        """When fileref has a .xml extension, _load_tree must call ET.ElementTree(file=fileref) and return the result."""
+        mock_tree = MagicMock()
+        mock_et.return_value = mock_tree
+
+        result = bare_instance._load_tree(MANIFEST_XML)
+
+        mock_et.assert_called_once_with(file=MANIFEST_XML)
+        assert result is mock_tree
+
+    def test_json_extension_delegates_to_json_to_xml(self, bare_instance):
+        """When fileref has a .json extension, _load_tree must delegate to self._json_to_xml and return its result."""
+        expected = MagicMock()
+        bare_instance._json_to_xml = MagicMock(return_value=expected)
+
+        result = bare_instance._load_tree(MANIFEST_JSON)
+
+        bare_instance._json_to_xml.assert_called_once_with(MANIFEST_JSON)
+        assert result is expected
+
+    def test_unsupported_extension_raises_typeerror(self, bare_instance):
+        """When fileref has an unsupported extension, _load_tree must raise TypeError."""
+        with pytest.raises(TypeError):
+            bare_instance._load_tree(MANIFEST_XYZ)
+
+    def test_file_parse_error_raises_typeerror(self, bare_instance, mock_et):
+        """When ET.ElementTree raises an exception during parsing, _load_tree must catch it and raise TypeError."""
+        mock_et.side_effect = Exception(PARSE_ERROR_MSG)
+
+        with pytest.raises(TypeError):
+            bare_instance._load_tree(MANIFEST_XML)
+
+    def test_json_parse_error_raises_typeerror(self, bare_instance):
+        """When _json_to_xml raises an exception during JSON parsing, _load_tree must catch it and raise TypeError."""
+        bare_instance._json_to_xml = MagicMock(side_effect=Exception(PARSE_ERROR_MSG))
+
+        with pytest.raises(TypeError):
+            bare_instance._load_tree(MANIFEST_JSON)


### PR DESCRIPTION
…ze its existing methods if needed

Implemented unit tests and documentation for the BaseXmlHelper() class to improve clarity, reliability, and maintainability. Some internal methods were refactored to extract logic into smaller helper functions, making the codebase easier to test.

Changes:
-Added unit tests for the BaseXmlHelper() class, covering the main execution paths and edge cases. 
-Created the corresponding documentation file BaseXmlHelper_TestCases.md. 
-Extracted logic from __init__(self, fileref, xml_types) into a dedicated helper function called _load_tree(fileref, json_to_xml_fn). 
-All new tests rely on mocked dependencies and do not perform filesystem or network operations. 
-Updated internal references to use the refactored helpers.

Fixes: #326