### PR TITLE
EdkRepo: Create unit tests for the cache_command.py module and modula…

### DIFF
--- a/edkrepo/commands/cache_command.py
+++ b/edkrepo/commands/cache_command.py
@@ -3,7 +3,7 @@
 ## @file
 # cache_command.py
 #
-# Copyright (c) 2020-2022, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -104,14 +104,7 @@ class CacheCommand(EdkrepoCommand):
             pull_all_manifest_repos(config['cfg_file'], config['user_cfg_file'])
 
         # Check to see if a manifest was provided and add any missing remotes
-        manifest = None
-        if args.project is not None:
-            manifest = _get_manifest(args.project, config, args.source_manifest_repo)
-        else:
-            try:
-                manifest = get_workspace_manifest()
-            except Exception:
-                pass
+        manifest = _resolve_manifest(args, config)
 
         # If manifest is provided attempt to add any remotes that do not exist
         if manifest is not None and not args.info:
@@ -150,6 +143,7 @@ class CacheCommand(EdkrepoCommand):
         cache_obj.close(args.verbose)
 
 def _create_cache_json_object(info):
+    """Convert a list of cache info items into a JSON-serialisable list of dicts."""
     def _create_cache_dict_item(item):
         return {
             'path': item.path,
@@ -160,6 +154,7 @@ def _create_cache_json_object(info):
     return [_create_cache_dict_item(item) for item in info]
 
 def _get_manifest(project, config, source_manifest_repo=None):
+    """Load and return the ManifestXml for a project path or name; raise EdkrepoCacheException on failure."""
     if os.path.exists(project):
         manifest_path = project
     else:
@@ -179,8 +174,17 @@ def _get_manifest(project, config, source_manifest_repo=None):
         raise EdkrepoCacheException(UNABLE_TO_PARSE_MANIFEST)
     return manifest
 
+def _resolve_manifest(args, config):
+    """Return the ManifestXml for the given args, or None if unavailable."""
+    if args.project is not None:
+        return _get_manifest(args.project, config, args.source_manifest_repo)
+    try:
+        return get_workspace_manifest()
+    except Exception:
+        return None
 
 def _get_used_refs(manifest, cache_obj):
+    """Return a dict mapping remote names to the list of refs that are not yet cached."""
     used_refs = defaultdict(list)
     combo_list = [c.name for c in manifest.combinations]
     for combo in combo_list:
@@ -215,6 +219,7 @@ def _get_used_refs(manifest, cache_obj):
     return used_refs
 
 def _get_used_refs_patchset(manifest, source):
+    """Return a dict mapping remote names to SHAs referenced by CherryPick and Revert patchset operations."""
     used_refs = defaultdict(list)
     patchset = manifest.get_patchset(source.patch_set, source.remote_name)
     patchset_ops = manifest.get_patchset_operations(patchset.name, patchset.remote)
@@ -225,7 +230,9 @@ def _get_used_refs_patchset(manifest, source):
     return used_refs
 
 def _get_operation_remote(patchset, operation):
+    """Return the effective remote for a patchset operation, falling back to the patchset remote."""
     return operation.source_remote if operation.source_remote else patchset.remote
 
 def _flatten_list(lst):
+    """Flatten a list of lists into a single list."""
     return [e for sublist in lst for e in sublist]

--- a/edkrepo/commands/unit_tests/CacheCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/CacheCommand_TestCases.md
@@ -1,0 +1,132 @@
+# Test Cases for `cache_command` Module
+
+## Test Cases
+
+### TestCacheCommand
+All unit tests for the private helper functions of the `cache_command` module are
+contained in a single test class. Shared constants (remote names, URLs, SHAs, paths,
+etc.) are defined as class-level attributes and reused across tests.
+
+#### `_create_cache_json_object`
+Converts a list of cache info items into a JSON-serialisable list of dictionaries.
+
+##### 1. Normal Info List — `test_normal_info_list_produces_correct_dicts`
+- **Description**: A non-empty list of two items built from `CACHE_REPO1_*` / `CACHE_REPO2_*` constants, each with `path`, `remote`, and `url` attributes, is provided.
+- **Expected Outcome**: Returns a list of two dicts each containing the correct `path`, `remote`, and `url` values.
+
+##### 2. Empty Info List — `test_empty_info_list_returns_empty_list`
+- **Description**: An empty list is provided.
+- **Expected Outcome**: Returns an empty list.
+
+#### `_get_manifest`
+Loads and returns a `ManifestXml` for a given project, resolving the manifest file
+path either directly or through the manifest index.
+
+##### 1. Project Is an Existing File Path — `test_project_is_existing_file_loads_manifest_directly`
+- **Description**: `project` is `MANIFEST_PATH_EXISTING`; `os.path.exists` returns `True`.
+- **Expected Outcome**: `ManifestXml` is constructed directly with `MANIFEST_PATH_EXISTING` and returned. `find_project_in_all_indices` is never called.
+
+##### 2. Project Name Found in Indices — `test_project_name_found_in_indices`
+- **Description**: `project` is `PROJECT_NAME`; `os.path.exists` returns `False` but `find_project_in_all_indices` resolves `MANIFEST_PATH_RESOLVED`.
+- **Expected Outcome**: `ManifestXml` is constructed with `MANIFEST_PATH_RESOLVED` and returned.
+
+##### 3. Project Name Not Found in Indices — `test_project_name_not_found_raises_load_exception`
+- **Description**: `project` is `PROJECT_NAME_MISSING`; `os.path.exists` returns `False` and `find_project_in_all_indices` raises an exception.
+- **Expected Outcome**: Raises `EdkrepoCacheException` with the `UNABLE_TO_LOAD_MANIFEST` message.
+
+##### 4. Manifest File Cannot Be Parsed — `test_manifest_parse_failure_raises_parse_exception`
+- **Description**: `project` is `MANIFEST_PATH_BAD`; `os.path.exists` returns `True` but `ManifestXml` raises an exception.
+- **Expected Outcome**: Raises `EdkrepoCacheException` with the `UNABLE_TO_PARSE_MANIFEST` message.
+
+#### `_resolve_manifest`
+Returns a `ManifestXml` instance for the current invocation or `None` when no
+manifest can be found.
+
+##### 1. Project Argument Provided — `test_project_arg_provided_delegates_to_get_manifest`
+- **Description**: `args.project` is set to `PROJECT_NAME` and `args.source_manifest_repo` to `SOURCE_MANIFEST_REPO`.
+- **Expected Outcome**: Delegates to `_get_manifest` with `PROJECT_NAME`, the local `config` dict, and `SOURCE_MANIFEST_REPO`, and returns the resulting manifest.
+
+##### 2. No Project Argument, Workspace Manifest Found — `test_no_project_arg_workspace_manifest_found`
+- **Description**: `args.project` is `None` and `get_workspace_manifest` succeeds.
+- **Expected Outcome**: Returns the manifest returned by `get_workspace_manifest`.
+
+##### 3. No Project Argument, Workspace Manifest Not Found — `test_no_project_arg_workspace_manifest_not_found`
+- **Description**: `args.project` is `None` and `get_workspace_manifest` raises an exception.
+- **Expected Outcome**: Returns `None` without propagating the exception.
+
+#### `_get_used_refs`
+Iterates over all combos and sources in a manifest and builds a map of remote-name
+to list-of-refs that are not yet present in the cache.
+
+##### 1. Source With Uncached Commit — `test_uncached_commit_is_included`
+- **Description**: A source with `commit=COMMIT_SHA`; `cache_obj.is_sha_cached` returns `False`.
+- **Expected Outcome**: `COMMIT_SHA` is included in `used_refs` under `REMOTE_NAME`.
+
+##### 2. Source With Already-Cached Commit — `test_already_cached_commit_is_excluded`
+- **Description**: A source with `commit=COMMIT_SHA`; `cache_obj.is_sha_cached` returns `True`.
+- **Expected Outcome**: `REMOTE_NAME` is absent from the result.
+
+##### 3. Source With Uncached Tag — `test_uncached_tag_is_included`
+- **Description**: A source with `tag=TAG_NAME`; `cache_obj.is_sha_cached` returns `False`.
+- **Expected Outcome**: `TAG_NAME` is included in `used_refs` under `REMOTE_NAME`.
+
+##### 4. Branch With Uncached Head SHA — `test_branch_with_uncached_head_sha_is_included`
+- **Description**: A source with `branch=BRANCH_NAME`; `get_latest_sha` returns `SHA_HEAD` which is not yet cached.
+- **Expected Outcome**: `BRANCH_NAME` is included in `used_refs` under `REMOTE_NAME`.
+
+##### 5. Branch With Unresolvable Head SHA — `test_branch_with_unresolvable_head_sha_is_included`
+- **Description**: A source with `branch=BRANCH_FEATURE`; `get_latest_sha` returns `None`.
+- **Expected Outcome**: `BRANCH_FEATURE` is included in `used_refs` under `REMOTE_NAME`.
+
+##### 6. Source With Patchset — `test_source_with_patchset_delegates_to_get_used_refs_patchset`
+- **Description**: A source with `patch_set=PATCHSET_NAME`; `_get_used_refs_patchset` returns `{REMOTE_NAME: [SHA_FROM_PATCHSET]}`.
+- **Expected Outcome**: `_get_used_refs_patchset` is called once and `SHA_FROM_PATCHSET` is merged into `used_refs` under `REMOTE_NAME`.
+
+#### `_get_used_refs_patchset`
+Collects commit SHAs from `CherryPick` and `Revert` patchset operations into a
+remote-keyed dict.
+
+##### 1. CherryPick and Revert Operations Collected — `test_cherrypick_and_revert_operations_are_collected`
+- **Description**: The patchset contains a `CherryPick` operation with `SHA_CHERRYPICK` and a `Revert` operation with `SHA_REVERT`, both sourced from `REMOTE_NAME`.
+- **Expected Outcome**: Both SHAs appear in `used_refs` under `REMOTE_NAME`.
+
+##### 2. Only Unsupported Operation Types Present — `test_unsupported_operation_types_are_ignored`
+- **Description**: The patchset contains only an `Apply` operation with `SHA_APPLY`.
+- **Expected Outcome**: Returns an empty `defaultdict`; no entries are added.
+
+#### `_get_operation_remote`
+Resolves the effective remote for a patchset operation, falling back to the
+patchset remote when the operation has none of its own.
+
+##### 1. Operation Has a Source Remote — `test_operation_with_source_remote_returns_source_remote`
+- **Description**: A local `operation` mock has `source_remote` set to `REMOTE_EXPLICIT`; a local `patchset` mock has `remote` set to `REMOTE_PATCHSET`.
+- **Expected Outcome**: Returns `REMOTE_EXPLICIT`.
+
+##### 2. Operation Has No Source Remote — `test_operation_without_source_remote_returns_patchset_remote`
+- **Description**: A local `operation` mock has `source_remote` set to `None`; a local `patchset` mock has `remote` set to `REMOTE_PATCHSET`.
+- **Expected Outcome**: Returns `REMOTE_PATCHSET`.
+
+#### `_flatten_list`
+Flattens one level of nesting from a list of lists.
+
+##### 1. Nested List — `test_nested_list_is_flattened`
+- **Description**: `[[1, 2], [3, 4], [5]]` is provided.
+- **Expected Outcome**: Returns `[1, 2, 3, 4, 5]`.
+
+##### 2. Empty List — `test_empty_list_returns_empty_list`
+- **Description**: An empty list is provided.
+- **Expected Outcome**: Returns an empty list.
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_cache_command.py
+++ b/edkrepo/commands/unit_tests/test_cache_command.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_cache_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.commands.cache_command import (
+    _resolve_manifest,
+    _create_cache_json_object,
+    _get_manifest,
+    _get_used_refs,
+    _get_used_refs_patchset,
+    _get_operation_remote,
+    _flatten_list,
+)
+from edkrepo.common.edkrepo_exception import EdkrepoCacheException
+
+
+class TestCacheCommand:
+    """Unit tests for all private helper functions in edkrepo/commands/cache_command.py."""
+
+    REMOTE_NAME = "origin"
+    REMOTE_URL = "https://example.com/repo.git"
+    REMOTE_UPSTREAM = "upstream"
+    REMOTE_PATCHSET = "patchset_remote"
+    REMOTE_EXPLICIT = "explicit_remote"
+
+    CACHE_REPO1_PATH = "/cache/repo1"
+    CACHE_REPO2_PATH = "/cache/repo2"
+    CACHE_REPO1_URL = "https://example.com/repo1.git"
+    CACHE_REPO2_URL = "https://example.com/repo2.git"
+
+    COMMIT_SHA = "abc123"
+    BRANCH_NAME = "main"
+    BRANCH_FEATURE = "feature"
+    TAG_NAME = "v1.0"
+    PATCHSET_NAME = "ps1"
+    COMBO_NAME = "combo1"
+
+    SHA_HEAD = "headsha123"
+    SHA_CHERRYPICK = "sha_cp"
+    SHA_REVERT = "sha_rv"
+    SHA_APPLY = "sha_apply"
+    SHA_FROM_PATCHSET = "sha_from_patchset"
+
+    PROJECT_NAME = "MyProject"
+    PROJECT_NAME_MISSING = "MissingProject"
+    SOURCE_MANIFEST_REPO = "repo1"
+    MANIFEST_PATH_EXISTING = "/some/manifest.xml"
+    MANIFEST_PATH_RESOLVED = "/resolved/manifest.xml"
+    MANIFEST_PATH_BAD = "/bad/manifest.xml"
+
+    # Helper factories
+
+    @staticmethod
+    def _make_source(remote_name="origin", remote_url="https://example.com/repo.git",
+                     commit=None, tag=None, branch=None, patch_set=None):
+        src = MagicMock()
+        src.remote_name = remote_name
+        src.remote_url = remote_url
+        src.commit = commit
+        src.tag = tag
+        src.branch = branch
+        src.patch_set = patch_set
+        return src
+
+    @staticmethod
+    def _make_operation(op_type, sha, source_remote=None):
+        op = MagicMock()
+        op.type = op_type
+        op.sha = sha
+        op.source_remote = source_remote
+        return op
+
+    @staticmethod
+    def _make_info_item(path, remote, url):
+        item = MagicMock()
+        item.path = path
+        item.remote = remote
+        item.url = url
+        return item
+
+    @staticmethod
+    def _make_manifest_with_sources(sources):
+        manifest = MagicMock()
+        combo = MagicMock()
+        combo.name = "combo1"
+        manifest.combinations = [combo]
+        manifest.get_repo_sources.return_value = sources
+        return manifest
+
+    @staticmethod
+    def _make_manifest_with_patchset_ops(operations):
+        manifest = MagicMock()
+        patchset = MagicMock()
+        patchset.name = "ps1"
+        patchset.remote = "origin"
+        manifest.get_patchset.return_value = patchset
+        manifest.get_patchset_operations.return_value = [operations]
+        return manifest, patchset
+
+    # _create_cache_json_object
+
+    def test_normal_info_list_produces_correct_dicts(self):
+        mock_info_items = [
+            self._make_info_item(self.CACHE_REPO1_PATH, self.REMOTE_NAME, self.CACHE_REPO1_URL),
+            self._make_info_item(self.CACHE_REPO2_PATH, self.REMOTE_UPSTREAM, self.CACHE_REPO2_URL),
+        ]
+
+        result = _create_cache_json_object(mock_info_items)
+
+        assert len(result) == 2
+        assert result[0] == {
+            'path': self.CACHE_REPO1_PATH,
+            'remote': self.REMOTE_NAME,
+            'url': self.CACHE_REPO1_URL,
+        }
+        assert result[1] == {
+            'path': self.CACHE_REPO2_PATH,
+            'remote': self.REMOTE_UPSTREAM,
+            'url': self.CACHE_REPO2_URL,
+        }
+
+    def test_empty_info_list_returns_empty_list(self):
+        result = _create_cache_json_object([])
+
+        assert result == []
+
+    # _get_manifest
+
+    @patch('edkrepo.commands.cache_command.os.path.exists', return_value=True)
+    @patch('edkrepo.commands.cache_command.ManifestXml')
+    def test_project_is_existing_file_loads_manifest_directly(self, mock_manifest_xml, mock_exists):
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+        expected_manifest = MagicMock()
+        mock_manifest_xml.return_value = expected_manifest
+
+        result = _get_manifest(self.MANIFEST_PATH_EXISTING, config)
+
+        mock_manifest_xml.assert_called_once_with(self.MANIFEST_PATH_EXISTING)
+        assert result is expected_manifest
+
+    @patch('edkrepo.commands.cache_command.os.path.exists', return_value=False)
+    @patch('edkrepo.commands.cache_command.find_project_in_all_indices',
+           return_value=("repo", "cfg", "/resolved/manifest.xml"))
+    @patch('edkrepo.commands.cache_command.ManifestXml')
+    def test_project_name_found_in_indices(self, mock_manifest_xml, mock_find, mock_exists):
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+        expected_manifest = MagicMock()
+        mock_manifest_xml.return_value = expected_manifest
+
+        result = _get_manifest(self.PROJECT_NAME, config)
+
+        mock_manifest_xml.assert_called_once_with(self.MANIFEST_PATH_RESOLVED)
+        assert result is expected_manifest
+
+    @patch('edkrepo.commands.cache_command.os.path.exists', return_value=False)
+    @patch('edkrepo.commands.cache_command.find_project_in_all_indices', side_effect=Exception("not found"))
+    def test_project_name_not_found_raises_load_exception(self, mock_find, mock_exists):
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+
+        with pytest.raises(EdkrepoCacheException):
+            _get_manifest(self.PROJECT_NAME_MISSING, config)
+
+    @patch('edkrepo.commands.cache_command.os.path.exists', return_value=True)
+    @patch('edkrepo.commands.cache_command.ManifestXml', side_effect=Exception("bad xml"))
+    def test_manifest_parse_failure_raises_parse_exception(self, mock_manifest_xml, mock_exists):
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+
+        with pytest.raises(EdkrepoCacheException):
+            _get_manifest(self.MANIFEST_PATH_BAD, config)
+
+    # _resolve_manifest
+
+    @patch('edkrepo.commands.cache_command._get_manifest')
+    def test_project_arg_provided_delegates_to_get_manifest(self, mock_get_manifest):
+        args = MagicMock()
+        args.project = self.PROJECT_NAME
+        args.source_manifest_repo = self.SOURCE_MANIFEST_REPO
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+        expected_manifest = MagicMock()
+        mock_get_manifest.return_value = expected_manifest
+
+        result = _resolve_manifest(args, config)
+
+        mock_get_manifest.assert_called_once_with(self.PROJECT_NAME, config, self.SOURCE_MANIFEST_REPO)
+        assert result is expected_manifest
+
+    @patch('edkrepo.commands.cache_command.get_workspace_manifest')
+    def test_no_project_arg_workspace_manifest_found(self, mock_get_workspace_manifest):
+        args = MagicMock()
+        args.project = None
+        args.source_manifest_repo = None
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+        expected_manifest = MagicMock()
+        mock_get_workspace_manifest.return_value = expected_manifest
+
+        result = _resolve_manifest(args, config)
+
+        assert result is expected_manifest
+
+    @patch('edkrepo.commands.cache_command.get_workspace_manifest', side_effect=Exception("no workspace"))
+    def test_no_project_arg_workspace_manifest_not_found(self, mock_get_workspace_manifest):
+        args = MagicMock()
+        args.project = None
+        args.source_manifest_repo = None
+        config = {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+
+        result = _resolve_manifest(args, config)
+
+        assert result is None
+
+    # _get_used_refs
+
+    def test_uncached_commit_is_included(self):
+        source = self._make_source(remote_name=self.REMOTE_NAME, commit=self.COMMIT_SHA)
+        cache_obj = MagicMock()
+        cache_obj.is_sha_cached.return_value = False
+        manifest = self._make_manifest_with_sources([source])
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        assert self.REMOTE_NAME in result
+        assert self.COMMIT_SHA in result[self.REMOTE_NAME]
+
+    def test_already_cached_commit_is_excluded(self):
+        source = self._make_source(remote_name=self.REMOTE_NAME, commit=self.COMMIT_SHA)
+        cache_obj = MagicMock()
+        cache_obj.is_sha_cached.return_value = True
+        manifest = self._make_manifest_with_sources([source])
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        assert self.REMOTE_NAME not in result
+
+    def test_uncached_tag_is_included(self):
+        source = self._make_source(remote_name=self.REMOTE_NAME, tag=self.TAG_NAME)
+        cache_obj = MagicMock()
+        cache_obj.is_sha_cached.return_value = False
+        manifest = self._make_manifest_with_sources([source])
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        assert self.REMOTE_NAME in result
+        assert self.TAG_NAME in result[self.REMOTE_NAME]
+
+    @patch('edkrepo.commands.cache_command.get_latest_sha', return_value="headsha123")
+    def test_branch_with_uncached_head_sha_is_included(self, mock_get_latest_sha):
+        source = self._make_source(remote_name=self.REMOTE_NAME, branch=self.BRANCH_NAME)
+        cache_obj = MagicMock()
+        cache_obj.is_sha_cached.return_value = False
+        manifest = self._make_manifest_with_sources([source])
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        assert self.REMOTE_NAME in result
+        assert self.BRANCH_NAME in result[self.REMOTE_NAME]
+
+    @patch('edkrepo.commands.cache_command.get_latest_sha', return_value=None)
+    def test_branch_with_unresolvable_head_sha_is_included(self, mock_get_latest_sha):
+        source = self._make_source(remote_name=self.REMOTE_NAME, branch=self.BRANCH_FEATURE)
+        cache_obj = MagicMock()
+        manifest = self._make_manifest_with_sources([source])
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        assert self.REMOTE_NAME in result
+        assert self.BRANCH_FEATURE in result[self.REMOTE_NAME]
+
+    @patch('edkrepo.commands.cache_command._get_used_refs_patchset')
+    def test_source_with_patchset_delegates_to_get_used_refs_patchset(self, mock_get_used_refs_patchset):
+        source = self._make_source(remote_name=self.REMOTE_NAME, patch_set=self.PATCHSET_NAME)
+        cache_obj = MagicMock()
+        manifest = self._make_manifest_with_sources([source])
+        mock_get_used_refs_patchset.return_value = defaultdict(
+            list, {self.REMOTE_NAME: [self.SHA_FROM_PATCHSET]}
+        )
+
+        result = _get_used_refs(manifest, cache_obj)
+
+        mock_get_used_refs_patchset.assert_called_once_with(manifest, source)
+        assert self.SHA_FROM_PATCHSET in result[self.REMOTE_NAME]
+
+    # _get_used_refs_patchset
+
+    def test_cherrypick_and_revert_operations_are_collected(self):
+        op_cp = self._make_operation('CherryPick', self.SHA_CHERRYPICK, source_remote=self.REMOTE_NAME)
+        op_rv = self._make_operation('Revert', self.SHA_REVERT, source_remote=self.REMOTE_NAME)
+        source = self._make_source(remote_name=self.REMOTE_NAME, patch_set=self.PATCHSET_NAME)
+        manifest, _ = self._make_manifest_with_patchset_ops([op_cp, op_rv])
+
+        result = _get_used_refs_patchset(manifest, source)
+
+        assert self.SHA_CHERRYPICK in result[self.REMOTE_NAME]
+        assert self.SHA_REVERT in result[self.REMOTE_NAME]
+
+    def test_unsupported_operation_types_are_ignored(self):
+        op_other = self._make_operation('Apply', self.SHA_APPLY, source_remote=self.REMOTE_NAME)
+        source = self._make_source(remote_name=self.REMOTE_NAME, patch_set=self.PATCHSET_NAME)
+        manifest, _ = self._make_manifest_with_patchset_ops([op_other])
+
+        result = _get_used_refs_patchset(manifest, source)
+
+        assert result == defaultdict(list)
+
+    # _get_operation_remote
+
+    def test_operation_with_source_remote_returns_source_remote(self):
+        patchset = MagicMock()
+        patchset.remote = self.REMOTE_PATCHSET
+        operation = MagicMock()
+        operation.source_remote = self.REMOTE_EXPLICIT
+
+        result = _get_operation_remote(patchset, operation)
+
+        assert result == self.REMOTE_EXPLICIT
+
+    def test_operation_without_source_remote_returns_patchset_remote(self):
+        patchset = MagicMock()
+        patchset.remote = self.REMOTE_PATCHSET
+        operation = MagicMock()
+        operation.source_remote = None
+
+        result = _get_operation_remote(patchset, operation)
+
+        assert result == self.REMOTE_PATCHSET
+
+    # _flatten_list
+
+    def test_nested_list_is_flattened(self):
+        result = _flatten_list([[1, 2], [3, 4], [5]])
+
+        assert result == [1, 2, 3, 4, 5]
+
+    def test_empty_list_returns_empty_list(self):
+        result = _flatten_list([])
+
+        assert result == []


### PR DESCRIPTION
…rize its existing methods if needed

Implemented unit tests and documentation for the cache_command.py module to improve clarity, reliability, and maintainability. Some internal methods were refactored to extract logic into smaller helper functions, making the codebase easier to test.

Changes:
-Added unit tests for the cache_command.py module, covering the main execution paths and edge cases. 
-Created the corresponding documentation file CacheCommand_TestCases.md. 
-Extracted logic from run_command(self, args, config) into a dedicated helper function called _resolve_manifest(args, config). 
-All new tests rely on mocked dependencies and do not perform filesystem or network operations. 
-Updated internal references to use the refactored helpers.

Fixes: #353