### PR TITLE
EdkRepo: Create unit tests for the checkout_command.py module and mod…

### DIFF
--- a/edkrepo/commands/checkout_command.py
+++ b/edkrepo/commands/checkout_command.py
@@ -3,7 +3,7 @@
 ## @file
 # checkout_command.py
 #
-# Copyright (c) 2017- 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -41,7 +41,11 @@ class CheckoutCommand(EdkrepoCommand):
         manifest = get_workspace_manifest()
         manifest_repo = manifest.general_config.source_manifest_repo
         global_manifest_path = get_manifest_repo_path(manifest_repo, config)
-        if combination_is_in_manifest(args.Combination, manifest):
-            checkout(args.Combination, global_manifest_path, args.verbose, args.override, get_repo_cache_obj(config))
-        else:
-            raise EdkrepoInvalidParametersException(humble.NO_COMBO.format(args.Combination))
+        _checkout_combination(args.Combination, manifest, global_manifest_path, args.verbose, args.override, config)
+
+def _checkout_combination(combination, manifest, global_manifest_path, verbose, override, config):
+    """Check out the requested combination, or raise EdkrepoInvalidParametersException if not found in the manifest."""
+    if combination_is_in_manifest(combination, manifest):
+        checkout(combination, global_manifest_path, verbose, override, get_repo_cache_obj(config))
+    else:
+        raise EdkrepoInvalidParametersException(humble.NO_COMBO.format(combination))

--- a/edkrepo/commands/unit_tests/CheckoutCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/CheckoutCommand_TestCases.md
@@ -1,0 +1,45 @@
+# Test Cases for `checkout_command` Module
+
+## Test Cases
+
+### TestCheckoutCommand
+All unit tests for the `CheckoutCommand` class and its module-level helper function are contained in a single test class. Shared constants (combination names, paths, repo names, metadata keys, argument names, and config keys) are defined as class-level attributes and reused across tests.
+
+#### `get_metadata`
+Returns the command metadata dict including the command name, help text, and argument definitions.
+
+##### 1. Returns Expected Metadata Structure — `test_get_metadata_returns_expected_structure`
+- **Description**: Call `get_metadata` on a fresh `CheckoutCommand` instance.
+- **Expected Outcome**: The returned dict has `name == 'checkout'`, a non-empty `help-text`, and an `arguments` list containing entries for `Combination` and `override`.
+
+#### `run_command`
+Resolves the workspace manifest, looks up the global manifest path, and delegates to `_checkout_combination`.
+
+##### 1. Resolves Manifest and Delegates — `test_run_command_resolves_manifest_and_delegates`
+- **Description**: `get_workspace_manifest` returns a valid manifest; `get_manifest_repo_path` and `_checkout_combination` are patched out.
+- **Expected Outcome**: `_checkout_combination` is called once with the resolved combination, manifest, global manifest path, and the `verbose`/`override` flags from `args`.
+
+#### `_checkout_combination`
+Decides whether to call `checkout` for a valid combination name, or raise `EdkrepoInvalidParametersException` for an unknown one.
+
+##### 1. Valid Combination Triggers Checkout — `test_valid_combination_triggers_checkout`
+- **Description**: `combination_is_in_manifest` returns `True` for the supplied combination name; `get_repo_cache_obj` returns a local cache mock.
+- **Expected Outcome**: `checkout` is called once with the combination, global manifest path, `verbose`, `override`, and the cache object; no exception is raised.
+
+##### 2. Invalid Combination Raises Exception — `test_invalid_combination_raises_exception`
+- **Description**: `combination_is_in_manifest` returns `False` for the supplied combination name.
+- **Expected Outcome**: `EdkrepoInvalidParametersException` is raised and `checkout` is never called.
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_checkout_command.py
+++ b/edkrepo/commands/unit_tests/test_checkout_command.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_checkout_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.commands.checkout_command import CheckoutCommand, _checkout_combination
+from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException
+
+
+class TestCheckoutCommand:
+    """Unit tests for all methods and helper functions in edkrepo/commands/checkout_command.py."""
+
+    COMBINATION_DEV = "DEV"
+    COMBINATION_MISSING = "MISSING"
+    GLOBAL_MANIFEST_PATH = "/global/manifest/path"
+    MANIFEST_REPO = "repo1"
+
+    CFG_FILE = "cfg_file"
+    USER_CFG_FILE = "user_cfg_file"
+    COMMAND_NAME = "checkout"
+    META_NAME = "name"
+    META_HELP_TEXT = "help-text"
+    META_ARGUMENTS = "arguments"
+    ARG_COMBINATION = "Combination"
+    ARG_OVERRIDE = "override"
+
+    # get_metadata
+
+    def test_get_metadata_returns_expected_structure(self):
+        cmd = CheckoutCommand()
+        metadata = cmd.get_metadata()
+
+        assert metadata[self.META_NAME] == self.COMMAND_NAME
+        assert self.META_HELP_TEXT in metadata
+        arg_names = [a[self.META_NAME] if isinstance(a, dict) and self.META_NAME in a else None
+                     for a in metadata[self.META_ARGUMENTS]]
+        assert self.ARG_COMBINATION in arg_names
+        assert self.ARG_OVERRIDE in arg_names
+
+    # run_command
+
+    @patch('edkrepo.commands.checkout_command._checkout_combination')
+    @patch('edkrepo.commands.checkout_command.get_workspace_manifest')
+    @patch('edkrepo.commands.checkout_command.get_manifest_repo_path', return_value=GLOBAL_MANIFEST_PATH)
+    def test_run_command_resolves_manifest_and_delegates(self, mock_get_manifest_repo_path, mock_get_workspace_manifest, mock_checkout_combination):
+        mock_manifest = MagicMock()
+        mock_manifest.general_config.source_manifest_repo = self.MANIFEST_REPO
+        mock_get_workspace_manifest.return_value = mock_manifest
+        args = MagicMock()
+        args.Combination = self.COMBINATION_DEV
+        args.verbose = True
+        args.override = False
+        config = {self.CFG_FILE: MagicMock(), self.USER_CFG_FILE: MagicMock()}
+
+        CheckoutCommand().run_command(args, config)
+
+        mock_checkout_combination.assert_called_once_with(
+            self.COMBINATION_DEV, mock_manifest, self.GLOBAL_MANIFEST_PATH, True, False, config
+        )
+
+    # _checkout_combination
+
+    @patch('edkrepo.commands.checkout_command.checkout')
+    @patch('edkrepo.commands.checkout_command.get_repo_cache_obj')
+    @patch('edkrepo.commands.checkout_command.combination_is_in_manifest', return_value=True)
+    def test_valid_combination_triggers_checkout(self, mock_combination_is_in_manifest, mock_get_repo_cache_obj, mock_checkout):
+        mock_manifest = MagicMock()
+        mock_cache = MagicMock()
+        mock_get_repo_cache_obj.return_value = mock_cache
+        config = {self.CFG_FILE: MagicMock(), self.USER_CFG_FILE: MagicMock()}
+
+        _checkout_combination(self.COMBINATION_DEV, mock_manifest, self.GLOBAL_MANIFEST_PATH, False, False, config)
+
+        mock_checkout.assert_called_once_with(self.COMBINATION_DEV, self.GLOBAL_MANIFEST_PATH, False, False, mock_cache)
+
+    @patch('edkrepo.commands.checkout_command.checkout')
+    @patch('edkrepo.commands.checkout_command.combination_is_in_manifest', return_value=False)
+    def test_invalid_combination_raises_exception(self, mock_combination_is_in_manifest, mock_checkout):
+        mock_manifest = MagicMock()
+        config = {self.CFG_FILE: MagicMock(), self.USER_CFG_FILE: MagicMock()}
+
+        with pytest.raises(EdkrepoInvalidParametersException):
+            _checkout_combination(self.COMBINATION_MISSING, mock_manifest, self.GLOBAL_MANIFEST_PATH, False, False, config)
+
+        mock_checkout.assert_not_called()
+


### PR DESCRIPTION
…ularize its existing methods if needed

Implemented unit tests and documentation for the checkout_command.py module to improve clarity, reliability, and maintainability. Some internal methods were refactored to extract logic into smaller helper functions, making the codebase easier to test.

Changes:
-Added unit tests for the checkout_command.py module, covering the main execution paths and edge cases. 
-Created the corresponding documentation file CheckoutCommand_TestCases.md. 
-Extracted logic from run_command(self, args, config) into a dedicated helper function called _checkout_combination(combination, manifest, global_manifest_path, verbose, override, config). 
-All new tests rely on mocked dependencies and do not perform filesystem or network operations. 
-Updated internal references to use the refactored helpers.

Fixes: #355