### PR TITLE
EdkRepo: Create unit tests for the checkout_pin_command.py module and…

### DIFF
--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -3,7 +3,7 @@
 ## @file
 # checkout_pin_command.py
 #
-# Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -20,13 +20,12 @@ from edkrepo.common.common_repo_functions import check_dirty_repos, checkout_rep
 from edkrepo.common.humble import SPARSE_CHECKOUT, SPARSE_RESET, SUBMODULE_DEINIT_FAILED
 from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoProjectMismatchException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
-from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo, get_manifest_repo_path
+from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import find_source_manifest_repo
 from edkrepo.config.config_factory import get_workspace_path, get_workspace_manifest
 from edkrepo.config.tool_config import SUBMODULE_CACHE_REPO_NAME
 from edkrepo_manifest_parser.edk_manifest import ManifestXml
 from project_utils.submodule import deinit_full, maintain_submodules
 import edkrepo.common.ui_functions as ui_functions
-
 
 
 class CheckoutPinCommand(EdkrepoCommand):
@@ -62,7 +61,7 @@ class CheckoutPinCommand(EdkrepoCommand):
         else:
             manifest_repo_path = None
 
-        pin_path = self.__get_pin_path(args, workspace_path, manifest_repo_path, manifest)
+        pin_path = _get_pin_path(args, workspace_path, manifest_repo_path, manifest)
         pin = ManifestXml(pin_path)
         manifest_sources = manifest.get_repo_sources(manifest.general_config.current_combo)
         check_dirty_repos(manifest, workspace_path)
@@ -71,7 +70,7 @@ class CheckoutPinCommand(EdkrepoCommand):
             repo = Repo(local_path)
             origin = repo.remotes.origin
             origin.fetch()
-        self.__pin_matches_project(pin, manifest, workspace_path)
+        _pin_matches_project(pin, manifest, workspace_path)
         sparse_enabled = sparse_checkout_enabled(workspace_path, manifest_sources)
         if sparse_enabled:
             ui_functions.print_info_msg(SPARSE_RESET, header = False)
@@ -97,77 +96,80 @@ class CheckoutPinCommand(EdkrepoCommand):
                 ui_functions.print_info_msg(SPARSE_CHECKOUT, header = False)
                 sparse_checkout(workspace_path, pin_repo_sources, manifest)
 
-    def __get_pin_path(self, args, workspace_path, manifest_repo_path, manifest):
-        pin_path = None
-        if not args.pinfile.endswith('.xml'):
-            pin_name = '{}.xml'.format(args.pinfile)
-        else:
-            pin_name = args.pinfile
+def _get_pin_path(args, workspace_path, manifest_repo_path, manifest):
+    """Locate the pin XML file via absolute path, manifest repo, or workspace; raise if not found."""
+    pin_path = None
+    if not args.pinfile.endswith('.xml'):
+        pin_name = '{}.xml'.format(args.pinfile)
+    else:
+        pin_name = args.pinfile
 
-        if os.path.isabs(args.pinfile) and os.path.isfile(args.pinfile):
-            pin_path = os.path.normpath(args.pinfile)
-        elif manifest_repo_path is not None:
-            pin_path = self.__find_pin_in_manifest_repo(pin_name, manifest_repo_path, manifest.general_config.pin_path)
-        else:
-            pin_path = self.__find_pin_in_workspace(workspace_path, pin_name)
+    if os.path.isabs(args.pinfile) and os.path.isfile(args.pinfile):
+        pin_path = os.path.normpath(args.pinfile)
+    elif manifest_repo_path is not None:
+        pin_path = _find_pin_in_manifest_repo(pin_name, manifest_repo_path, manifest.general_config.pin_path)
+    else:
+        pin_path = _find_pin_in_workspace(workspace_path, pin_name)
 
-        if pin_path:
-            return pin_path
-        else:
-            raise EdkrepoInvalidParametersException(humble.NOT_FOUND)
+    if pin_path:
+        return pin_path
+    else:
+        raise EdkrepoInvalidParametersException(humble.NOT_FOUND)
+    
+def _find_pin_in_manifest_repo(pin_name, manifest_repo_path, pin_path):
+    """Search for the pin file under the manifest repo pin_path subdirectory and root; return the path or None."""
+    expected_path_in_manifest_repo = os.path.normpath(os.path.join(manifest_repo_path, pin_path, pin_name))
+    path_if_at_root_of_man_repo = os.path.normpath(os.path.join(manifest_repo_path, pin_name))
+    if os.path.isfile(expected_path_in_manifest_repo):
+        return expected_path_in_manifest_repo
+    elif os.path.isfile(path_if_at_root_of_man_repo): # Corner case to catch pins that may have been placed in the root dir of the manifest repo.
+        return path_if_at_root_of_man_repo
+    else:
+        return None
+    
+def _find_pin_in_workspace(workspace_path, pin_name):
+    """Search for the pin file at the workspace root and repo/ subdirectory; return the path or None."""
+    # Before walking the entire workspace attempt to locate the pin at the root and in the repo/ dir as a performance improvement.
+    path_at_wkspc_root = os.path.normpath(os.path.join(workspace_path, pin_name))
+    path_in_repo_dir = os.path.normpath(os.path.join(workspace_path, 'repo', pin_name))
+    if os.path.isfile(path_at_wkspc_root):
+        return path_at_wkspc_root
+    elif os.path.isfile(path_in_repo_dir):
+        return path_in_repo_dir
+    elif os.path.dirname(pin_name) is None:
+        for dirpath, dirnames, filenames in os.walk(workspace_path):
+            if pin_name in filenames:
+                return os.path.join(dirpath, pin_name)
+    else:
+        return None
 
-
-    def __find_pin_in_manifest_repo(self, pin_name, manifest_repo_path, pin_path):
-        expected_path_in_manifest_repo = os.path.normpath(os.path.join(manifest_repo_path, pin_path, pin_name))
-        path_if_at_root_of_man_repo = os.path.normpath(os.path.join(manifest_repo_path, pin_name))
-        if os.path.isfile(expected_path_in_manifest_repo):
-            return expected_path_in_manifest_repo
-        elif os.path.isfile(path_if_at_root_of_man_repo): # Corner case to catch pins that may have been placed in the root dir of the manifest repo.
-            return path_if_at_root_of_man_repo
-        else:
-            return None
-
-    def __find_pin_in_workspace(self, workspace_path, pin_name):
-        # Before walking the entire workspace attempt to locate the pin at the root and in the repo/ dir as a performance improvement.
-        path_at_wkspc_root = os.path.normpath(os.path.join(workspace_path, pin_name))
-        path_in_repo_dir = os.path.normpath(os.path.join(workspace_path, 'repo', pin_name))
-        if os.path.isfile(path_at_wkspc_root):
-            return path_at_wkspc_root
-        elif os.path.isfile(path_in_repo_dir):
-            return path_in_repo_dir
-        elif os.path.dirname(pin_name) is None:
-             for dirpath, dirnames, filenames in os.walk(workspace_path):
-                if pin_name in filenames:
-                    return os.path.join(dirpath, pin_name)
-        else:
-            return None
-
-
-    def __pin_matches_project(self, pin, manifest, workspace_path):
-        manifest_remotes = [(x.name, x.url) for x in manifest.remotes]
-        pin_remotes = [(x.name, x.url) for x in pin.remotes]
-        if pin.project_info.codename != manifest.project_info.codename:
-            raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
-        elif not set(pin_remotes).issubset(set(manifest_remotes)):
-            raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
-        elif pin.general_config.current_combo not in combinations_in_manifest(manifest):
-            ui_functions.print_warning_msg(humble.COMBO_NOT_FOUND.format(pin.general_config.current_combo), header=True)
-        combo_name = pin.general_config.current_combo
-        pin_sources = pin.get_repo_sources(combo_name)
-        pin_root_remote = {source.root:source.remote_name for source in pin_sources}
-        try:
-            # If the pin and the project manifest have the same combo get the
-            # repo sources from that combo. Otherwise get the default combo's
-            # repo sources
-            manifest_sources = manifest.get_repo_sources(combo_name)
-        except ValueError:
-            manifest_sources = manifest.get_repo_sources(manifest.general_config.default_combo)
-        manifest_root_remote = {source.root:source.remote_name for source in manifest_sources}
-        if set(pin_root_remote.items()).isdisjoint(set(manifest_root_remote.items())):
-            raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
-        pin_root_commit = {source.root:source.commit for source in pin_sources}
-        for source in pin_sources:
-            source_repo_path = os.path.join(workspace_path, source.root)
-            repo = Repo(source_repo_path)
-            if repo.commit(pin_root_commit[source.root]) is None:
-                raise EdkrepoProjectMismatchException(humble.NOT_FOUND)
+def _pin_matches_project(pin, manifest, workspace_path):
+    """Validate that the pin's codename, remotes, combo, and repo/remote mapping are compatible with the manifest."""
+    manifest_remotes = [(x.name, x.url) for x in manifest.remotes]
+    pin_remotes = [(x.name, x.url) for x in pin.remotes]
+    if pin.project_info.codename != manifest.project_info.codename:
+        raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
+    elif not set(pin_remotes).issubset(set(manifest_remotes)):
+        raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
+    elif pin.general_config.current_combo not in combinations_in_manifest(manifest):
+        ui_functions.print_warning_msg(humble.COMBO_NOT_FOUND.format(pin.general_config.current_combo), header=True)
+    combo_name = pin.general_config.current_combo
+    pin_sources = pin.get_repo_sources(combo_name)
+    pin_root_remote = {source.root:source.remote_name for source in pin_sources}
+    try:
+        # If the pin and the project manifest have the same combo get the
+        # repo sources from that combo. Otherwise get the default combo's
+        # repo sources
+        manifest_sources = manifest.get_repo_sources(combo_name)
+    except ValueError:
+        manifest_sources = manifest.get_repo_sources(manifest.general_config.default_combo)
+    manifest_root_remote = {source.root:source.remote_name for source in manifest_sources}
+    if set(pin_root_remote.items()).isdisjoint(set(manifest_root_remote.items())):
+        raise EdkrepoProjectMismatchException(humble.MANIFEST_MISMATCH)
+    pin_root_commit = {source.root:source.commit for source in pin_sources}
+    for source in pin_sources:
+        source_repo_path = os.path.join(workspace_path, source.root)
+        repo = Repo(source_repo_path)
+        if repo.commit(pin_root_commit[source.root]) is None:
+            raise EdkrepoProjectMismatchException(humble.NOT_FOUND)
+        

--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -3,7 +3,7 @@
 ## @file
 # checkout_pin_command.py
 #
-# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 

--- a/edkrepo/commands/unit_tests/CheckoutPinCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/CheckoutPinCommand_TestCases.md
@@ -1,0 +1,110 @@
+﻿# Test Cases for `checkout_pin_command` Module
+
+## Test Cases
+
+### TestCheckoutPinCommand
+All unit tests for the `CheckoutPinCommand` class and its module-level helper functions are contained in a single test class. Shared constants (paths, project names, remote info, combo names, repo roots, metadata keys, argument names, and config keys) are defined as class-level attributes and reused across tests.
+
+#### `get_metadata`
+Returns the command metadata dict including the command name, alias, help text, and argument definitions.
+
+##### 1. Returns Expected Metadata Structure — `test_get_metadata_returns_expected_structure`
+- **Description**: Call `get_metadata` on a fresh `CheckoutPinCommand` instance.
+- **Expected Outcome**: The returned dict has `name == 'checkout-pin'`, `alias == 'chp'`, a `help-text` key, and an `arguments` list containing entries for `pinfile`, `override`, and `source-manifest-repo`.
+
+#### `run_command`
+Resolves the workspace path and manifest, locates the pin file, validates project compatibility, checks out repos, and updates the current combo.
+
+##### 1. Performs Checkout and Writes Combo — `test_run_command_performs_checkout_and_writes_combo`
+- **Description**: All external dependencies are patched; `sparse_checkout_enabled` returns `False`; `get_repo_cache_obj` returns `None`; `_get_pin_path`, `ManifestXml`, `checkout_repos`, and `maintain_submodules` are patched out.
+- **Expected Outcome**: `checkout_repos` is called once and `manifest.write_current_combo` is called once.
+
+#### `_get_pin_path`
+Locates the pin XML file via absolute path, manifest repo, or workspace; raises `EdkrepoInvalidParametersException` if not found.
+
+##### 1. Absolute Path Resolved — `test_get_pin_path_absolute_path_resolved`
+- **Description**: `args.pinfile` is an absolute path and `os.path.isfile` returns `True`.
+- **Expected Outcome**: Returns the normalized absolute path.
+
+##### 2. Resolved via Manifest Repo — `test_get_pin_path_resolved_via_manifest_repo`
+- **Description**: `os.path.isabs` returns `False`; `manifest_repo_path` is not `None`; `_find_pin_in_manifest_repo` is patched to return the expected path; pin name has no `.xml` extension.
+- **Expected Outcome**: `_find_pin_in_manifest_repo` is called with `'test.xml'`, the manifest repo path, and the pin subdir; the returned path is returned.
+
+##### 3. Resolved via Workspace — `test_get_pin_path_resolved_via_workspace`
+- **Description**: `os.path.isabs` returns `False`; `manifest_repo_path` is `None`; `_find_pin_in_workspace` is patched to return the expected path.
+- **Expected Outcome**: `_find_pin_in_workspace` is called with the workspace path and pin filename; the returned path is returned.
+
+##### 4. Not Found Raises Exception — `test_get_pin_path_not_found_raises_exception`
+- **Description**: `os.path.isabs` returns `False`; `manifest_repo_path` is `None`; `_find_pin_in_workspace` returns `None`.
+- **Expected Outcome**: `EdkrepoInvalidParametersException` is raised.
+
+#### `_find_pin_in_manifest_repo`
+Searches for the pin file under the manifest repo pin_path subdirectory and root; returns the path or `None`.
+
+##### 1. Found at Expected Subdirectory Path — `test_find_pin_in_manifest_repo_found_at_expected_path`
+- **Description**: `os.path.isfile` returns `True` only for the expected subdirectory path.
+- **Expected Outcome**: Returns the normalized subdirectory path.
+
+##### 2. Found at Root of Manifest Repo — `test_find_pin_in_manifest_repo_found_at_root`
+- **Description**: `os.path.isfile` returns `True` only for the manifest repo root path (corner case).
+- **Expected Outcome**: Returns the normalized root path.
+
+##### 3. Not Found Returns None — `test_find_pin_in_manifest_repo_not_found_returns_none`
+- **Description**: `os.path.isfile` always returns `False`.
+- **Expected Outcome**: Returns `None`.
+
+#### `_find_pin_in_workspace`
+Searches for the pin file at the workspace root and `repo/` subdirectory; returns the path or `None`.
+
+##### 1. Found at Workspace Root — `test_find_pin_in_workspace_found_at_root`
+- **Description**: `os.path.isfile` returns `True` only for the workspace root path.
+- **Expected Outcome**: Returns the normalized workspace root path.
+
+##### 2. Found in `repo/` Subdirectory — `test_find_pin_in_workspace_found_in_repo_subdir`
+- **Description**: `os.path.isfile` returns `True` only for the `repo/` subdirectory path.
+- **Expected Outcome**: Returns the normalized `repo/` path.
+
+##### 3. Not Found Returns None — `test_find_pin_in_workspace_not_found_returns_none`
+- **Description**: `os.path.isfile` always returns `False`.
+- **Expected Outcome**: Returns `None`.
+
+#### `_pin_matches_project`
+Validates that the pin's codename, remotes, combo, and repo/remote mapping are compatible with the manifest.
+
+##### 1. Codename Mismatch Raises Exception — `test_pin_matches_project_codename_mismatch_raises_exception`
+- **Description**: `pin.project_info.codename` differs from `manifest.project_info.codename`.
+- **Expected Outcome**: `EdkrepoProjectMismatchException` is raised.
+
+##### 2. Remotes Not Subset Raises Exception — `test_pin_matches_project_remotes_not_subset_raises_exception`
+- **Description**: Codenames match; pin has a remote not present in the manifest's remote list.
+- **Expected Outcome**: `EdkrepoProjectMismatchException` is raised.
+
+##### 3. Combo Not in Manifest Prints Warning — `test_pin_matches_project_combo_not_in_manifest_prints_warning`
+- **Description**: Codenames and remotes match; `combinations_in_manifest` does not include the pin's current combo; pin and manifest share the same repo source.
+- **Expected Outcome**: `ui_functions.print_warning_msg` is called once; no exception is raised.
+
+##### 4. Root/Remote Mapping Disjoint Raises Exception — `test_pin_matches_project_root_remote_disjoint_raises_exception`
+- **Description**: Codenames and remotes match; pin and manifest sources have completely different root/remote pairs.
+- **Expected Outcome**: `EdkrepoProjectMismatchException` is raised.
+
+##### 5. All Validations Pass — `test_pin_matches_project_all_validations_pass`
+- **Description**: Codenames, remotes, combo, and source root/remote mapping all match; `Repo.commit` returns a valid object.
+- **Expected Outcome**: `repo.commit` is called once with `COMMIT_SHA`; no exception is raised.
+
+##### 6. ValueError Falls Back to Default Combo — `test_pin_matches_project_value_error_falls_back_to_default_combo`
+- **Description**: Codenames, remotes, and combo match; `manifest.get_repo_sources` raises `ValueError` on the first call (pin combo not found in manifest), then returns sources on the second call (default combo).
+- **Expected Outcome**: `manifest.get_repo_sources` is called twice; the second call uses `manifest.general_config.default_combo`.
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo/commands/unit_tests/test_checkout_pin_command.py
+++ b/edkrepo/commands/unit_tests/test_checkout_pin_command.py
@@ -61,24 +61,57 @@ class TestCheckoutPinCommand:
     REPO_SUBDIR = 'repo'
     COMBO_NOT_FOUND_MSG = 'combo not found'
 
-    # --- helpers ---
-
-    @staticmethod
-    def _make_remote(name, url):
+    def _make_remote(self, name, url):
         r = MagicMock()
         r.name = name
         r.url = url
         return r
 
-    @staticmethod
-    def _make_source(root, remote_name, commit='abc'):
+    def _make_source(self, root, remote_name, commit='abc'):
         s = MagicMock()
         s.root = root
         s.remote_name = remote_name
         s.commit = commit
         return s
 
-    # get_metadata
+    def _make_pin_args(self, pinfile):
+        args = MagicMock()
+        args.pinfile = pinfile
+        return args
+
+    @pytest.fixture
+    def default_remote(self):
+        r = MagicMock()
+        r.name = self.REMOTE_NAME
+        r.url = self.REMOTE_URL
+        return r
+
+    @pytest.fixture
+    def default_source(self, default_remote):
+        s = MagicMock()
+        s.root = self.REPO_ROOT_A
+        s.remote_name = default_remote.name
+        s.commit = self.COMMIT_SHA
+        return s
+
+    @pytest.fixture
+    def matched_pin_manifest(self, default_remote):
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        pin.remotes = [default_remote]
+        manifest.remotes = [default_remote]
+        pin.general_config.current_combo = self.COMBO_X
+        return pin, manifest
+
+    @pytest.fixture
+    def mock_pin_repo(self):
+        with patch('edkrepo.commands.checkout_pin_command.Repo') as mock_repo_cls:
+            mock_repo = MagicMock()
+            mock_repo.commit.return_value = MagicMock()
+            mock_repo_cls.return_value = mock_repo
+            yield mock_repo
 
     def test_get_metadata_returns_expected_structure(self):
         cmd = CheckoutPinCommand()
@@ -87,15 +120,10 @@ class TestCheckoutPinCommand:
         assert metadata[self.META_NAME] == self.COMMAND_NAME
         assert metadata[self.META_ALIAS] == self.COMMAND_ALIAS
         assert self.META_HELP_TEXT in metadata
-        arg_names = [
-            a[self.META_NAME] if isinstance(a, dict) and self.META_NAME in a else None
-            for a in metadata[self.META_ARGUMENTS]
-        ]
+        arg_names = [arg[self.META_NAME] for arg in metadata[self.META_ARGUMENTS]]
         assert self.ARG_PINFILE in arg_names
         assert self.ARG_OVERRIDE in arg_names
         assert self.ARG_SOURCE_MANIFEST_REPO in arg_names
-
-    # run_command
 
     @patch('edkrepo.commands.checkout_pin_command.maintain_submodules')
     @patch('edkrepo.commands.checkout_pin_command.get_repo_cache_obj', return_value=None)
@@ -114,19 +142,19 @@ class TestCheckoutPinCommand:
     def test_run_command_performs_checkout_and_writes_combo(
         self, mock_gwp, mock_gwm, mock_fsmr, mock_lavmr, mock_gpp,
         mock_manifest_xml_cls, mock_cdr, mock_repo_cls, mock_pmp,
-        mock_sce, mock_deinit, mock_checkout_repos, mock_grco, mock_ms
+        mock_sce, mock_deinit, mock_checkout_repos, mock_grco, mock_ms,
+        default_source
     ):
         mock_manifest = MagicMock()
         mock_manifest.general_config.current_combo = self.COMBO_X
-        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
-        mock_manifest.get_repo_sources.return_value = [source]
+        mock_manifest.get_repo_sources.return_value = [default_source]
         mock_gwm.return_value = mock_manifest
 
         mock_lavmr.return_value = ([self.MANIFEST_REPO_PATH], [], [])
 
         mock_pin = MagicMock()
         mock_pin.general_config.current_combo = self.COMBO_X
-        mock_pin.get_repo_sources.return_value = [source]
+        mock_pin.get_repo_sources.return_value = [default_source]
         mock_manifest_xml_cls.return_value = mock_pin
 
         mock_repo = MagicMock()
@@ -144,15 +172,12 @@ class TestCheckoutPinCommand:
         mock_checkout_repos.assert_called_once()
         mock_manifest.write_current_combo.assert_called_once()
 
-    # _get_pin_path
-
     @patch('os.path.isfile')
     @patch('os.path.isabs')
     def test_get_pin_path_absolute_path_resolved(self, mock_isabs, mock_isfile):
         mock_isabs.return_value = True
         mock_isfile.return_value = True
-        args = MagicMock()
-        args.pinfile = self.ABS_PIN_PATH
+        args = self._make_pin_args(self.ABS_PIN_PATH)
         manifest = MagicMock()
 
         result = _get_pin_path(args, self.WORKSPACE_PATH, self.MANIFEST_REPO_PATH, manifest)
@@ -165,8 +190,7 @@ class TestCheckoutPinCommand:
     def test_get_pin_path_resolved_via_manifest_repo(self, mock_isabs, mock_isfile, mock_find_in_manifest):
         expected = os.path.normpath(os.path.join(self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR, self.PIN_FILE_XML))
         mock_find_in_manifest.return_value = expected
-        args = MagicMock()
-        args.pinfile = self.PIN_FILE_NO_EXT
+        args = self._make_pin_args(self.PIN_FILE_NO_EXT)
         manifest = MagicMock()
         manifest.general_config.pin_path = self.PIN_PATH_SUBDIR
 
@@ -181,8 +205,7 @@ class TestCheckoutPinCommand:
     def test_get_pin_path_resolved_via_workspace(self, mock_isabs, mock_isfile, mock_find_in_workspace):
         expected = os.path.normpath(os.path.join(self.WORKSPACE_PATH, self.PIN_FILE_XML))
         mock_find_in_workspace.return_value = expected
-        args = MagicMock()
-        args.pinfile = self.PIN_FILE_XML
+        args = self._make_pin_args(self.PIN_FILE_XML)
         manifest = MagicMock()
 
         result = _get_pin_path(args, self.WORKSPACE_PATH, None, manifest)
@@ -194,14 +217,11 @@ class TestCheckoutPinCommand:
     @patch('os.path.isfile', return_value=False)
     @patch('os.path.isabs', return_value=False)
     def test_get_pin_path_not_found_raises_exception(self, mock_isabs, mock_isfile, mock_find_in_workspace):
-        args = MagicMock()
-        args.pinfile = self.PIN_FILE_MISSING
+        args = self._make_pin_args(self.PIN_FILE_MISSING)
         manifest = MagicMock()
 
         with pytest.raises(EdkrepoInvalidParametersException):
             _get_pin_path(args, self.WORKSPACE_PATH, None, manifest)
-
-    # _find_pin_in_manifest_repo
 
     @patch('os.path.isfile')
     def test_find_pin_in_manifest_repo_found_at_expected_path(self, mock_isfile):
@@ -227,8 +247,6 @@ class TestCheckoutPinCommand:
 
         assert result is None
 
-    # _find_pin_in_workspace
-
     @patch('os.path.isfile')
     def test_find_pin_in_workspace_found_at_root(self, mock_isfile):
         root_path = os.path.normpath(os.path.join(self.WORKSPACE_PATH, self.PIN_FILE_XML))
@@ -252,8 +270,6 @@ class TestCheckoutPinCommand:
         result = _find_pin_in_workspace(self.WORKSPACE_PATH, self.PIN_FILE_XML)
 
         assert result is None
-
-    # _pin_matches_project
 
     @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
     def test_pin_matches_project_codename_mismatch_raises_exception(self, mock_combos):
@@ -279,40 +295,25 @@ class TestCheckoutPinCommand:
         with pytest.raises(EdkrepoProjectMismatchException):
             _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
 
-    @patch('edkrepo.commands.checkout_pin_command.Repo')
     @patch('edkrepo.commands.checkout_pin_command.ui_functions')
     @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
-    def test_pin_matches_project_combo_not_in_manifest_prints_warning(self, mock_combos, mock_ui, mock_repo_cls):
-        mock_repo = MagicMock()
-        mock_repo.commit.return_value = MagicMock()
-        mock_repo_cls.return_value = mock_repo
-        pin = MagicMock()
-        manifest = MagicMock()
-        pin.project_info.codename = self.PROJECT_A
-        manifest.project_info.codename = self.PROJECT_A
-        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
-        pin.remotes = [shared_remote]
-        manifest.remotes = [shared_remote]
-        pin.general_config.current_combo = self.COMBO_X
+    def test_pin_matches_project_combo_not_in_manifest_prints_warning(
+        self, mock_combos, mock_ui, mock_pin_repo, matched_pin_manifest, default_source
+    ):
+        pin, manifest = matched_pin_manifest
         mock_combos.return_value = [self.COMBO_Y]
-        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
-        pin.get_repo_sources.return_value = [source]
-        manifest.get_repo_sources.return_value = [source]
+        pin.get_repo_sources.return_value = [default_source]
+        manifest.get_repo_sources.return_value = [default_source]
 
         _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
 
         mock_ui.print_warning_msg.assert_called_once()
 
     @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
-    def test_pin_matches_project_root_remote_disjoint_raises_exception(self, mock_combos):
-        pin = MagicMock()
-        manifest = MagicMock()
-        pin.project_info.codename = self.PROJECT_A
-        manifest.project_info.codename = self.PROJECT_A
-        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
-        pin.remotes = [shared_remote]
-        manifest.remotes = [shared_remote]
-        pin.general_config.current_combo = self.COMBO_X
+    def test_pin_matches_project_root_remote_disjoint_raises_exception(
+        self, mock_combos, matched_pin_manifest
+    ):
+        pin, manifest = matched_pin_manifest
         mock_combos.return_value = [self.COMBO_X]
         pin_source = self._make_source(self.REPO_ROOT_PIN, self.REMOTE_NAME)
         manifest_source = self._make_source(self.REPO_ROOT_MANIFEST, self.UPSTREAM_REMOTE)
@@ -322,47 +323,27 @@ class TestCheckoutPinCommand:
         with pytest.raises(EdkrepoProjectMismatchException):
             _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
 
-    @patch('edkrepo.commands.checkout_pin_command.Repo')
     @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
-    def test_pin_matches_project_all_validations_pass(self, mock_combos, mock_repo_cls):
-        mock_repo = MagicMock()
-        mock_repo.commit.return_value = MagicMock()
-        mock_repo_cls.return_value = mock_repo
-        pin = MagicMock()
-        manifest = MagicMock()
-        pin.project_info.codename = self.PROJECT_A
-        manifest.project_info.codename = self.PROJECT_A
-        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
-        pin.remotes = [shared_remote]
-        manifest.remotes = [shared_remote]
-        pin.general_config.current_combo = self.COMBO_X
+    def test_pin_matches_project_all_validations_pass(
+        self, mock_combos, mock_pin_repo, matched_pin_manifest, default_source
+    ):
+        pin, manifest = matched_pin_manifest
         mock_combos.return_value = [self.COMBO_X]
-        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME, self.COMMIT_SHA)
-        pin.get_repo_sources.return_value = [source]
-        manifest.get_repo_sources.return_value = [source]
+        pin.get_repo_sources.return_value = [default_source]
+        manifest.get_repo_sources.return_value = [default_source]
 
         _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
 
-        mock_repo.commit.assert_called_once_with(self.COMMIT_SHA)
+        mock_pin_repo.commit.assert_called_once_with(self.COMMIT_SHA)
 
-    @patch('edkrepo.commands.checkout_pin_command.Repo')
     @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
-    def test_pin_matches_project_value_error_falls_back_to_default_combo(self, mock_combos, mock_repo_cls):
-        mock_repo = MagicMock()
-        mock_repo.commit.return_value = MagicMock()
-        mock_repo_cls.return_value = mock_repo
-        pin = MagicMock()
-        manifest = MagicMock()
-        pin.project_info.codename = self.PROJECT_A
-        manifest.project_info.codename = self.PROJECT_A
-        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
-        pin.remotes = [shared_remote]
-        manifest.remotes = [shared_remote]
-        pin.general_config.current_combo = self.COMBO_X
+    def test_pin_matches_project_value_error_falls_back_to_default_combo(
+        self, mock_combos, mock_pin_repo, matched_pin_manifest, default_source
+    ):
+        pin, manifest = matched_pin_manifest
         mock_combos.return_value = [self.COMBO_X]
-        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
-        pin.get_repo_sources.return_value = [source]
-        manifest.get_repo_sources.side_effect = [ValueError(self.COMBO_NOT_FOUND_MSG), [source]]
+        pin.get_repo_sources.return_value = [default_source]
+        manifest.get_repo_sources.side_effect = [ValueError(self.COMBO_NOT_FOUND_MSG), [default_source]]
 
         _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
 

--- a/edkrepo/commands/unit_tests/test_checkout_pin_command.py
+++ b/edkrepo/commands/unit_tests/test_checkout_pin_command.py
@@ -1,0 +1,370 @@
+﻿#!/usr/bin/env python3
+#
+## @file
+# test_checkout_pin_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.commands.checkout_pin_command import (
+    CheckoutPinCommand,
+    _get_pin_path,
+    _find_pin_in_manifest_repo,
+    _find_pin_in_workspace,
+    _pin_matches_project,
+)
+from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoProjectMismatchException
+
+
+class TestCheckoutPinCommand:
+    """Unit tests for all methods and helper functions in edkrepo/commands/checkout_pin_command.py."""
+
+    WORKSPACE_PATH = '/workspace'
+    MANIFEST_REPO_PATH = '/manifest/repo'
+    PIN_PATH_SUBDIR = 'pins'
+    PIN_FILE_XML = 'test.xml'
+    PIN_FILE_NO_EXT = 'test'
+    PIN_FILE_MISSING = 'missing.xml'
+    ABS_PIN_PATH = '/absolute/path/test.xml'
+    PROJECT_A = 'ProjectA'
+    PROJECT_B = 'ProjectB'
+    REMOTE_NAME = 'origin'
+    REMOTE_URL = 'https://example.git'
+    EXTRA_REMOTE_URL = 'https://extra.git'
+    UPSTREAM_REMOTE = 'upstream'
+    COMBO_X = 'COMBO_X'
+    COMBO_Y = 'COMBO_Y'
+    REPO_ROOT_A = 'repo_a'
+    REPO_ROOT_PIN = 'repo_pin'
+    REPO_ROOT_MANIFEST = 'repo_manifest'
+    COMMIT_SHA = 'abc'
+    COMMAND_NAME = 'checkout-pin'
+    COMMAND_ALIAS = 'chp'
+    META_NAME = 'name'
+    META_HELP_TEXT = 'help-text'
+    META_ALIAS = 'alias'
+    META_ARGUMENTS = 'arguments'
+    ARG_PINFILE = 'pinfile'
+    ARG_OVERRIDE = 'override'
+    ARG_SOURCE_MANIFEST_REPO = 'source-manifest-repo'
+    CFG_FILE = 'cfg_file'
+    USER_CFG_FILE = 'user_cfg_file'
+    PIN_RESOLVED_PATH = '/workspace/pins/test.xml'
+    MANIFEST_REPO_NAME = 'repo1'
+    REPO_SUBDIR = 'repo'
+    COMBO_NOT_FOUND_MSG = 'combo not found'
+
+    # --- helpers ---
+
+    @staticmethod
+    def _make_remote(name, url):
+        r = MagicMock()
+        r.name = name
+        r.url = url
+        return r
+
+    @staticmethod
+    def _make_source(root, remote_name, commit='abc'):
+        s = MagicMock()
+        s.root = root
+        s.remote_name = remote_name
+        s.commit = commit
+        return s
+
+    # get_metadata
+
+    def test_get_metadata_returns_expected_structure(self):
+        cmd = CheckoutPinCommand()
+        metadata = cmd.get_metadata()
+
+        assert metadata[self.META_NAME] == self.COMMAND_NAME
+        assert metadata[self.META_ALIAS] == self.COMMAND_ALIAS
+        assert self.META_HELP_TEXT in metadata
+        arg_names = [
+            a[self.META_NAME] if isinstance(a, dict) and self.META_NAME in a else None
+            for a in metadata[self.META_ARGUMENTS]
+        ]
+        assert self.ARG_PINFILE in arg_names
+        assert self.ARG_OVERRIDE in arg_names
+        assert self.ARG_SOURCE_MANIFEST_REPO in arg_names
+
+    # run_command
+
+    @patch('edkrepo.commands.checkout_pin_command.maintain_submodules')
+    @patch('edkrepo.commands.checkout_pin_command.get_repo_cache_obj', return_value=None)
+    @patch('edkrepo.commands.checkout_pin_command.checkout_repos')
+    @patch('edkrepo.commands.checkout_pin_command.deinit_full')
+    @patch('edkrepo.commands.checkout_pin_command.sparse_checkout_enabled', return_value=False)
+    @patch('edkrepo.commands.checkout_pin_command._pin_matches_project')
+    @patch('edkrepo.commands.checkout_pin_command.Repo')
+    @patch('edkrepo.commands.checkout_pin_command.check_dirty_repos')
+    @patch('edkrepo.commands.checkout_pin_command.ManifestXml')
+    @patch('edkrepo.commands.checkout_pin_command._get_pin_path', return_value=PIN_RESOLVED_PATH)
+    @patch('edkrepo.commands.checkout_pin_command.list_available_manifest_repos')
+    @patch('edkrepo.commands.checkout_pin_command.find_source_manifest_repo', return_value=MANIFEST_REPO_NAME)
+    @patch('edkrepo.commands.checkout_pin_command.get_workspace_manifest')
+    @patch('edkrepo.commands.checkout_pin_command.get_workspace_path', return_value=WORKSPACE_PATH)
+    def test_run_command_performs_checkout_and_writes_combo(
+        self, mock_gwp, mock_gwm, mock_fsmr, mock_lavmr, mock_gpp,
+        mock_manifest_xml_cls, mock_cdr, mock_repo_cls, mock_pmp,
+        mock_sce, mock_deinit, mock_checkout_repos, mock_grco, mock_ms
+    ):
+        mock_manifest = MagicMock()
+        mock_manifest.general_config.current_combo = self.COMBO_X
+        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
+        mock_manifest.get_repo_sources.return_value = [source]
+        mock_gwm.return_value = mock_manifest
+
+        mock_lavmr.return_value = ([self.MANIFEST_REPO_PATH], [], [])
+
+        mock_pin = MagicMock()
+        mock_pin.general_config.current_combo = self.COMBO_X
+        mock_pin.get_repo_sources.return_value = [source]
+        mock_manifest_xml_cls.return_value = mock_pin
+
+        mock_repo = MagicMock()
+        mock_repo_cls.return_value = mock_repo
+
+        args = MagicMock()
+        args.pinfile = self.PIN_FILE_XML
+        args.verbose = False
+        args.override = False
+        args.source_manifest_repo = None
+        config = {self.CFG_FILE: MagicMock(), self.USER_CFG_FILE: MagicMock()}
+
+        CheckoutPinCommand().run_command(args, config)
+
+        mock_checkout_repos.assert_called_once()
+        mock_manifest.write_current_combo.assert_called_once()
+
+    # _get_pin_path
+
+    @patch('os.path.isfile')
+    @patch('os.path.isabs')
+    def test_get_pin_path_absolute_path_resolved(self, mock_isabs, mock_isfile):
+        mock_isabs.return_value = True
+        mock_isfile.return_value = True
+        args = MagicMock()
+        args.pinfile = self.ABS_PIN_PATH
+        manifest = MagicMock()
+
+        result = _get_pin_path(args, self.WORKSPACE_PATH, self.MANIFEST_REPO_PATH, manifest)
+
+        assert result == os.path.normpath(self.ABS_PIN_PATH)
+
+    @patch('edkrepo.commands.checkout_pin_command._find_pin_in_manifest_repo')
+    @patch('os.path.isfile', return_value=False)
+    @patch('os.path.isabs', return_value=False)
+    def test_get_pin_path_resolved_via_manifest_repo(self, mock_isabs, mock_isfile, mock_find_in_manifest):
+        expected = os.path.normpath(os.path.join(self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR, self.PIN_FILE_XML))
+        mock_find_in_manifest.return_value = expected
+        args = MagicMock()
+        args.pinfile = self.PIN_FILE_NO_EXT
+        manifest = MagicMock()
+        manifest.general_config.pin_path = self.PIN_PATH_SUBDIR
+
+        result = _get_pin_path(args, self.WORKSPACE_PATH, self.MANIFEST_REPO_PATH, manifest)
+
+        mock_find_in_manifest.assert_called_once_with(self.PIN_FILE_XML, self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR)
+        assert result == expected
+
+    @patch('edkrepo.commands.checkout_pin_command._find_pin_in_workspace')
+    @patch('os.path.isfile', return_value=False)
+    @patch('os.path.isabs', return_value=False)
+    def test_get_pin_path_resolved_via_workspace(self, mock_isabs, mock_isfile, mock_find_in_workspace):
+        expected = os.path.normpath(os.path.join(self.WORKSPACE_PATH, self.PIN_FILE_XML))
+        mock_find_in_workspace.return_value = expected
+        args = MagicMock()
+        args.pinfile = self.PIN_FILE_XML
+        manifest = MagicMock()
+
+        result = _get_pin_path(args, self.WORKSPACE_PATH, None, manifest)
+
+        mock_find_in_workspace.assert_called_once_with(self.WORKSPACE_PATH, self.PIN_FILE_XML)
+        assert result == expected
+
+    @patch('edkrepo.commands.checkout_pin_command._find_pin_in_workspace', return_value=None)
+    @patch('os.path.isfile', return_value=False)
+    @patch('os.path.isabs', return_value=False)
+    def test_get_pin_path_not_found_raises_exception(self, mock_isabs, mock_isfile, mock_find_in_workspace):
+        args = MagicMock()
+        args.pinfile = self.PIN_FILE_MISSING
+        manifest = MagicMock()
+
+        with pytest.raises(EdkrepoInvalidParametersException):
+            _get_pin_path(args, self.WORKSPACE_PATH, None, manifest)
+
+    # _find_pin_in_manifest_repo
+
+    @patch('os.path.isfile')
+    def test_find_pin_in_manifest_repo_found_at_expected_path(self, mock_isfile):
+        expected = os.path.normpath(os.path.join(self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR, self.PIN_FILE_XML))
+        mock_isfile.side_effect = lambda p: p == expected
+
+        result = _find_pin_in_manifest_repo(self.PIN_FILE_XML, self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR)
+
+        assert result == expected
+
+    @patch('os.path.isfile')
+    def test_find_pin_in_manifest_repo_found_at_root(self, mock_isfile):
+        root_path = os.path.normpath(os.path.join(self.MANIFEST_REPO_PATH, self.PIN_FILE_XML))
+        mock_isfile.side_effect = lambda p: p == root_path
+
+        result = _find_pin_in_manifest_repo(self.PIN_FILE_XML, self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR)
+
+        assert result == root_path
+
+    @patch('os.path.isfile', return_value=False)
+    def test_find_pin_in_manifest_repo_not_found_returns_none(self, mock_isfile):
+        result = _find_pin_in_manifest_repo(self.PIN_FILE_XML, self.MANIFEST_REPO_PATH, self.PIN_PATH_SUBDIR)
+
+        assert result is None
+
+    # _find_pin_in_workspace
+
+    @patch('os.path.isfile')
+    def test_find_pin_in_workspace_found_at_root(self, mock_isfile):
+        root_path = os.path.normpath(os.path.join(self.WORKSPACE_PATH, self.PIN_FILE_XML))
+        mock_isfile.side_effect = lambda p: p == root_path
+
+        result = _find_pin_in_workspace(self.WORKSPACE_PATH, self.PIN_FILE_XML)
+
+        assert result == root_path
+
+    @patch('os.path.isfile')
+    def test_find_pin_in_workspace_found_in_repo_subdir(self, mock_isfile):
+        repo_path = os.path.normpath(os.path.join(self.WORKSPACE_PATH, self.REPO_SUBDIR, self.PIN_FILE_XML))
+        mock_isfile.side_effect = lambda p: p == repo_path
+
+        result = _find_pin_in_workspace(self.WORKSPACE_PATH, self.PIN_FILE_XML)
+
+        assert result == repo_path
+
+    @patch('os.path.isfile', return_value=False)
+    def test_find_pin_in_workspace_not_found_returns_none(self, mock_isfile):
+        result = _find_pin_in_workspace(self.WORKSPACE_PATH, self.PIN_FILE_XML)
+
+        assert result is None
+
+    # _pin_matches_project
+
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_codename_mismatch_raises_exception(self, mock_combos):
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_B
+        pin.remotes = []
+        manifest.remotes = []
+
+        with pytest.raises(EdkrepoProjectMismatchException):
+            _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_remotes_not_subset_raises_exception(self, mock_combos):
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        pin.remotes = [self._make_remote(self.REMOTE_NAME, self.EXTRA_REMOTE_URL)]
+        manifest.remotes = []
+
+        with pytest.raises(EdkrepoProjectMismatchException):
+            _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+    @patch('edkrepo.commands.checkout_pin_command.Repo')
+    @patch('edkrepo.commands.checkout_pin_command.ui_functions')
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_combo_not_in_manifest_prints_warning(self, mock_combos, mock_ui, mock_repo_cls):
+        mock_repo = MagicMock()
+        mock_repo.commit.return_value = MagicMock()
+        mock_repo_cls.return_value = mock_repo
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
+        pin.remotes = [shared_remote]
+        manifest.remotes = [shared_remote]
+        pin.general_config.current_combo = self.COMBO_X
+        mock_combos.return_value = [self.COMBO_Y]
+        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
+        pin.get_repo_sources.return_value = [source]
+        manifest.get_repo_sources.return_value = [source]
+
+        _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+        mock_ui.print_warning_msg.assert_called_once()
+
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_root_remote_disjoint_raises_exception(self, mock_combos):
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
+        pin.remotes = [shared_remote]
+        manifest.remotes = [shared_remote]
+        pin.general_config.current_combo = self.COMBO_X
+        mock_combos.return_value = [self.COMBO_X]
+        pin_source = self._make_source(self.REPO_ROOT_PIN, self.REMOTE_NAME)
+        manifest_source = self._make_source(self.REPO_ROOT_MANIFEST, self.UPSTREAM_REMOTE)
+        pin.get_repo_sources.return_value = [pin_source]
+        manifest.get_repo_sources.return_value = [manifest_source]
+
+        with pytest.raises(EdkrepoProjectMismatchException):
+            _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+    @patch('edkrepo.commands.checkout_pin_command.Repo')
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_all_validations_pass(self, mock_combos, mock_repo_cls):
+        mock_repo = MagicMock()
+        mock_repo.commit.return_value = MagicMock()
+        mock_repo_cls.return_value = mock_repo
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
+        pin.remotes = [shared_remote]
+        manifest.remotes = [shared_remote]
+        pin.general_config.current_combo = self.COMBO_X
+        mock_combos.return_value = [self.COMBO_X]
+        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME, self.COMMIT_SHA)
+        pin.get_repo_sources.return_value = [source]
+        manifest.get_repo_sources.return_value = [source]
+
+        _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+        mock_repo.commit.assert_called_once_with(self.COMMIT_SHA)
+
+    @patch('edkrepo.commands.checkout_pin_command.Repo')
+    @patch('edkrepo.commands.checkout_pin_command.combinations_in_manifest')
+    def test_pin_matches_project_value_error_falls_back_to_default_combo(self, mock_combos, mock_repo_cls):
+        mock_repo = MagicMock()
+        mock_repo.commit.return_value = MagicMock()
+        mock_repo_cls.return_value = mock_repo
+        pin = MagicMock()
+        manifest = MagicMock()
+        pin.project_info.codename = self.PROJECT_A
+        manifest.project_info.codename = self.PROJECT_A
+        shared_remote = self._make_remote(self.REMOTE_NAME, self.REMOTE_URL)
+        pin.remotes = [shared_remote]
+        manifest.remotes = [shared_remote]
+        pin.general_config.current_combo = self.COMBO_X
+        mock_combos.return_value = [self.COMBO_X]
+        source = self._make_source(self.REPO_ROOT_A, self.REMOTE_NAME)
+        pin.get_repo_sources.return_value = [source]
+        manifest.get_repo_sources.side_effect = [ValueError(self.COMBO_NOT_FOUND_MSG), [source]]
+
+        _pin_matches_project(pin, manifest, self.WORKSPACE_PATH)
+
+        assert manifest.get_repo_sources.call_count == 2
+        manifest.get_repo_sources.assert_called_with(manifest.general_config.default_combo)


### PR DESCRIPTION
… modularize its existing methods if needed

Implemented unit tests and documentation for the checkout_pin_command.py module to improve clarity, reliability, and maintainability.

Changes:
-Added unit tests for the checkout_pin_command.py module, covering the main execution paths and edge cases. 
-Created the corresponding documentation file CheckoutPinCommand_TestCases.md. 
-Renamed __get_pin_path(self, args, workspace_path, manifest_repo_path, manifest) to _get_pin_path(args, workspace_path, manifest_repo_path, manifest), __find_pin_in_manifest_repo(self, pin_name, manifest_repo_path, pin_path) to _find_pin_in_manifest_repo(pin_name, manifest_repo_path, pin_path), __find_pin_in_workspace(self, workspace_path, pin_name) to _find_pin_in_workspace(workspace_path, pin_name), and __pin_matches_project(self, pin, manifest, workspace_path) to _pin_matches_project(pin, manifest, workspace_path) to allow test usage. 
-All new tests rely on mocked dependencies and do not perform filesystem or network operations. 
-Updated internal references to use the refactored helpers.

Fixes: #356