### PR TITLE
Make nested_repo an opt-in SourceRepo attribute in edkrepo manifests.

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1127,10 +1127,13 @@ class _RepoSource():
 
         if self.patch_set is not None and (self.branch is not None or self.commit is not None or self.tag is not None):
             raise ValueError(INVALID_COMBO_DEFINITION_ERROR)
-        
-        if len(os.path.normpath(self.root).split(os.path.sep)) > 1:
-            self.nested_repo = True
-        else:
+
+        try:
+            if (element.attrib['nested_repo'].lower() == 'true') and len(os.path.normpath(self.root).split(os.path.sep)) > 1:
+                self.nested_repo = True
+            else:
+                self.nested_repo = False
+        except Exception:
             self.nested_repo = False
 
     @property


### PR DESCRIPTION
Do not apply the nested_repo feature to existing manifest repositories implemented before edkrepo 3.3.0 tianocore release based off OS filepath alone.

Issue:
https://github.com/tianocore/edk2-edkrepo/issues/324