### PR TITLE
EdkRepo: Create unit tests for the module‑level functions in edk_mani…

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/edk_manifest_validation.py
@@ -64,76 +64,69 @@ def _try_parse_manifest_xml(manifest_file):
     except Exception as e_message:
         return None, e_message
 
+def _collect_file_validation_results(manifest_filepath):
+    """Validate parsing and codename for a single manifest file; return a list of (type, status, message) result tuples."""
+    manifest_obj = ValidateManifest(manifest_filepath)
+    results = []
+    validate_parsing = manifest_obj.validate_parsing()
+    results.append(validate_parsing)
+    if manifest_obj._manifest_xmldata:
+        val_codename = manifest_obj.validate_codename(manifest_obj._manifest_xmldata.project_info.codename)
+        results.append(val_codename)
+    else:
+        results.append(('CODENAME', False, 'Cannot process codename validation'))
+    return results
+
+def _resolve_project_manifest_path(ci_index_xml, global_manifest_directory, project):
+    """Return the absolute filesystem path to the manifest XML file for the given project."""
+    project_path = os.path.normpath(ci_index_xml.get_project_xml(project))
+    return os.path.join(global_manifest_directory, project_path)
+
+def _collect_project_validation_results(manifest_filepath, project, project_list, ci_index_filename):
+    """Run parsing, codename, and deduplication validations for one project; return a list of (type, status, message) result tuples."""
+    manifest_obj = ValidateManifest(manifest_filepath)
+    results = []
+    validate_parsing = manifest_obj.validate_parsing()
+    results.append(validate_parsing)
+    val_codename = manifest_obj.validate_codename(project)
+    results.append(val_codename)
+    val_name_duplication = manifest_obj.validate_case_insensitive_single_match(project, project_list, ci_index_filename)
+    results.append(val_name_duplication)
+    return results
+
 def validate_manifestfiles(manifestfile_list=[]):
+    """Validate parsing and codename for each manifest file in the list; return a dict mapping filepath to result lists."""
     manifestfile_validation = {}
     for manifest_filepath in manifestfile_list:
-        manifest_obj = None
-        validate_parsing = None
-        val_codename = None
-        results = []
-        # Validate parsing and add results
-        manifest_obj = ValidateManifest(manifest_filepath)
-        validate_parsing = manifest_obj.validate_parsing()
-        results.append(validate_parsing)
-
-        # Validate code name and add results
-        if manifest_obj._manifest_xmldata:
-            val_codename = manifest_obj.validate_codename(manifest_obj._manifest_xmldata.project_info.codename)
-            results.append(val_codename)
-            manifestfile_validation[manifest_filepath] = results
-        else:
-            results.append(('CODENAME', False, 'Cannot process codename validation'))
-        manifestfile_validation[manifest_filepath] = results
+        manifestfile_validation[manifest_filepath] = _collect_file_validation_results(manifest_filepath)
     return manifestfile_validation
 
 def validate_manifestrepo(global_manifest_directory, verify_archived=False):
+    """Validate all manifest files referenced by CiIndex.xml; return a dict mapping filepath to result lists."""
     manifestfile_validation = {}
-    # Open CiIndex.xml and parse the data
     ci_index_filename = os.path.join(global_manifest_directory, 'CiIndex.xml')
     ci_index_xml = CiIndexXml(ci_index_filename)
-    # Check every entry in the CiIndex.xml file to verify consistency
     project_list = ci_index_xml.project_list
     if verify_archived:
         project_list.extend(ci_index_xml.archived_project_list)
     for project in project_list:
-        manifest_filepath = None
-        manifest_obj = None
-        validate_parsing = None
-        val_name_duplication = None
-        results = []
-        # Get project XML file path
-        project_path = os.path.normpath(ci_index_xml.get_project_xml(project))
-
-        # Validate parsing and add results
-        manifest_filepath = os.path.join(global_manifest_directory, project_path)
-        manifest_obj = ValidateManifest(manifest_filepath)
-        validate_parsing = manifest_obj.validate_parsing()
-        results.append(validate_parsing)
-
-        # Validate Code name and add results
-        val_codename = manifest_obj.validate_codename(project)
-        results.append(val_codename)
-
-        # Verify that name not already used and add results.  The name is not case sensitive.
-        val_name_duplication = manifest_obj.validate_case_insensitive_single_match(project, project_list, ci_index_filename)
-        results.append(val_name_duplication)
-
-        # Add all results to a dictionary with file path as key
+        manifest_filepath = _resolve_project_manifest_path(ci_index_xml, global_manifest_directory, project)
+        results = _collect_project_validation_results(manifest_filepath, project, project_list, ci_index_filename)
         manifestfile_validation[manifest_filepath] = results
     return manifestfile_validation
 
 def get_manifest_validation_status(manifestfile_validation):
-    # Check for all validation results and print status.
+    """Verify the validation status of all manifest files; return True if any failure is detected, False otherwise."""
     manifest_error = False
     for manifestfile in manifestfile_validation.keys():
         for result in manifestfile_validation[manifestfile]:
             if not result[1]:
                 manifest_error = True
-                break  # break for first error
-
+                break
     return manifest_error
 
 def print_manifest_errors(manifestfile_validation):
+    """Print the error header and details for every failed validation result in the dict."""
     print(VERIFY_ERROR_HEADER)
     for manifestfile in manifestfile_validation.keys():
         for result in manifestfile_validation[manifestfile]:
@@ -141,25 +134,22 @@ def print_manifest_errors(manifestfile_validation):
                 print ("File name: {} ".format(manifestfile))
                 print ("Error type: {} ".format(result[0]))
                 print("Error message: {} \n".format(result[2]))
+
 def main():
+    """Parse CLI arguments and run manifest validation, printing results or raising on failure."""
     parser = argparse.ArgumentParser()
-    # Add mutually exclusive arguments group
     mutex = parser.add_mutually_exclusive_group()
     mutex.add_argument("-a", '--all', help="CiIndex xml directory path to validate all manifest files")
     mutex.add_argument('--files', nargs='+', help="List of manifest xml file paths for validation ")
     args = parser.parse_args()
 
-    # Validate list of  manifest files
     if args.files:
         manifestfile_validation = validate_manifestfiles(args.files)
-    # Validate all manifest files in CiIndex xml
     elif args.all:
         manifestfile_validation = validate_manifestrepo(args.all)
 
-    # Check for all validation results and print status.
     manifest_error = get_manifest_validation_status(manifestfile_validation)
 
-    # Check status.If any error print errors and raise exception.
     if not manifest_error:
         print("Manifest validation status: PASS \n")
     else:
@@ -173,3 +163,4 @@ if __name__ == '__main__':
     except Exception as e:
         traceback.print_exc()
         sys.exit(1)
+        

--- a/edkrepo_manifest_parser/unit_tests/EdkManifestValidation_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/EdkManifestValidation_TestCases.md
@@ -1,0 +1,99 @@
+# Test Cases for `edk_manifest_validation` Module
+
+## Test Cases
+
+### TestCollectFileValidationResults
+Tests the `_collect_file_validation_results` helper which validates parsing and codename for a single manifest file.
+
+#### 1. Parsing Succeeds — Codename Validation Included
+- **Description**: When `validate_parsing` returns success and `_manifest_xmldata` is populated.
+- **Expected Outcome**: The result list contains a passing PARSING tuple followed by a passing CODENAME tuple from `validate_codename`.
+
+#### 2. Parsing Fails — Hardcoded Codename Error Appended
+- **Description**: When `validate_parsing` returns failure and `_manifest_xmldata` is `None`.
+- **Expected Outcome**: The result list contains a failing PARSING tuple followed by a hardcoded `('CODENAME', False, 'Cannot process codename validation')` tuple.
+
+### TestResolveProjectManifestPath
+Tests the `_resolve_project_manifest_path` helper which computes the absolute path to a project manifest file.
+
+#### 3. Returns Normalized Joined Path
+- **Description**: Given a `CiIndexXml` mock whose `get_project_xml` returns a relative path, and a `global_manifest_directory`.
+- **Expected Outcome**: Returns `os.path.join(global_manifest_directory, os.path.normpath(relative_path))`.
+
+### TestCollectProjectValidationResults
+Tests the `_collect_project_validation_results` helper which runs parsing, codename, and deduplication validations for one project.
+
+#### 4. All Validations Pass — Three Results Returned
+- **Description**: When all three `ValidateManifest` methods return passing tuples.
+- **Expected Outcome**: The result list has exactly three entries, all with a `True` status.
+
+#### 5. Parsing Fails — Three Results Still Returned
+- **Description**: When `validate_parsing` returns a failure tuple; the other validators still run.
+- **Expected Outcome**: The result list has exactly three entries; the first has `False` status.
+
+### TestValidateManifestFiles
+Tests `validate_manifestfiles` which validates every manifest file in a provided list.
+
+#### 6. Empty List Returns Empty Dict
+- **Description**: Called with an empty `manifestfile_list`.
+- **Expected Outcome**: Returns an empty dictionary; `_collect_file_validation_results` is never called.
+
+#### 7. Single Manifest — Helper Called Once
+- **Description**: Called with a list containing one manifest filepath.
+- **Expected Outcome**: Returns a dict with one entry keyed by the filepath whose value is the list returned by `_collect_file_validation_results`.
+
+#### 8. Multiple Manifests — Helper Called for Each
+- **Description**: Called with a list containing two manifest filepaths.
+- **Expected Outcome**: Returns a dict with two entries; `_collect_file_validation_results` is called once per filepath with the correct argument.
+
+### TestValidateManifestRepo
+Tests `validate_manifestrepo` which validates all manifest files referenced by `CiIndex.xml`.
+
+#### 9. Without Archived — Only Active Projects Processed
+- **Description**: Called with `verify_archived=False`; `CiIndex.xml` contains one active project and one archived project.
+- **Expected Outcome**: Returns a dict with one entry; `archived_project_list` is not included.
+
+#### 10. With Archived — Active and Archived Projects Processed
+- **Description**: Called with `verify_archived=True`; `CiIndex.xml` contains one active project and one archived project.
+- **Expected Outcome**: Returns a dict with two entries, one per project.
+
+### TestGetManifestValidationStatus
+Tests `get_manifest_validation_status` which verifies the validation status of all manifest files; parametrized over all-pass, one-fail, and empty-dict inputs.
+
+#### 11. All Results Pass — Returns False
+- **Description**: Every result tuple in the dict has a `True` status.
+- **Expected Outcome**: Returns `False`.
+
+#### 12. One Result Fails — Returns True
+- **Description**: At least one result tuple in the dict has a `False` status.
+- **Expected Outcome**: Returns `True`.
+
+#### 13. Empty Dict — Returns False
+- **Description**: Called with an empty dictionary.
+- **Expected Outcome**: Returns `False`.
+
+### TestPrintManifestErrors
+Tests `print_manifest_errors` which prints error details for every failed validation result.
+
+#### 14. Prints Header and Details for Each Failure
+- **Description**: The dict contains one manifest file with one failing result and one passing result.
+- **Expected Outcome**: `VERIFY_ERROR_HEADER` is printed once, followed by three print calls for the failing result (file name, error type, error message); the passing result is skipped.
+
+#### 15. All Passing — Only Header Printed
+- **Description**: The dict contains one manifest file where all results are passing.
+- **Expected Outcome**: `print` is called exactly once with `VERIFY_ERROR_HEADER`; no error detail lines are printed.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/unit_tests/test_edk_manifest_validation.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_edk_manifest_validation.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest_validation import (
+    _collect_file_validation_results,
+    _resolve_project_manifest_path,
+    _collect_project_validation_results,
+    validate_manifestfiles,
+    validate_manifestrepo,
+    get_manifest_validation_status,
+    print_manifest_errors,
+)
+from edkrepo.common.humble import VERIFY_ERROR_HEADER
+
+MANIFEST_PATH            = '/fake/path/manifest.xml'
+MANIFEST_PATH_2          = '/fake/path/manifest2.xml'
+MANIFEST_DIR             = '/fake/manifest/dir'
+CI_INDEX_PATH            = '/fake/manifest/dir/CiIndex.xml'
+PROJECT_XML_RELATIVE     = 'ProjectA/ProjectA.xml'
+PROJECT_A                = 'ProjectA'
+PROJECT_B                = 'ProjectB'
+PROJECT_LIST             = [PROJECT_A, PROJECT_B]
+BAD_XML_MSG              = 'bad xml'
+CANNOT_PROCESS_MSG       = 'Cannot process codename validation'
+RESULT_PARSING           = 'PARSING'
+RESULT_CODENAME          = 'CODENAME'
+RESULT_DUPLICATE         = 'DUPLICATE'
+PARSE_PASS               = (RESULT_PARSING, True, None)
+PARSE_FAIL               = (RESULT_PARSING, False, BAD_XML_MSG)
+CODENAME_PASS            = (RESULT_CODENAME, True, None)
+DUPLICATE_PASS           = (RESULT_DUPLICATE, True, None)
+CODENAME_HARDCODED_FAIL  = (RESULT_CODENAME, False, CANNOT_PROCESS_MSG)
+FILE_RESULTS             = [PARSE_PASS, CODENAME_PASS]
+FAILURE_RESULTS          = [PARSE_FAIL, CODENAME_PASS]
+PROJECT_RESULTS          = [PARSE_PASS, CODENAME_PASS, DUPLICATE_PASS]
+FILE_NAME_FMT            = 'File name: {} '
+ERROR_TYPE_FMT           = 'Error type: {} '
+ERROR_MSG_FMT            = 'Error message: {} \n'
+
+VALIDATION_STATUS_FIELDS   = 'data, expected'
+ID_ALL_PASS                = 'all_pass'
+ID_ONE_FAIL                = 'one_fail'
+ID_EMPTY_DICT              = 'empty_dict'
+
+
+class TestEdkManifestValidation:
+
+    @pytest.fixture
+    def mock_validate_manifest(self):
+        """Patch ValidateManifest for the duration of a test; yields the mock class for per-test configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest_validation.ValidateManifest') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_collect_file_results(self):
+        """Patch _collect_file_validation_results for the duration of a test; yields the mock for per-test configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest_validation._collect_file_validation_results') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_ci_index_cls(self):
+        """Patch CiIndexXml for the duration of a test; yields the mock class for per-test configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest_validation.CiIndexXml') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_resolve_path(self):
+        """Patch _resolve_project_manifest_path for the duration of a test; yields the mock for per-test configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest_validation._resolve_project_manifest_path') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_collect_project_results(self):
+        """Patch _collect_project_validation_results for the duration of a test; yields the mock for per-test configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest_validation._collect_project_validation_results') as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_print(self):
+        """Patch builtins.print for the duration of a test; yields the mock for assertion."""
+        with patch('builtins.print') as mock:
+            yield mock
+
+    @staticmethod
+    def _make_mock_ci_index(mock_ci_index_cls, project_list, archived_project_list):
+        """Configure a mock CiIndexXml class so its instance returns the given project and archived lists."""
+        mock_ci = mock_ci_index_cls.return_value
+        mock_ci.project_list = project_list
+        mock_ci.archived_project_list = archived_project_list
+        return mock_ci
+
+    @staticmethod
+    def _make_mock_project_validator(mock_cls, parse_result):
+        """Configure a mock ValidateManifest class so its instance returns the given parse result and passing validations."""
+        mock_vm = mock_cls.return_value
+        mock_vm.validate_parsing.return_value = parse_result
+        mock_vm.validate_codename.return_value = CODENAME_PASS
+        mock_vm.validate_case_insensitive_single_match.return_value = DUPLICATE_PASS
+        return mock_vm
+
+    @staticmethod
+    def _setup_file_validator_mock(mock_validate_manifest, parse_result, xmldata):
+        """Configure the ValidateManifest instance mock with the given parse result and _manifest_xmldata; return mock_vm."""
+        mock_vm = mock_validate_manifest.return_value
+        mock_vm.validate_parsing.return_value = parse_result
+        mock_vm._manifest_xmldata = xmldata
+        return mock_vm
+
+    @staticmethod
+    def _call_collect_project_results(mock_validate_manifest, parse_result):
+        """Set up the ValidateManifest mock, invoke _collect_project_validation_results, assert three results, and return (mock_vm, result)."""
+        mock_vm = TestEdkManifestValidation._make_mock_project_validator(mock_validate_manifest, parse_result)
+        result = _collect_project_validation_results(MANIFEST_PATH, PROJECT_A, PROJECT_LIST, CI_INDEX_PATH)
+        assert len(result) == 3
+        return mock_vm, result
+
+    @staticmethod
+    def _setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results):
+        """Configure CiIndexXml with one active and one archived project and set collect-project mock to return PROJECT_RESULTS."""
+        TestEdkManifestValidation._make_mock_ci_index(mock_ci_index_cls, [PROJECT_A], [PROJECT_B])
+        mock_collect_project_results.return_value = PROJECT_RESULTS
+
+    @staticmethod
+    def _call_print_errors(results):
+        """Build a single-entry validation dict keyed by MANIFEST_PATH and invoke print_manifest_errors."""
+        print_manifest_errors({MANIFEST_PATH: results})
+
+    def test_collect_file_validation_results_parsing_succeeds_codename_included(self, mock_validate_manifest):
+        """When parsing succeeds and _manifest_xmldata is populated, validate_codename is called and its result is appended."""
+        xmldata = MagicMock()
+        xmldata.project_info.codename = PROJECT_A
+        mock_vm = self._setup_file_validator_mock(mock_validate_manifest, PARSE_PASS, xmldata)
+        mock_vm.validate_codename.return_value = CODENAME_PASS
+
+        result = _collect_file_validation_results(MANIFEST_PATH)
+
+        assert result == [PARSE_PASS, CODENAME_PASS]
+        mock_vm.validate_codename.assert_called_once_with(PROJECT_A)
+
+    def test_collect_file_validation_results_parsing_fails_hardcoded_codename_error(self, mock_validate_manifest):
+        """When parsing fails and _manifest_xmldata is None, a hardcoded CODENAME failure tuple is appended without calling validate_codename."""
+        mock_vm = self._setup_file_validator_mock(mock_validate_manifest, PARSE_FAIL, None)
+
+        result = _collect_file_validation_results(MANIFEST_PATH)
+
+        assert result == [PARSE_FAIL, CODENAME_HARDCODED_FAIL]
+        mock_vm.validate_codename.assert_not_called()
+
+    def test_resolve_project_manifest_path_returns_normalized_joined_path(self):
+        """The returned path equals os.path.join(global_manifest_directory, os.path.normpath(get_project_xml(project)))."""
+        mock_ci_index = MagicMock()
+        mock_ci_index.get_project_xml.return_value = PROJECT_XML_RELATIVE
+
+        result = _resolve_project_manifest_path(mock_ci_index, MANIFEST_DIR, PROJECT_A)
+
+        expected = os.path.join(MANIFEST_DIR, os.path.normpath(PROJECT_XML_RELATIVE))
+        assert result == expected
+        mock_ci_index.get_project_xml.assert_called_once_with(PROJECT_A)
+
+    def test_collect_project_validation_results_all_validations_pass(self, mock_validate_manifest):
+        """When all three ValidateManifest methods return passing tuples, the result contains exactly three passing entries."""
+        _, result = self._call_collect_project_results(mock_validate_manifest, PARSE_PASS)
+
+        assert result[2][0] == RESULT_DUPLICATE
+        assert all(entry[1] is True for entry in result)
+
+    def test_collect_project_validation_results_parsing_fails_three_results_returned(self, mock_validate_manifest):
+        """When parsing fails, all three validators still run and three results are returned with the first having False status."""
+        mock_vm, result = self._call_collect_project_results(mock_validate_manifest, PARSE_FAIL)
+
+        assert result[0][1] is False
+        mock_vm.validate_codename.assert_called_once_with(PROJECT_A)
+        mock_vm.validate_case_insensitive_single_match.assert_called_once_with(
+            PROJECT_A, PROJECT_LIST, CI_INDEX_PATH
+        )
+
+    def test_validate_manifestfiles_empty_list_returns_empty_dict(self):
+        """When called with an empty list, returns an empty dictionary without invoking any helper."""
+        result = validate_manifestfiles([])
+        assert result == {}
+
+    def test_validate_manifestfiles_single_manifest_calls_helper_once(self, mock_collect_file_results):
+        """When the list contains one path, _collect_file_validation_results is called once and the result is keyed by that path."""
+        mock_collect_file_results.return_value = FILE_RESULTS
+
+        result = validate_manifestfiles([MANIFEST_PATH])
+
+        mock_collect_file_results.assert_called_once_with(MANIFEST_PATH)
+        assert result == {MANIFEST_PATH: FILE_RESULTS}
+
+    def test_validate_manifestfiles_multiple_manifests_calls_helper_for_each(self, mock_collect_file_results):
+        """When the list contains two paths, _collect_file_validation_results is called once per path and both results are mapped correctly."""
+        results_a = FILE_RESULTS
+        results_b = [PARSE_FAIL, CODENAME_HARDCODED_FAIL]
+        mock_collect_file_results.side_effect = [results_a, results_b]
+
+        result = validate_manifestfiles([MANIFEST_PATH, MANIFEST_PATH_2])
+
+        assert mock_collect_file_results.call_count == 2
+        mock_collect_file_results.assert_any_call(MANIFEST_PATH)
+        mock_collect_file_results.assert_any_call(MANIFEST_PATH_2)
+        assert result == {MANIFEST_PATH: results_a, MANIFEST_PATH_2: results_b}
+
+    def test_validate_manifestrepo_without_archived_only_active_projects_processed(
+            self, mock_ci_index_cls, mock_resolve_path, mock_collect_project_results):
+        """When verify_archived=False, only active projects are iterated and the dict contains exactly one entry."""
+        self._setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results)
+        mock_resolve_path.return_value = MANIFEST_PATH
+
+        result = validate_manifestrepo(MANIFEST_DIR, verify_archived=False)
+
+        mock_collect_project_results.assert_called_once()
+        assert list(result.keys()) == [MANIFEST_PATH]
+
+    def test_validate_manifestrepo_with_archived_active_and_archived_processed(
+            self, mock_ci_index_cls, mock_resolve_path, mock_collect_project_results):
+        """When verify_archived=True, both active and archived projects are iterated and the dict contains two entries."""
+        self._setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results)
+        mock_resolve_path.side_effect = [MANIFEST_PATH, MANIFEST_PATH_2]
+
+        result = validate_manifestrepo(MANIFEST_DIR, verify_archived=True)
+
+        assert mock_collect_project_results.call_count == 2
+        assert set(result.keys()) == {MANIFEST_PATH, MANIFEST_PATH_2}
+
+    @pytest.mark.parametrize(VALIDATION_STATUS_FIELDS, [
+        pytest.param({MANIFEST_PATH: FILE_RESULTS},    False, id=ID_ALL_PASS),
+        pytest.param({MANIFEST_PATH: FAILURE_RESULTS}, True,  id=ID_ONE_FAIL),
+        pytest.param({},                               False, id=ID_EMPTY_DICT),
+    ])
+    def test_get_manifest_validation_status(self, data, expected):
+        """Verify all manifests in the dict; parametrized over all-pass, one-fail, and empty-dict scenarios."""
+        assert get_manifest_validation_status(data) is expected
+
+    def test_print_manifest_errors_prints_header_and_details_for_failures(self, mock_print):
+        """When the dict contains a failing result, VERIFY_ERROR_HEADER and the file/type/message lines are all printed."""
+        self._call_print_errors(FAILURE_RESULTS)
+
+        mock_print.assert_any_call(VERIFY_ERROR_HEADER)
+        mock_print.assert_any_call(FILE_NAME_FMT.format(MANIFEST_PATH))
+        mock_print.assert_any_call(ERROR_TYPE_FMT.format(RESULT_PARSING))
+        mock_print.assert_any_call(ERROR_MSG_FMT.format(BAD_XML_MSG))
+        assert mock_print.call_count == 4
+
+    def test_print_manifest_errors_all_passing_only_header_printed(self, mock_print):
+        """When all results are passing, only VERIFY_ERROR_HEADER is printed and no error detail lines follow."""
+        self._call_print_errors(FILE_RESULTS)
+
+        mock_print.assert_called_once_with(VERIFY_ERROR_HEADER)


### PR DESCRIPTION
…fest_validation.py and modularize them if needed

Implemented unit tests and documentation for the module‑level functions in edk_manifest_validation.py to improve clarity, reliability, and maintainability. Some internal methods were refactored to extract logic into smaller helper functions, making the codebase easier to test.

Changes:
-Added unit tests for the the module‑level functions in edk_manifest_validation.py module, covering the main execution paths and edge cases. 
-Created the corresponding documentation file EdkManifestValidation_TestCases.md. 
-Extracted logic from validate_manifestrepo(global_manifest_directory, verify_archived=False) and validate_manifestfiles(manifestfile_list=[]) into some dedicated helper functions called _collect_file_validation_results(manifest_filepath), _resolve_project_manifest_path(ci_index_xml, global_manifest_directory, project), and _collect_project_validation_results(manifest_filepath, project, project_list, ci_index_filename). 
-All new tests rely on mocked dependencies and do not perform filesystem or network operations. 
-Updated internal references to use the refactored helpers.

Fixes: #349