### PR TITLE
EdkRepo: Fix "cannot lock ref" when remote has mixed-case branch names

### DIFF
--- a/edkrepo/commands/checkout_pin_command.py
+++ b/edkrepo/commands/checkout_pin_command.py
@@ -3,7 +3,7 @@
 ## @file
 # checkout_pin_command.py
 #
-# Copyright (c) 2017 - 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -16,7 +16,7 @@ import edkrepo.commands.arguments.checkout_pin_args as arguments
 import edkrepo.commands.humble.checkout_pin_humble as humble
 from edkrepo.common.common_cache_functions import get_repo_cache_obj
 from edkrepo.common.common_repo_functions import sparse_checkout_enabled, reset_sparse_checkout, sparse_checkout
-from edkrepo.common.common_repo_functions import check_dirty_repos, checkout_repos, combinations_in_manifest
+from edkrepo.common.common_repo_functions import check_dirty_repos, checkout_repos, combinations_in_manifest, fetch_from_remote
 from edkrepo.common.humble import SPARSE_CHECKOUT, SPARSE_RESET, SUBMODULE_DEINIT_FAILED
 from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoProjectMismatchException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
@@ -69,8 +69,7 @@ class CheckoutPinCommand(EdkrepoCommand):
         for source in manifest_sources:
             local_path = os.path.join(workspace_path, source.root)
             repo = Repo(local_path)
-            origin = repo.remotes.origin
-            origin.fetch()
+            fetch_from_remote(repo, repo.remotes.origin)
         self.__pin_matches_project(pin, manifest, workspace_path)
         sparse_enabled = sparse_checkout_enabled(workspace_path, manifest_sources)
         if sparse_enabled:

--- a/edkrepo/commands/send_review_command.py
+++ b/edkrepo/commands/send_review_command.py
@@ -3,7 +3,7 @@
 ## @file
 # send_review_command.py
 #
-# Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2025 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -111,7 +111,7 @@ class SendReviewCommand(EdkrepoCommand):
         try:
             repo.git.commit(latest_sha)
         except ValueError:
-            repo.git.remotes.origin.fetch('refs/heads/{}'.format(target_branch))
+            common_repo_functions.fetch_from_remote(repo.git, repo.git.remotes.origin, 'refs/heads/{}'.format(target_branch))
         branch_origin = next(itertools.islice(repo.git.iter_commits(), commit_count, commit_count + 1))
         behind_count = int(repo.git.git.rev_list('--count', '{}..{}'.format(branch_origin.hexsha, latest_sha)))
         if behind_count:

--- a/edkrepo/commands/sync_command.py
+++ b/edkrepo/commands/sync_command.py
@@ -3,7 +3,7 @@
 ## @file
 # sync_command.py
 #
-# Copyright (c) 2017 - 2023, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -36,7 +36,7 @@ from edkrepo.common.common_repo_functions import update_editor_config
 from edkrepo.common.common_repo_functions import update_repo_commit_template, get_latest_sha
 from edkrepo.common.common_repo_functions import update_hooks, combinations_in_manifest
 from edkrepo.common.common_repo_functions import write_included_config, remove_included_config
-from edkrepo.common.common_repo_functions import find_git_version
+from edkrepo.common.common_repo_functions import find_git_version, fetch_from_remote
 from edkrepo.common.git_version import GitVersion
 from edkrepo.common.workspace_maintenance.git_config_maintenance import clean_git_globalconfig
 from edkrepo.common.workspace_maintenance.workspace_maintenance import generate_name_for_obsolete_backup
@@ -175,41 +175,20 @@ class SyncCommand(EdkrepoCommand):
                 update_hooks(hooks_add, hooks_update, hooks_uninstall, local_repo_path, repo_to_sync, config, global_manifest_directory)
             repo = Repo(local_repo_path)
             #Fetch notes
-            repo.remotes.origin.fetch("refs/notes/*:refs/notes/*")
+            fetch_from_remote(repo, repo.remotes.origin, "refs/notes/*:refs/notes/*")
             if repo_to_sync.patch_set:
                 patchset_branch_creation_flow(repo_to_sync, repo, workspace_path, manifest, global_manifest_path, args.override)
             elif repo_to_sync.commit is None and repo_to_sync.tag is None:
                 local_commits = False
                 initial_active_branch = repo.active_branch
-                repo.remotes.origin.fetch("refs/heads/{0}:refs/remotes/origin/{0}".format(repo_to_sync.branch))
+                fetch_from_remote(repo, repo.remotes.origin, "refs/heads/{0}:refs/remotes/origin/{0}".format(repo_to_sync.branch))
                 #The new branch may not exist in the heads list yet if it is a new branch
                 repo.git.checkout(repo_to_sync.branch)
                 if not args.fetch:
                     ui_functions.print_info_msg(humble.SYNCING.format(repo_to_sync.root, repo.active_branch), header = False)
                 else:
                     ui_functions.print_info_msg(humble.FETCHING.format(repo_to_sync.root, repo.active_branch), header = False)
-                try:
-                    repo.remotes.origin.fetch()
-                except GitCommandError as e:
-                    prune_needed = False
-                    prune_needed_heuristic_str = "error: some local refs could not be updated"
-                    if e.stdout.strip().find(prune_needed_heuristic_str) != -1:
-                        prune_needed = True
-                    if e.stderr.strip().find(prune_needed_heuristic_str) != -1:
-                        prune_needed = True
-                    prune_needed_heuristic_str = "error: cannot lock ref"
-                    if e.stdout.strip().find(prune_needed_heuristic_str) != -1:
-                        prune_needed = True
-                    if e.stderr.strip().find(prune_needed_heuristic_str) != -1:
-                        prune_needed = True
-                    if prune_needed:
-                        ui_functions.print_info_msg(humble.SYNC_AUTOMATIC_REMOTE_PRUNE)
-                        time.sleep(1.0)
-                        repo.git.remote('prune', 'origin')
-                        time.sleep(1.0)
-                        repo.remotes.origin.fetch()
-                    else:
-                        raise
+                fetch_from_remote(repo, repo.remotes.origin)
 
                 if not args.override and not repo.is_ancestor(ancestor_rev='HEAD', rev='origin/{}'.format(repo_to_sync.branch)):
                     ui_functions.print_info_msg(humble.SYNC_COMMITS_ON_TARGET.format(repo_to_sync.branch, repo_to_sync.root), header=False)
@@ -272,30 +251,7 @@ class SyncCommand(EdkrepoCommand):
         for initial_repo in initial_sources:
             local_repo_path = os.path.join(workspace_path, initial_repo.root)
             repo = Repo(local_repo_path)
-            origin = repo.remotes.origin
-            try:
-                origin.fetch()
-            except GitCommandError as e:
-                prune_needed = False
-                prune_needed_heuristic_str = "error: some local refs could not be updated"
-                if e.stdout.strip().find(prune_needed_heuristic_str) != -1:
-                    prune_needed = True
-                if e.stderr.strip().find(prune_needed_heuristic_str) != -1:
-                    prune_needed = True
-                prune_needed_heuristic_str = "error: cannot lock ref"
-                if e.stdout.strip().find(prune_needed_heuristic_str) != -1:
-                    prune_needed = True
-                if e.stderr.strip().find(prune_needed_heuristic_str) != -1:
-                    prune_needed = True
-                if prune_needed:
-                    ui_functions.print_info_msg(humble.SYNC_AUTOMATIC_REMOTE_PRUNE)
-                    # The sleep is to give the operating system time to close all the file handles that Git has open
-                    time.sleep(1.0)
-                    repo.git.remote('prune', 'origin')
-                    time.sleep(1.0)
-                    origin.fetch()
-                else:
-                    raise
+            fetch_from_remote(repo, repo.remotes.origin)
 
         #see if there is an entry in CiIndex.xml that matches the prject name of the current manifest
         index_path = os.path.join(global_manifest_directory, 'CiIndex.xml')

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -3,7 +3,7 @@
 ## @file
 # common_repo_functions.py
 #
-# Copyright (c) 2017 - 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -27,7 +27,7 @@ from edkrepo.common.edkrepo_exception import EdkrepoFetchBranchNotFoundException
 from edkrepo.common.edkrepo_exception import EdkrepoPatchNotFoundException, EdkrepoPatchFailedException
 from edkrepo.common.edkrepo_exception import EdkrepoRemoteNotFoundException, EdkrepoRemoteAddException, EdkrepoRemoteRemoveException
 from edkrepo.common.edkrepo_exception import EdkrepoManifestInvalidException
-from edkrepo.common.edkrepo_exception import EdkrepoUncommitedChangesException
+from edkrepo.common.edkrepo_exception import EdkrepoUncommitedChangesException, EdkrepoProxyNotSetException
 from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoNotFoundException
 from edkrepo.common.progress_handler import GitProgressHandler
 from edkrepo.common.humble import APPLYING_CHERRY_PICK_FAILED, APPLYING_PATCH_FAILED, APPLYING_REVERT_FAILED, BRANCH_EXISTS, CHECKING_OUT_DEFAULT, CHECKING_OUT_PATCHSET, LOCAL_BRANCH_EXISTS
@@ -53,9 +53,11 @@ from edkrepo.common.humble import VERIFY_GLOBAL, VERIFY_ARCHIVED, VERIFY_PROJ, V
 from edkrepo.common.humble import VERIFY_GLOBAL_FAIL
 from edkrepo.common.humble import SUBMODULE_DEINIT_FAILED, BRANCH_COLLIDES_WITH_PARENT_SHA
 from edkrepo.common.humble import MISSING_BRANCH_COMMIT, MULTIPLE_SOURCE_ATTRIBUTES_SPECIFIED, TAG_AND_BRANCH_SPECIFIED
-from edkrepo.common.humble import CLONE_FAIL, NETRC_NOT_FOUND
+from edkrepo.common.humble import CLONE_FAIL, PROXY_STR_NOT_FOUND, NETRC_NOT_FOUND
+from edkrepo.common.humble import AUTOMATIC_REMOTE_PRUNE, AUTOMATIC_REFS_REPACK
 from edkrepo.common.pathfix import get_actual_path, expanduser
 from edkrepo.common.git_version import GitVersion
+from edkrepo.common.repo_case_conflict_solver import scrub_repo_case_conflicts, scrub_stale_remote_reflogs
 from project_utils.sparse import BuildInfo, process_sparse_checkout
 from edkrepo.config.config_factory import get_workspace_path
 from edkrepo.config.config_factory import get_workspace_manifest
@@ -329,7 +331,7 @@ def check_branches(sources, workspace_path):
             continue
         if repo_to_check.branch not in repo.remotes['origin'].refs:
             try:
-               repo.remotes.origin.fetch("refs/heads/{0}:refs/remotes/origin/{0}".format(repo_to_check.branch), progress=GitProgressHandler())
+               fetch_from_remote(repo, repo.remotes.origin, "refs/heads/{0}:refs/remotes/origin/{0}".format(repo_to_check.branch), progress=GitProgressHandler())
             except:
                 raise EdkrepoManifestInvalidException(CHECKOUT_NO_REMOTE.format(repo_to_check.root))
 
@@ -833,7 +835,7 @@ def create_local_branch(name, patchset, global_manifest_path, manifest_obj, repo
         if patchset.remote == remote.name:
             REMOTE_IN_REMOTE_LIST = True
             try:
-                repo.remotes.origin.fetch(patchset.fetch_branch, progress=GitProgressHandler())
+                fetch_from_remote(repo, repo.remotes.origin, patchset.fetch_branch, progress=GitProgressHandler())
             except:
                 raise EdkrepoFetchBranchNotFoundException(FETCH_BRANCH_DOES_NOT_EXIST.format(patchset.fetch_branch))
             parent_patchsets = _list_patchset_ancestors(manifest_obj, patchset)
@@ -985,7 +987,7 @@ def apply_patchset_operations(repo, operations_list, global_manifest_path, remot
                         raise EdkrepoRemoteNotFoundException(REMOTE_NOT_FOUND.format(operation.source_remote))
                 else:
                     try:
-                        repo.remotes.origin.fetch(operation.source_branch)
+                        fetch_from_remote(repo, repo.remotes.origin, operation.source_branch)
                     except:
                         raise EdkrepoFetchBranchNotFoundException(FETCH_BRANCH_DOES_NOT_EXIST.format(operation.source_branch))
                     try:
@@ -1027,6 +1029,80 @@ def get_commits_ahead(repo, rev1, rev2):
         "{}..{}".format(
             rev1,
             rev2))
+
+def _is_case_insensitive_fs():
+    """Returns True on filesystems that are case-insensitive by default (Windows, macOS)."""
+    return os.name == 'nt' or sys.platform == 'darwin'
+
+def _get_fetch_error_output(e):
+    return (e.stdout or '') + (e.stderr or '')
+
+def _fetch_error_needs_prune(e):
+    combined = _get_fetch_error_output(e)
+    return ('error: some local refs could not be updated' in combined or
+            'error: cannot lock ref' in combined or
+            'unable to update local ref' in combined or
+            'unable to resolve reference' in combined or
+            'cannot update the ref' in combined)
+
+def _fetch_error_needs_repack(e):
+    combined = _get_fetch_error_output(e)
+    return 'incorrect old value provided' in combined
+
+def fetch_from_remote(repo, remote, *args, _repack_attempted=False, _prune_attempted=False, **kwargs):
+    """
+    Fetch from a remote, automatically pruning stale remote-tracking refs on failure.
+
+    On case-insensitive filesystems, if the prune itself fails due to
+    case-conflicting ref names in the local .git directory,
+    scrub_repo_case_conflicts() is called before retrying the prune.
+
+    Args:
+        repo:     GitPython Repo object
+        remote:   GitPython Remote object (e.g. repo.remotes.origin)
+        *args:    Optional refspec arguments forwarded to remote.fetch()
+        **kwargs: Optional keyword arguments forwarded to remote.fetch() (e.g. progress=)
+    """
+    try:
+        return remote.fetch(*args, **kwargs)
+    except git.GitCommandError as fetch_error:
+        if _fetch_error_needs_repack(fetch_error):
+            if _repack_attempted:
+                raise
+            # Refs exist in both loose and packed forms with conflicting values.
+            # Pack all refs to consolidate them, then retry via a recursive call
+            # so that a potential subsequent prune error is also handled
+            # automatically.
+            ui_functions.print_info_msg(AUTOMATIC_REFS_REPACK, header=False)
+            # Give the OS time to release file handles Git has open
+            time.sleep(1.0)
+            repo.git.pack_refs('--all')
+            time.sleep(1.0)
+            return fetch_from_remote(repo, remote, *args, _repack_attempted=True, _prune_attempted=_prune_attempted, **kwargs)
+        elif _fetch_error_needs_prune(fetch_error):
+            if _prune_attempted:
+                raise
+            ui_functions.print_info_msg(AUTOMATIC_REMOTE_PRUNE, header=False)
+            # Give the OS time to release file handles Git has open
+            time.sleep(1.0)
+            try:
+                repo.git.remote('prune', remote.name)
+            except git.GitCommandError:
+                if _is_case_insensitive_fs():
+                    time.sleep(1.0)
+                    scrub_repo_case_conflicts(repo, verbose=True)
+                    time.sleep(1.0)
+                    ui_functions.print_info_msg(AUTOMATIC_REMOTE_PRUNE, header=False)
+                    repo.git.remote('prune', remote.name)
+                else:
+                    raise
+            time.sleep(1.0)
+            if _is_case_insensitive_fs():
+                scrub_stale_remote_reflogs(repo, verbose=True)
+                time.sleep(1.0)
+            return fetch_from_remote(repo, remote, *args, _repack_attempted=_repack_attempted, _prune_attempted=True, **kwargs)
+        else:
+            raise
 
 def get_proxy_str():
     proxy_out = subprocess.run('git config --global --get-urlmatch http https://github.com',

--- a/edkrepo/common/edkrepo_exception.py
+++ b/edkrepo/common/edkrepo_exception.py
@@ -3,7 +3,7 @@
 ## @file
 # edkrepo_exception.py
 #
-# Copyright (c) 2017- 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -170,5 +170,8 @@ class EdkrepoPinFileNotFoundException(EdkrepoException):
     def __init__(self, message):
         super().__init__(message, 140)
 
+class EdkrepoProxyNotSetException(EdkrepoException):
+    def __init__(self, message):
+        super().__init__(message, 141)
 
 

--- a/edkrepo/common/humble.py
+++ b/edkrepo/common/humble.py
@@ -44,6 +44,21 @@ CONFLICTING_PARTIAL_CLONE = 'Multiple partial clone arguments were provided.'
 SPARSE_CHECKOUT = 'Performing sparse checkout...'
 SPARSE_RESET = 'Resetting sparse checkout state...'
 
+# Remote fetch/prune messages
+AUTOMATIC_REMOTE_PRUNE = 'Performing automatic remote prune...'
+AUTOMATIC_REFS_REPACK = 'Performing automatic refs repack to fix duplicate ref entries...'
+
+# Case conflict scrubbing messages
+CASE_CONFLICT_SCRUB = 'Scrubbing case-conflicting remote refs...'
+CASE_CONFLICT_FOUND = 'Found {} case-conflicting remote ref(s)'
+CASE_CONFLICT_NONE = 'No case-conflicting remote refs found'
+CASE_CONFLICT_DELETED = 'Deleted {} case-conflicting remote ref(s)'
+CASE_CONFLICT_DELETING_REF = '  Deleting: refs/remotes/{} (conflicts with refs/remotes/{})'
+CASE_CONFLICT_DELETE_FAILED = 'Failed to delete ref {}: {}'
+STALE_REFLOG_SCRUB = 'Scrubbing stale remote reflog files...'
+STALE_REFLOG_DELETING_FILE = '  Deleting stale reflog: {}'
+STALE_REFLOG_DELETING_DIR = '  Removing empty reflog directory: {}'
+
 # Error messages for checkout_command.py
 CHECKOUT_EXIT = 'Exiting without performing checkout opereration.'
 CHECKOUT_INVALID_COMBO = UNSUPPORTED_COMBO + CHECKOUT_EXIT
@@ -151,4 +166,6 @@ LOCAL_BRANCH_EXISTS = "The branch {} already exists. Please resolve the branch n
 COLLISION_DETECTED = "A branch with the same name detected. Renaming the old {} branch and creating a new one from the manifest."
 BRANCH_COLLIDES_WITH_PARENT_SHA = "Patchset should not use branch name as base parent_sha"
 
+# Error messages for environment setup
+PROXY_STR_NOT_FOUND = 'Could not find a value for GitHub proxy in Git config.'
 NETRC_NOT_FOUND = 'Path to netrc not found. Please ensure you have configured your netrc file properly according to your OS guide.'

--- a/edkrepo/common/repo_case_conflict_solver.py
+++ b/edkrepo/common/repo_case_conflict_solver.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+#
+## @file
+# repo_case_conflict_solver.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import unicodedata
+import tempfile
+
+import edkrepo.common.ui_functions as ui_functions
+from edkrepo.common.humble import CASE_CONFLICT_SCRUB, CASE_CONFLICT_FOUND
+from edkrepo.common.humble import CASE_CONFLICT_NONE, CASE_CONFLICT_DELETED
+from edkrepo.common.humble import CASE_CONFLICT_DELETING_REF, CASE_CONFLICT_DELETE_FAILED
+from edkrepo.common.humble import STALE_REFLOG_SCRUB, STALE_REFLOG_DELETING_FILE, STALE_REFLOG_DELETING_DIR
+from edkrepo.config.tool_config import CI_INDEX_FILE_NAME
+from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
+from edkrepo.config.config_factory import GlobalConfig, GlobalUserConfig
+from edkrepo_manifest_parser.edk_manifest import CiIndexXml, ManifestXml
+
+_str_cache = {}
+def _case_insensitive_equal(str1, str2):
+    # Note: This function is performance sensitive. It has been written to
+    # minimize case conversions and enumerations
+    str1_casefold = _str_cache.get(str1)
+    if str1_casefold is None:
+        str1_casefold = unicodedata.normalize("NFKD", str1.casefold())
+        _str_cache[str1] = str1_casefold
+    str2_casefold = _str_cache.get(str2)
+    if str2_casefold is None:
+        str2_casefold = unicodedata.normalize("NFKD", str2.casefold())
+        _str_cache[str2] = str2_casefold
+    return str1_casefold == str2_casefold
+
+def _normalize_url(url):
+    # Strip trailing slashes, optional .git suffix, then casefold so that URL
+    # comparisons are insensitive to both case and common formatting differences.
+    url = url.rstrip('/')
+    if url.lower().endswith('.git'):
+        url = url[:-4]
+    return url.casefold()
+
+def get_known_good_refs(repo):
+    """
+    Build a frozenset of known-good remote-qualified ref names by scanning
+    the locally-cached global manifest repositories.  A ref is "known good"
+    when it is referenced by at least one active or archived project combination
+    in any manifest that is associated with a remote of *repo*.
+
+    The returned strings have the form ``<remote_name>/<branch_or_tag>``,
+    mirroring the path components stored under ``.git/refs/remotes/``.
+
+    No network access is performed; if no manifest cache exists or the edkrepo
+    configuration is unavailable, an empty frozenset is returned silently so
+    the caller can fall back to the uppercase heuristic.
+
+    Args:
+        repo: GitPython Repo object
+
+    Returns:
+        frozenset of known-good ref path strings (e.g. ``{'origin/MyBranch'}``)
+    """
+    try:
+        cfg_file = GlobalConfig()
+        user_cfg_file = GlobalUserConfig()
+    except Exception:
+        return frozenset()
+
+    try:
+        cfg_manifest_repos, user_cfg_manifest_repos, _ = list_available_manifest_repos(
+            cfg_file, user_cfg_file)
+    except Exception:
+        return frozenset()
+
+    # Build a mapping from normalized URL → set of remote names for this repo.
+    url_to_remotes = {}
+    for remote in repo.remotes:
+        for url in remote.urls:
+            norm = _normalize_url(url)
+            url_to_remotes.setdefault(norm, set()).add(remote.name)
+
+    if not url_to_remotes:
+        return frozenset()
+
+    known_refs = set()
+    for manifest_repo, cfg_obj in (
+        [(r, cfg_file) for r in cfg_manifest_repos] +
+        [(r, user_cfg_file) for r in user_cfg_manifest_repos]):
+
+        manifest_dir = cfg_obj.manifest_repo_abs_path(manifest_repo)
+        if not os.path.isdir(manifest_dir):
+            continue
+
+        try:
+            ci_index_xml = CiIndexXml(os.path.join(manifest_dir, CI_INDEX_FILE_NAME))
+        except Exception:
+            continue
+
+        all_projects = list(ci_index_xml.project_list) + list(ci_index_xml.archived_project_list)
+        for project in all_projects:
+            try:
+                xml_file = ci_index_xml.get_project_xml(project)
+                manifest = ManifestXml(
+                    os.path.normpath(os.path.join(manifest_dir, xml_file)))
+            except Exception:
+                continue
+
+            all_combos = list(manifest.combinations) + list(manifest.archived_combinations)
+            for combo in all_combos:
+                try:
+                    sources = manifest.get_repo_sources(combo.name)
+                except Exception:
+                    continue
+                for source in sources:
+                    norm = _normalize_url(source.remote_url)
+                    remote_names = url_to_remotes.get(norm)
+                    if remote_names is None:
+                        continue
+                    for remote_name in remote_names:
+                        if source.branch:
+                            known_refs.add(remote_name + '/' + source.branch)
+                        if source.tag:
+                            known_refs.add(remote_name + '/' + source.tag)
+
+    return frozenset(known_refs)
+
+def check_for_case_conflicts(ref_list, known_good_refs=frozenset()):
+    conflicting_refs = []
+    path_tree = [{}, []]
+
+    def _combine_ref_paths(parent_path, child_path):
+        if parent_path == '':
+            return child_path
+        else:
+            return '/'.join((parent_path, child_path))
+
+    def _find_node(sub_tree, path):
+        current_path = path.split('/')
+        remaining_path = '/'.join(current_path[1:])
+        current_path = current_path[0]
+        if current_path in sub_tree[0]:
+            current_tree = sub_tree[0][current_path]
+            if remaining_path == '':
+                return current_tree
+            else:
+                return _find_node(current_tree, remaining_path)
+        raise ValueError('{} not in tree'.format(path))
+
+    def _add_conflicts_from_sub_tree(sub_tree, parent_path, force=False):
+        for ref in sub_tree[1]:
+            if force or any(char.isupper() for char in ref):
+                if len(_find_node(path_tree, parent_path)[0]) == 0:
+                    conflicting_refs.append((ref, parent_path))
+                else:
+                    conflicting_refs.append((ref, '{}/*'.format(parent_path)))
+        for key in sub_tree[0]:
+            _add_conflicts_from_sub_tree(sub_tree[0][key], parent_path, force)
+
+    def _is_known_good(parent_path, component):
+        full = _combine_ref_paths(parent_path, component)
+        return any(r == full or r.startswith(full + '/') for r in known_good_refs)
+
+    def _check_for_conflicts(sub_tree, parent_path=''):
+        already_added = []
+        for path in sub_tree[0]:
+            for path2 in sub_tree[0]:
+                if path != path2 and _case_insensitive_equal(path, path2):
+                    if path in already_added:
+                        continue
+                    # Prefer manifest-defined ref names regardless of case
+                    if known_good_refs:
+                        path_good  = _is_known_good(parent_path, path)
+                        path2_good = _is_known_good(parent_path, path2)
+                        if path_good and not path2_good:
+                            # path2 is bad; path is the manifest-defined ref.
+                            already_added.append(path2)
+                            _add_conflicts_from_sub_tree(
+                                sub_tree[0][path2],
+                                _combine_ref_paths(parent_path, path),
+                                force=True)
+                            continue
+                        elif path2_good and not path_good:
+                            # path is bad; path2 is the manifest-defined ref.
+                            # Mark path2 handled so it is not re-processed when
+                            # it becomes the outer loop variable.
+                            already_added.append(path2)
+                            _add_conflicts_from_sub_tree(
+                                sub_tree[0][path],
+                                _combine_ref_paths(parent_path, path2),
+                                force=True)
+                            continue
+                    # The ref names are not manifest-defined ref names, or both
+                    # refs are known-good. In both cases, the lowercase variant
+                    # is preferred.
+                    bad_path = None
+                    if any(char.isupper() for char in path):
+                        bad_path = path
+                    if any(char.isupper() for char in path2):
+                        if bad_path is None:
+                            bad_path = path2
+                        else:
+                            bad_path = None
+                    if bad_path is not None:
+                        if bad_path == path:
+                            already_added.append(path2)
+                            _add_conflicts_from_sub_tree(sub_tree[0][path], _combine_ref_paths(parent_path, path2))
+                        else:
+                            # bad_path == path2: path is good, path2 is bad.
+                            # This pair will be resolved when path2 becomes the
+                            # outer loop variable.
+                            pass
+                    else:
+                        _add_conflicts_from_sub_tree(sub_tree[0][path], _combine_ref_paths(parent_path, path))
+            _check_for_conflicts(sub_tree[0][path], _combine_ref_paths(parent_path, path))
+
+    for ref in ref_list:
+        paths = ref.split('/')
+        current_tree = path_tree
+        for path in paths:
+            if path not in current_tree[0]:
+                current_tree[0][path] = [{}, []]
+            current_tree = current_tree[0][path]
+        current_tree[1].append(ref)
+
+    _check_for_conflicts(path_tree)
+    return conflicting_refs
+
+def _get_local_remote_refs(git_dir):
+    """Get all remote refs from .git/refs/remotes/ directory structure."""
+    refs = []
+    remotes_dir = os.path.join(git_dir, 'refs', 'remotes')
+
+    if not os.path.exists(remotes_dir):
+        return refs
+
+    for root, _, files in os.walk(remotes_dir):
+        for file in files:
+            file_path = os.path.join(root, file)
+            rel_path = os.path.relpath(file_path, remotes_dir)
+            ref_name = 'refs/remotes/' + rel_path.replace('\\', '/')
+            refs.append(ref_name)
+
+    return refs
+
+def _get_packed_remote_refs(git_dir):
+    """Get all remote refs from .git/packed-refs file."""
+    refs = []
+    packed_refs_file = os.path.join(git_dir, 'packed-refs')
+
+    if not os.path.exists(packed_refs_file):
+        return refs
+
+    with open(packed_refs_file, 'r', encoding='utf-8') as fh:
+        for line in fh:
+            line = line.strip()
+            if line.startswith('#') or not line:
+                continue
+            if line.startswith('^'):
+                continue
+            parts = line.split()
+            if len(parts) >= 2:
+                ref_name = parts[1]
+                if ref_name.startswith('refs/remotes/'):
+                    refs.append(ref_name)
+
+    return refs
+
+def _delete_ref_from_filesystem(git_dir, ref_name):
+    """Delete a ref from .git/refs/remotes/ directory."""
+    if not ref_name.startswith('refs/remotes/'):
+        return False
+
+    rel_path = ref_name[len('refs/remotes/'):]
+    file_path = os.path.join(git_dir, 'refs', 'remotes', rel_path.replace('/', os.sep))
+
+    if os.path.exists(file_path):
+        try:
+            os.remove(file_path)
+
+            # Clean up empty directories
+            parent_dir = os.path.dirname(file_path)
+            remotes_dir = os.path.join(git_dir, 'refs', 'remotes')
+            while parent_dir != remotes_dir:
+                try:
+                    if os.path.isdir(parent_dir) and not os.listdir(parent_dir):
+                        os.rmdir(parent_dir)
+                        parent_dir = os.path.dirname(parent_dir)
+                    else:
+                        break
+                except OSError:
+                    break
+
+            return True
+        except OSError as e:
+            ui_functions.print_warning_msg(CASE_CONFLICT_DELETE_FAILED.format(ref_name, e), header=False)
+            return False
+
+    return False
+
+def _scrub_packed_refs(git_dir, refs_to_delete):
+    """Remove specified refs from .git/packed-refs file.
+
+    Returns:
+        frozenset of ref names that were removed from packed-refs.
+    """
+    packed_refs_file = os.path.join(git_dir, 'packed-refs')
+
+    if not os.path.exists(packed_refs_file):
+        return frozenset()
+
+    with open(packed_refs_file, 'r', encoding='utf-8') as fh:
+        lines = fh.readlines()
+
+    deleted_refs = set()
+    new_lines = []
+    skip_next_peeled = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith('^'):
+            if not skip_next_peeled:
+                new_lines.append(line)
+            else:
+                skip_next_peeled = False
+            continue
+
+        if stripped.startswith('#') or not stripped:
+            new_lines.append(line)
+            continue
+
+        parts = stripped.split()
+        if len(parts) >= 2:
+            ref_name = parts[1]
+            if ref_name in refs_to_delete:
+                deleted_refs.add(ref_name)
+                skip_next_peeled = True
+                continue
+
+        new_lines.append(line)
+        skip_next_peeled = False
+
+    if deleted_refs:
+        # Write atomically: write to a temp file beside packed-refs, then
+        # rename over the original. This prevents corruption if the process
+        # is interrupted between the open() and the final write.
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(packed_refs_file))
+        try:
+            with os.fdopen(tmp_fd, 'wb') as fh:
+                for line in new_lines:
+                    fh.write(line.rstrip('\r\n').encode('utf-8'))
+                    fh.write(b'\n')
+            os.replace(tmp_path, packed_refs_file)  # atomic on POSIX; best-effort on Windows
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    return frozenset(deleted_refs)
+
+def scrub_repo_case_conflicts(repo, verbose=False):
+    """
+    Scrub case-conflicting remote refs from a git repository.
+
+    Removes "bad" refs (those with uppercase letters) that conflict with
+    lowercase refs, allowing git operations to work properly on
+    case-insensitive filesystems (Windows, macOS). Only refs/remotes/*
+    refs are touched to prevent data loss.
+
+    Args:
+        repo: GitPython Repo object
+        verbose: If True, print verbose detail about refs found
+
+    Returns:
+        Number of conflicting refs deleted
+    """
+    ui_functions.print_info_msg(CASE_CONFLICT_SCRUB, header=False)
+
+    git_dir = repo.git_dir
+
+    # Get all remote refs from both filesystem and packed-refs
+    filesystem_refs = _get_local_remote_refs(git_dir)
+    packed_refs = _get_packed_remote_refs(git_dir)
+    all_refs = sorted(set(filesystem_refs + packed_refs))
+
+    # Strip 'refs/remotes/' prefix for conflict checking
+    ref_names_only = []
+    for ref in all_refs:
+        if ref.startswith('refs/remotes/'):
+            ref_names_only.append(ref[len('refs/remotes/'):])
+
+    known_good_refs = get_known_good_refs(repo)
+    conflicting_refs = check_for_case_conflicts(sorted(ref_names_only), known_good_refs)
+
+    if not conflicting_refs:
+        if verbose:
+            ui_functions.print_info_msg(CASE_CONFLICT_NONE, header=False)
+        return 0
+
+    ui_functions.print_info_msg(CASE_CONFLICT_FOUND.format(len(conflicting_refs)), header=False)
+    if verbose:
+        for ref, conflict_location in conflicting_refs:
+            ui_functions.print_info_msg(CASE_CONFLICT_DELETING_REF.format(ref, conflict_location), header=False)
+
+    # Build set of full ref names to delete
+    refs_to_delete = set()
+    for ref, _ in conflicting_refs:
+        refs_to_delete.add('refs/remotes/' + ref)
+
+    # Delete from filesystem and packed-refs
+    deleted_from_fs = set()
+    for ref in refs_to_delete:
+        if _delete_ref_from_filesystem(git_dir, ref):
+            deleted_from_fs.add(ref)
+    deleted_from_packed = _scrub_packed_refs(git_dir, refs_to_delete)
+    deleted = len(deleted_from_fs | deleted_from_packed)
+
+    ui_functions.print_info_msg(CASE_CONFLICT_DELETED.format(deleted), header=False)
+    return deleted
+
+def scrub_stale_remote_reflogs(repo, verbose=False):
+    """
+    Delete reflog files under .git/logs/refs/remotes/ that have no corresponding
+    live ref in .git/refs/remotes/ or packed-refs.
+
+    On case-insensitive filesystems (Windows, macOS) a stale reflog file left
+    behind after a prune can block git from creating a new hierarchical ref
+    whose path reuses the stale file's name as a directory component, producing
+    the error "unable to create directory for '.git/logs/refs/remotes/...': No
+    such file or directory".  Deleting the orphaned log file unblocks the
+    subsequent fetch.
+
+    Args:
+        repo:    GitPython Repo object
+        verbose: If True, print each file and directory as it is deleted
+
+    Returns:
+        Number of stale reflog files deleted
+    """
+    ui_functions.print_info_msg(STALE_REFLOG_SCRUB, header=False)
+
+    git_dir = repo.git_dir
+    logs_remotes_dir = os.path.join(git_dir, 'logs', 'refs', 'remotes')
+    if not os.path.exists(logs_remotes_dir):
+        return 0
+
+    # Build a lower-cased set of live ref paths relative to refs/remotes/ so
+    # that comparison is case-insensitive on case-insensitive filesystems.
+    all_refs = sorted(_get_local_remote_refs(git_dir) + _get_packed_remote_refs(git_dir))
+    live_refs = set()
+    for ref in all_refs:
+        if ref.startswith('refs/remotes/'):
+            live_refs.add(ref[len('refs/remotes/'):].replace('/', os.sep).lower())
+
+    deleted = 0
+    # Walk bottom-up so directories can be pruned after their files are removed.
+    for root, dirs, files in os.walk(logs_remotes_dir, topdown=False):
+        for filename in files:
+            log_file = os.path.join(root, filename)
+            rel_path = os.path.relpath(log_file, logs_remotes_dir).lower()
+            if rel_path not in live_refs:
+                try:
+                    os.remove(log_file)
+                    deleted += 1
+                    if verbose:
+                        ui_functions.print_info_msg(STALE_REFLOG_DELETING_FILE.format(log_file), header=False)
+                except OSError:
+                    pass
+        for dirname in dirs:
+            dir_path = os.path.join(root, dirname)
+            try:
+                if not os.listdir(dir_path):
+                    os.rmdir(dir_path)
+                    if verbose:
+                        ui_functions.print_info_msg(STALE_REFLOG_DELETING_DIR.format(dir_path), header=False)
+            except OSError:
+                pass
+
+    return deleted

--- a/project_utils/cache.py
+++ b/project_utils/cache.py
@@ -3,7 +3,7 @@
 ## @file
 # cache.py
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2020 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 from collections import namedtuple
@@ -15,6 +15,7 @@ from git.exc import GitCommandError
 
 from edkrepo.common.progress_handler import GitProgressHandler
 from edkrepo.common.edkrepo_exception import EdkrepoGitException
+from edkrepo.common.common_repo_functions import fetch_from_remote
 from project_utils.project_utils_strings import CACHE_ADD_REMOTE, CACHE_ADDING_REPO, CACHE_CHECK_ROOT_DIR
 from project_utils.project_utils_strings import CACHE_FAILED_TO_CLOSE, CACHE_FAILED_TO_OPEN, CACHE_FETCH_REMOTE
 from project_utils.project_utils_strings import CACHE_REMOTE_EXISTS, CACHE_REMOVE_REPO, CACHE_REPO_EXISTS
@@ -69,7 +70,7 @@ class RepoCache(object):
         repo.create_remote(remote_name, url)
         if verbose:
             print(CACHE_FETCH_REMOTE.format(remote_name, url))
-        repo.remotes[remote_name].fetch(progress=GitProgressHandler())
+        fetch_from_remote(repo, repo.remotes[remote_name], progress=GitProgressHandler())
         repo.git.execute(['git', 'lfs', 'fetch', '--all'])
 
     def open(self, verbose=False):
@@ -231,14 +232,14 @@ class RepoCache(object):
                     print(CACHE_FETCH_REMOTE.format(dir_name, remote.url))
                 if sha_or_branch is not None and ((remote.name == dir_name) or (remote.url == url_or_name)):
                     print('Fetching ref {}'.format(sha_or_branch))
-                    remote.fetch(refspec=sha_or_branch, progress=GitProgressHandler())
+                    fetch_from_remote(repo, remote, refspec=sha_or_branch, progress=GitProgressHandler())
                     try:
                         repo.git.execute(['git', 'lfs', 'fetch', '{}'.format(remote.name), '{}'.format(sha_or_branch), '--recent'])
                     except GitCommandError:
                         print('No recent LFS object found in {}:{}'.format(remote.name, sha_or_branch))
                         pass
                 else:
-                    remote.fetch(progress=GitProgressHandler())
+                    fetch_from_remote(repo, remote, progress=GitProgressHandler())
                     try:
                         repo.git.execute(['git', 'lfs', 'fetch', '--recent'])
                     except GitCommandError:


### PR DESCRIPTION
## Summary

`edkrepo sync` (and other commands that fetch from a remote) has long been unreliable on Windows and macOS for users working with repositories that have (or have ever had) branch names containing uppercase letters. The failure manifests as a hard error during `git fetch` and leaves the working tree in a state where further operations also fail until the user manually repairs their local `.git` directory.

## What This Change Does

This PR introduces two improvements:

### 1. `scrub_repo_case_conflicts()` — automatic ref surgery

A new library module in `edkrepo/common/repo_case_conflict_solver.py` that provides:

- **`scrub_repo_case_conflicts()`**
    - Scans both `.git/refs/remotes/` (filesystem refs) and `.git/packed-refs`
    - Detects refs whose path components case-conflict with other refs
    - Removes the "bad" refs (those with uppercase letters in conflicting path segments)
    - Cleans up empty directories left behind
    - Only touches `refs/remotes/*` to prevent any risk of data loss on local branches or tags
- **`scrub_stale_remote_reflogs()`**
    - Removes stale reflog files under `.git/logs/refs/remotes/` that are no longer backed by a valid remote-tracking ref.
    - Removes any empty directories left behind.

### 2. `fetch_from_remote()` — centralized fetch with automatic recovery

A new function in `edkrepo/common/common_repo_functions.py` that replaces all direct calls to `remote.fetch()` across the codebase. On failure it applies two automatic recovery strategies:

**Prune recovery** (triggered by `"cannot lock ref"` and similar):

1. Run `git remote prune`.
2. If prune itself fails **and** we are on a case-insensitive filesystem, call `scrub_repo_case_conflicts()` to remove the conflicting stale refs, then retry the prune.
3. After a successful prune, call `scrub_stale_remote_reflogs()` on case-insensitive filesystems to clean up orphaned reflog files.
4. Retry the fetch.

The slow `scrub_repo_case_conflicts()` scan is only triggered as a last resort. Only when `git remote prune` fails, and only on platforms with case-insensitive filesystems. Linux users are unaffected.

**Repack recovery** (triggered by `"incorrect old value provided"`):

1. Run `git pack-refs --all` to consolidate loose and packed ref entries that have diverged.
2. Retry the fetch (via a recursive call, so that a prune error encountered after the repack is also handled automatically).

## Impact

- **Windows and macOS**: Users who hit this condition will now have it automatically repaired on the next `edkrepo sync` instead of receiving a cryptic error.
- **All platforms**: the retry/prune heuristic catches more stale ref errors that previously required manual intervention by adding `'unable to update local ref'` and `'unable to resolve reference'` to the set of detected error strings.
- **All platforms**: a new repack recovery path handles `"incorrect old value provided"` errors caused by refs existing in both loose and packed forms with conflicting values.
- All existing `.fetch()` call sites (`sync_command`, `checkout_pin_command`, `send_review_command`, `cache.py`) have been updated to go through `fetch_from_remote()` so recovery is consistent everywhere.

Fixes #384