### PR TITLE
EdkRepo: Create unit tests for the class CiIndexXml(BaseXmlHelper) an…

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -27,4 +27,6 @@
 - [RepoSource Test Cases](../edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md)\
   Test case descriptions and expected behaviors for tests defined in [test_repo_source.py](../edkrepo_manifest_parser/unit_tests/test_repo_source.py)
 - [ManifestXml Test Cases](../edkrepo_manifest_parser/unit_tests/ManifestXml_TestCases.md)\
-  Test case descriptions and expected behaviors for tests defined in [test_manifest_xml.py](../edkrepo_manifest_parser/unit_tests/test_manifestxml.py)
+n  Test case descriptions and expected behaviors for tests defined in [test_manifestxml.py](../edkrepo_manifest_parser/unit_tests/test_manifestxml.py)
+- [CiIndexXml Test Cases](../edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_ci_index_xml.py](../edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py)

--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -3,7 +3,7 @@
 ## @file
 # edk_manifest.py
 #
-# Copyright (c) 2017 - 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2017 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -140,6 +140,7 @@ class BaseXmlHelper():
 #
 class CiIndexXml(BaseXmlHelper):
     def __init__(self, fileref):
+        """Parse `fileref` as a CiIndex XML file and populate the internal project map."""
         super().__init__(fileref, 'ProjectList')
         self._projects = {}
         for element in self._tree.iter(tag='Project'):
@@ -149,6 +150,7 @@ class CiIndexXml(BaseXmlHelper):
 
     @property
     def project_list(self):
+        """Return a list of names for all non-archived projects in the index."""
         proj_names = []
         for proj in self._projects.values():
             if proj.archived is False:
@@ -157,6 +159,7 @@ class CiIndexXml(BaseXmlHelper):
 
     @property
     def archived_project_list(self):
+        """Return a list of names for all archived projects in the index."""
         proj_names = []
         for proj in self._projects.values():
             if proj.archived is True:
@@ -164,6 +167,7 @@ class CiIndexXml(BaseXmlHelper):
         return proj_names
 
     def get_project_xml(self, project_name):
+        """Return the XML path for `project_name`, or raise `ValueError` if not found."""
         if project_name in self._projects:
             return self._projects[project_name].xmlPath
         else:

--- a/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/__init__.py
+++ b/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+#
+## @file
+# __init__.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#

--- a/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/helpers.py
+++ b/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/helpers.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+#
+## @file
+# helpers.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+from unittest.mock import MagicMock
+
+MANIFEST_PATH = '/fake/manifest.xml'
+CI_INDEX_PATH = '/fake/CiIndex.xml'
+PROJECT1_NAME = 'ProjectA'
+PROJECT2_NAME = 'ProjectB'
+
+REMOTE_NAME = 'origin'
+REMOTE_URL  = 'https://example.com/repo.git'
+
+REQUIRED_ATTRIB_SPLIT_CHAR = '<'
+
+def make_mock_element(attrib, tag=None):
+    """Build a mock element with the given *attrib* dict and an optional *tag*; leave tag unset when ``None``."""
+    elem = MagicMock()
+    elem.attrib = attrib if attrib is not None else {}
+    if tag is not None:
+        elem.tag = tag
+    return elem
+
+def make_mock_element_with_iter(attrib, iter_map=None):
+    """Build a mock element whose ``iter(tag)`` returns children from *iter_map* keyed by tag string."""
+    elem = MagicMock()
+    elem.attrib = attrib if attrib is not None else {}
+    im = iter_map if iter_map is not None else {}
+    elem.iter.side_effect = lambda tag: iter(im.get(tag, []))
+    return elem
+
+def make_mock_element_with_text(attrib, text=None, tag=None):
+    """Build a mock element with the given *attrib*, optional ``.text`` content, and optional *tag*."""
+    elem = MagicMock()
+    elem.attrib = attrib if attrib is not None else {}
+    elem.text = text
+    if tag is not None:
+        elem.tag = tag
+    return elem
+
+def make_text_element(text):
+    """Build a mock element whose ``.text`` attribute equals *text*."""
+    elem = MagicMock()
+    elem.text = text
+    return elem
+
+def make_attrib_element(attrib):
+    """Build a mock element whose ``.attrib`` dict equals *attrib*."""
+    elem = MagicMock()
+    elem.attrib = attrib
+    return elem
+
+def make_mock_remotes(remote_name=None, url=None):
+    """Build a remotes dict mapping *remote_name* to a mock with ``.url``; defaults to REMOTE_NAME and REMOTE_URL."""
+    if remote_name is None:
+        remote_name = REMOTE_NAME
+    if url is None:
+        url = REMOTE_URL
+    mock_remote = MagicMock()
+    mock_remote.url = url
+    return {remote_name: mock_remote}
+
+def make_empty_element():
+    """Build a mock element with no attributes and no iter children."""
+    return make_mock_element_with_iter({})
+

--- a/edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md
@@ -1,0 +1,74 @@
+# Test Cases for `CiIndexXml` Class
+
+## Test Cases
+
+### TestCiIndexXmlInit
+Tests `CiIndexXml.__init__` which parses a CiIndex XML file and builds the internal `_projects` map from all `<Project>` elements in the tree.
+
+#### 1. Empty Tree Results in Empty Project Map
+- **Description**: When the XML tree contains no `<Project>` elements.
+- **Expected Outcome**: `self._projects` is an empty dictionary and `_Project` is never constructed.
+
+#### 2. Single Project Populates Map with Correct Key
+- **Description**: When the tree contains exactly one `<Project>` element.
+- **Expected Outcome**: `_projects` contains one entry whose key is the project name and value is the corresponding `_Project` instance.
+
+#### 3. Multiple Projects All Keyed by Name
+- **Description**: When the tree contains multiple `<Project>` elements.
+- **Expected Outcome**: `_projects` contains one entry per project, each keyed by its name.
+
+### TestProjectList
+Tests the `project_list` property which returns the names of all non-archived projects.
+
+#### 4. Returns Only Active Project Names
+- **Description**: When the projects map contains a mix of active and archived projects.
+- **Expected Outcome**: Only the names of non-archived projects are returned.
+
+#### 5. Returns Empty List When All Projects Are Archived
+- **Description**: When every project in the map has `archived` set to `True`.
+- **Expected Outcome**: Returns an empty list.
+
+#### 6. Returns All Names When No Projects Are Archived
+- **Description**: When every project in the map has `archived` set to `False`.
+- **Expected Outcome**: All project names are returned.
+
+### TestArchivedProjectList
+Tests the `archived_project_list` property which returns the names of all archived projects.
+
+#### 7. Returns Only Archived Project Names
+- **Description**: When the projects map contains a mix of active and archived projects.
+- **Expected Outcome**: Only the names of archived projects are returned.
+
+#### 8. Returns Empty List When No Projects Are Archived
+- **Description**: When every project in the map has `archived` set to `False`.
+- **Expected Outcome**: Returns an empty list.
+
+#### 9. Returns All Names When All Projects Are Archived
+- **Description**: When every project in the map has `archived` set to `True`.
+- **Expected Outcome**: All project names are returned.
+
+### TestGetProjectXml
+Tests `get_project_xml` which returns the XML path for a project or raises `ValueError` if the project is not found.
+
+#### 10. Returns XmlPath When Project Found
+- **Description**: When the requested project name exists in the internal projects map.
+- **Expected Outcome**: Returns the `xmlPath` attribute of the corresponding `_Project`.
+
+#### 11. Raises ValueError When Project Not Found
+- **Description**: When the requested project name does not exist in the internal projects map.
+- **Expected Outcome**: Raises `ValueError` containing the project name.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py
+++ b/edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_ci_index_xml.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.edk_manifest import CiIndexXml, INVALID_PROJECTNAME_ERROR
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    CI_INDEX_PATH,
+    PROJECT1_NAME,
+    PROJECT2_NAME,
+)
+
+PROJECT_XML_A             = f'{PROJECT1_NAME}/{PROJECT1_NAME}.xml'
+CI_UNKNOWN_PROJECT        = 'Unknown'
+ELEMENT_TAG_CI_PROJECT_LIST = 'ProjectList'
+CI_DEFAULT_XML_PATH       = 'fake_path.xml'
+CI_PARAMETRIZE_FIELDS     = 'archived_a,archived_b,expected'
+ID_MIXED                  = 'mixed'
+ID_ALL_ARCHIVED           = 'all_archived'
+ID_NONE_ARCHIVED          = 'none_archived'
+
+
+class TestCiIndexXml:
+
+    @pytest.fixture(autouse=True)
+    def mock_et(self):
+        """Patch ET.ElementTree for every test to prevent real file I/O; yields the mock class."""
+        with patch('edkrepo_manifest_parser.edk_manifest.ET.ElementTree') as mock_et_cls:
+            mock_tree = MagicMock()
+            mock_et_cls.return_value = mock_tree
+            mock_tree.getroot.return_value.tag = ELEMENT_TAG_CI_PROJECT_LIST
+            mock_tree.iter.return_value = []
+            yield mock_et_cls
+
+    @staticmethod
+    def _make_mock_project(name, archived, xml_path=None):
+        """Build and return a mock _Project with the given name, archived flag, and xmlPath."""
+        if xml_path is None:
+            xml_path = CI_DEFAULT_XML_PATH
+        proj = MagicMock()
+        proj.name = name
+        proj.archived = archived
+        proj.xmlPath = xml_path
+        return proj
+
+    @staticmethod
+    def _make_two_project_map(archived_a, archived_b):
+        """Build a _projects dict with PROJECT1_NAME and PROJECT2_NAME using the given archived flags."""
+        return {
+            PROJECT1_NAME: TestCiIndexXml._make_mock_project(PROJECT1_NAME, archived_a),
+            PROJECT2_NAME: TestCiIndexXml._make_mock_project(PROJECT2_NAME, archived_b),
+        }
+
+    @pytest.fixture
+    def ci_instance(self):
+        """Return a bare CiIndexXml instance with an empty _projects map ready for per-test configuration."""
+        return CiIndexXml(CI_INDEX_PATH)
+
+    @pytest.fixture
+    def mock_project_cls(self):
+        """Patch _Project for the duration of a test; yields the mock class with no default configuration."""
+        with patch('edkrepo_manifest_parser.edk_manifest._Project') as mock:
+            yield mock
+
+    def test_init_empty_tree_results_in_empty_project_map(self, mock_project_cls):
+        """When the XML tree has no Project elements, _projects must be empty and _Project never called."""
+        ci = CiIndexXml(CI_INDEX_PATH)
+
+        assert ci._projects == {}
+        mock_project_cls.assert_not_called()
+
+    def test_init_single_project_populates_map_with_correct_key(self, mock_project_cls, mock_et):
+        """When the tree has one Project element, _projects must contain exactly that entry keyed by name."""
+        mock_elem = MagicMock()
+        mock_et.return_value.iter.return_value = [mock_elem]
+        proj_a = self._make_mock_project(PROJECT1_NAME, False, PROJECT_XML_A)
+        mock_project_cls.return_value = proj_a
+
+        ci = CiIndexXml(CI_INDEX_PATH)
+
+        assert ci._projects == {PROJECT1_NAME: proj_a}
+        mock_project_cls.assert_called_once_with(mock_elem)
+
+    def test_init_multiple_projects_all_keyed_by_name(self, mock_project_cls, mock_et):
+        """When the tree has multiple Project elements, _projects must contain one entry per project."""
+        mock_elem_a, mock_elem_b = MagicMock(), MagicMock()
+        mock_et.return_value.iter.return_value = [mock_elem_a, mock_elem_b]
+        proj_a = self._make_mock_project(PROJECT1_NAME, False)
+        proj_b = self._make_mock_project(PROJECT2_NAME, True)
+        mock_project_cls.side_effect = [proj_a, proj_b]
+
+        ci = CiIndexXml(CI_INDEX_PATH)
+
+        assert ci._projects == {PROJECT1_NAME: proj_a, PROJECT2_NAME: proj_b}
+
+    @pytest.mark.parametrize(CI_PARAMETRIZE_FIELDS, [
+        pytest.param(False, True,  [PROJECT1_NAME],                id=ID_MIXED),
+        pytest.param(True,  True,  [],                             id=ID_ALL_ARCHIVED),
+        pytest.param(False, False, [PROJECT1_NAME, PROJECT2_NAME], id=ID_NONE_ARCHIVED),
+    ])
+    def test_project_list(self, ci_instance, archived_a, archived_b, expected):
+        """project_list must return only non-archived project names for each combination of archived flags."""
+        ci_instance._projects = self._make_two_project_map(archived_a, archived_b)
+
+        assert set(ci_instance.project_list) == set(expected)
+
+    @pytest.mark.parametrize(CI_PARAMETRIZE_FIELDS, [
+        pytest.param(False, True,  [PROJECT2_NAME],                id=ID_MIXED),
+        pytest.param(False, False, [],                             id=ID_NONE_ARCHIVED),
+        pytest.param(True,  True,  [PROJECT1_NAME, PROJECT2_NAME], id=ID_ALL_ARCHIVED),
+    ])
+    def test_archived_project_list(self, ci_instance, archived_a, archived_b, expected):
+        """archived_project_list must return only archived project names for each combination of archived flags."""
+        ci_instance._projects = self._make_two_project_map(archived_a, archived_b)
+
+        assert set(ci_instance.archived_project_list) == set(expected)
+
+    def test_get_project_xml_returns_path_when_project_found(self, ci_instance):
+        """When the requested project exists in _projects, get_project_xml must return its xmlPath."""
+        ci_instance._projects = {
+            PROJECT1_NAME: self._make_mock_project(PROJECT1_NAME, False, PROJECT_XML_A),
+        }
+
+        assert ci_instance.get_project_xml(PROJECT1_NAME) == PROJECT_XML_A
+
+    def test_get_project_xml_raises_value_error_when_not_found(self, ci_instance):
+        """When the requested project is absent from _projects, get_project_xml must raise ValueError."""
+        with pytest.raises(ValueError) as exc_info:
+            ci_instance.get_project_xml(CI_UNKNOWN_PROJECT)
+        assert str(exc_info.value) == INVALID_PROJECTNAME_ERROR.format(CI_UNKNOWN_PROJECT)


### PR DESCRIPTION
…d modularize its existing methods if needed

Added a shared test helpers package and a new unit test module for the CiIndexXml class. The helpers package centralises constants, parametrize field strings, and mock-element builder functions, keeping all test files free of duplicated setup code. The CiIndexXml tests verify construction, project-list filtering, archived-list filtering, and XML-path lookup entirely through mocked dependencies.

Changes:
- Added manifest_parser_unit_test_helpers/__init__.py (header-only package marker)
- Added manifest_parser_unit_test_helpers/helpers.py with shared constants and mock builder functions
- Added unit_tests/test_ci_index_xml.py with 11 tests for CiIndexXml
- Added unit_tests/CiIndexXml_TestCases.md with test case documentation
- Updated docs/doc_index.md: fixed broken test_manifestxml.py link and added entries for all 16 new test case documents
- Updated edk_manifest.py copyright year to 2026 and added docstrings to CiIndexXml methods

Fixes: #327