### PR TITLE
EdkRepo: Create unit tests for the class _Project() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -181,20 +181,23 @@ class CiIndexXml(BaseXmlHelper):
         else:
             raise ValueError(INVALID_PROJECTNAME_ERROR.format(project_name))
 
-
 class _Project():
     def __init__(self, element):
+        """Parse required and optional attributes from a `<Project>` XML element."""
+        self.name, self.xmlPath = _parse_project_required_attribs(element)
         try:
-            self.name = element.attrib['name']
-            self.xmlPath = element.attrib['xmlPath']
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
-        try:
-            # if the archived attrib is not explicitly set to true, then assume false
             self.archived = (element.attrib['archived'].lower() == 'true')
         except Exception:
             self.archived = False
 
+def _parse_project_required_attribs(element):
+    """Return (name, xmlPath) from `element`, or raise `KeyError` if either required attribute is missing."""
+    try:
+        name = element.attrib['name']
+        xml_path = element.attrib['xmlPath']
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return name, xml_path
 
 #
 #  This class will parse and the manifest XML file and populate the named

--- a/edkrepo_manifest_parser/unit_tests/Project_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/Project_TestCases.md
@@ -1,0 +1,56 @@
+# Test Cases for `_Project` Class
+
+## Test Cases
+
+### TestParseProjectRequiredAttribs
+Tests `_parse_project_required_attribs` which extracts the required `name` and `xmlPath` attributes from a `<Project>` XML element, raising `KeyError` if either is missing.
+
+#### 1. Returns Name and XmlPath When Both Present
+- **Description**: When `name` and `xmlPath` are both present in the element's attributes.
+- **Expected Outcome**: Returns a tuple `(name, xmlPath)` with the correct values and no exception is raised.
+
+#### 2. Raises KeyError When Name Is Missing
+- **Description**: When the `name` attribute is absent from the element.
+- **Expected Outcome**: Raises `KeyError` containing the required-attribute error message.
+
+#### 3. Raises KeyError When XmlPath Is Missing
+- **Description**: When the `xmlPath` attribute is absent from the element.
+- **Expected Outcome**: Raises `KeyError` containing the required-attribute error message.
+
+### TestProjectInit
+Tests `_Project.__init__` which parses required (`name`, `xmlPath`) and optional (`archived`) attributes from a `<Project>` XML element.
+
+#### 1. Sets Name and XmlPath from Required Attributes
+- **Description**: When all required attributes are present in the element.
+- **Expected Outcome**: `self.name` and `self.xmlPath` are set to the values from the element's attributes.
+
+#### 2. Sets Archived to True When Flag Is Lowercase True
+- **Description**: When the `archived` attribute is set to the string `'true'`.
+- **Expected Outcome**: `self.archived` is `True`.
+
+#### 3. Sets Archived to False When Flag Is Lowercase False
+- **Description**: When the `archived` attribute is set to the string `'false'`.
+- **Expected Outcome**: `self.archived` is `False`.
+
+#### 4. Defaults Archived to False When Attribute Is Missing
+- **Description**: When the `archived` attribute is absent from the element.
+- **Expected Outcome**: `self.archived` defaults to `False`.
+
+#### 5. Sets Archived to True When Flag Is Uppercase (Case Insensitive)
+- **Description**: When the `archived` attribute is set to `'TRUE'` (uppercase).
+- **Expected Outcome**: `self.archived` is `True`, confirming case-insensitive comparison.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_project.py
+++ b/edkrepo_manifest_parser/unit_tests/test_project.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_project.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import _Project, _parse_project_required_attribs, REQUIRED_ATTRIB_ERROR_MSG
+
+ATTRIB_NAME                  = 'name'
+ATTRIB_XML_PATH              = 'xmlPath'
+ATTRIB_ARCHIVED              = 'archived'
+ATTRIB_BOOL_TRUE             = 'true'
+ATTRIB_BOOL_FALSE            = 'false'
+ARCHIVED_TRUE_UPPER          = 'TRUE'
+ELEMENT_TAG_PROJECT          = 'Project'
+TEST_PROJECT_NAME            = 'MyProject'
+PROJECT_XML_PATH             = 'MyProject/MyProject.xml'
+PROJECT_ARCHIVED_FLAG_FIELDS = 'archived_value,expected'
+ID_TRUE_LOWER                = 'true_lower'
+ID_FALSE_LOWER               = 'false_lower'
+ID_MISSING                   = 'missing'
+ID_TRUE_UPPER                = 'true_upper'
+
+
+class TestProject:
+    @staticmethod
+    def _make_full_element(archived=None):
+        """Build a mock element with name, xmlPath and an optional archived value."""
+        attrib = {
+            ATTRIB_NAME: TEST_PROJECT_NAME,
+            ATTRIB_XML_PATH: PROJECT_XML_PATH,
+        }
+        if archived is not None:
+            attrib[ATTRIB_ARCHIVED] = archived
+        return make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
+
+    @staticmethod
+    def _assert_required_attrib_key_error(attrib):
+        """Call _parse_project_required_attribs with attrib and assert KeyError with the required-attrib message prefix."""
+        element = make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
+        with pytest.raises(KeyError) as exc_info:
+            _parse_project_required_attribs(element)
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_parse_required_attribs_returns_name_and_xml_path_when_both_present(self):
+        """When name and xmlPath are present, must return (name, xmlPath) without raising."""
+        element = self._make_full_element()
+
+        name, xml_path = _parse_project_required_attribs(element)
+
+        assert name == TEST_PROJECT_NAME
+        assert xml_path == PROJECT_XML_PATH
+
+    def test_parse_required_attribs_raises_key_error_when_name_missing(self):
+        """When name is absent from the element, must raise KeyError with the required-attrib message."""
+        self._assert_required_attrib_key_error({ATTRIB_XML_PATH: PROJECT_XML_PATH})
+
+    def test_parse_required_attribs_raises_key_error_when_xml_path_missing(self):
+        """When xmlPath is absent from the element, must raise KeyError with the required-attrib message."""
+        self._assert_required_attrib_key_error({ATTRIB_NAME: TEST_PROJECT_NAME})
+
+    def test_init_sets_name_and_xml_path_from_required_attribs(self):
+        """When all required attributes are present, __init__ must set name and xmlPath correctly."""
+        element = self._make_full_element()
+
+        proj = _Project(element)
+
+        assert proj.name == TEST_PROJECT_NAME
+        assert proj.xmlPath == PROJECT_XML_PATH
+
+    @pytest.mark.parametrize(PROJECT_ARCHIVED_FLAG_FIELDS, [
+        pytest.param(ATTRIB_BOOL_TRUE,    True,  id=ID_TRUE_LOWER),
+        pytest.param(ATTRIB_BOOL_FALSE,   False, id=ID_FALSE_LOWER),
+        pytest.param(None,                False, id=ID_MISSING),
+        pytest.param(ARCHIVED_TRUE_UPPER, True,  id=ID_TRUE_UPPER),
+    ])
+    def test_init_archived_flag(self, archived_value, expected):
+        """Each archived_value must produce the expected boolean on self.archived."""
+        element = self._make_full_element(archived=archived_value)
+        proj = _Project(element)
+        assert proj.archived is expected


### PR DESCRIPTION
Refactored _Project.__init__ to delegate required attribute parsing to a
new module-level function _parse_project_required_attribs, consistent with
the pattern already used by other private classes in edk_manifest.py. The
extraction improves testability by allowing the parser to be exercised
independently of object construction.

Changes:
- Extracted _parse_project_required_attribs() as a module-level function in edk_manifest.py
- Refactored _Project.__init__ to call _parse_project_required_attribs() for name and xmlPath
- Added docstring to _Project.__init__ and _parse_project_required_attribs()
- Added unit_tests/test_project.py with 7 tests covering _parse_project_required_attribs and _Project.__init__
- Added unit_tests/Project_TestCases.md with 8 test cases across 2 test groups (_parse_project_required_attribs and _Project.__init__)

Changes: #329