### PR TITLE
Edkrepo: Create unit tests for the class _PatchSet() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -908,15 +908,12 @@ class ManifestXml(BaseXmlHelper):
 
 class _PatchSet():
     def __init__(self, element):
-        try:
-            self.remote = element.attrib['remote']
-            self.name = element.attrib['name']
-            self.parentSha = element.attrib['parentSha']
-            self.fetchBranch = element.attrib['fetchBranch']
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required attributes from a ``<PatchSet>`` XML element."""
+        self.remote, self.name, self.parentSha, self.fetchBranch = \
+            _parse_patchset_required_attribs(element)
 
     def __eq__(self, other_patchset):
+        """Return ``True`` if *other_patchset* has the same four required fields."""
         if isinstance(other_patchset, _PatchSet):
             return (self.name, self.remote, self.parentSha, self.fetchBranch) == \
             (other_patchset.name, other_patchset.remote, other_patchset.parentSha, other_patchset.fetchBranch)
@@ -924,7 +921,19 @@ class _PatchSet():
 
     @property
     def tuple(self):
+        """Return a :class:`PatchSet` namedtuple representation of this patchset."""
         return PatchSet(self.remote, self.name, self.parentSha, self.fetchBranch)
+
+def _parse_patchset_required_attribs(element):
+    """Return ``(remote, name, parentSha, fetchBranch)`` from a ``<PatchSet>`` element, or raise ``KeyError`` if any required attribute is absent."""
+    try:
+        remote = element.attrib['remote']
+        name = element.attrib['name']
+        parentSha = element.attrib['parentSha']
+        fetchBranch = element.attrib['fetchBranch']
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return remote, name, parentSha, fetchBranch
 
 class _PatchSetOperations():
     def __init__(self, element):

--- a/edkrepo_manifest_parser/unit_tests/PatchSet_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/PatchSet_TestCases.md
@@ -1,0 +1,70 @@
+# Test Cases for `_PatchSet` Class
+
+## Test Cases
+
+### TestParsePatchsetRequiredAttribs
+Tests `_parse_patchset_required_attribs` which parses the four required attributes of a `<PatchSet>` XML element, or raises `KeyError` when any are absent.
+
+#### 1. Returns All Four Values When All Present
+- **Description**: When `remote`, `name`, `parentSha`, and `fetchBranch` are all present in `element.attrib`.
+- **Expected Outcome**: Returns the tuple `(remote, name, parentSha, fetchBranch)` with the correct values.
+
+#### 2. Raises KeyError When `remote` Missing
+- **Description**: When `remote` is absent from `element.attrib`.
+- **Expected Outcome**: `KeyError` is raised containing the required-attribute error message prefix.
+
+#### 3. Raises KeyError When `name` Missing
+- **Description**: When `name` is absent from `element.attrib`.
+- **Expected Outcome**: `KeyError` is raised containing the required-attribute error message prefix.
+
+#### 4. Raises KeyError When `parentSha` Missing
+- **Description**: When `parentSha` is absent from `element.attrib`.
+- **Expected Outcome**: `KeyError` is raised containing the required-attribute error message prefix.
+
+#### 5. Raises KeyError When `fetchBranch` Missing
+- **Description**: When `fetchBranch` is absent from `element.attrib`.
+- **Expected Outcome**: `KeyError` is raised containing the required-attribute error message prefix.
+
+### TestPatchSetInit
+Tests `_PatchSet.__init__` which delegates required-attribute parsing to `_parse_patchset_required_attribs` and assigns the four fields.
+
+#### 1. Sets All Fields From Required Attribs
+- **Description**: When all four required attributes are present.
+- **Expected Outcome**: `self.remote`, `self.name`, `self.parentSha`, and `self.fetchBranch` are set to the corresponding attribute values.
+
+### TestPatchSetEq
+Tests `_PatchSet.__eq__` which returns `True` only when compared to a `_PatchSet` with identical values for all four fields.
+
+#### 1. Returns True for Equal Patchsets
+- **Description**: Two `_PatchSet` instances constructed from identical attribute dicts.
+- **Expected Outcome**: `ps1 == ps2` evaluates to `True`.
+
+#### 2. Returns False for Different Patchsets
+- **Description**: Two `_PatchSet` instances that differ in at least one field.
+- **Expected Outcome**: `ps1 != ps2` evaluates to `True`.
+
+#### 3. Returns False for Non-`_PatchSet` Type
+- **Description**: Comparing a `_PatchSet` to an object that is not a `_PatchSet`.
+- **Expected Outcome**: `__eq__` returns `False`.
+
+### TestPatchSetTuple
+Tests `_PatchSet.tuple` which returns a `PatchSet` namedtuple with the four field values.
+
+#### 1. Returns Correct PatchSet Namedtuple
+- **Description**: When all fields are set.
+- **Expected Outcome**: `tuple` returns a `PatchSet(remote, name, parent_sha, fetch_branch)` with the correct values.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_patchset.py
+++ b/edkrepo_manifest_parser/unit_tests/test_patchset.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_patchset.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+    REMOTE_NAME,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _PatchSet,
+    _parse_patchset_required_attribs,
+    PatchSet,
+    REQUIRED_ATTRIB_ERROR_MSG,
+)
+
+ATTRIB_NAME          = 'name'
+ATTRIB_REMOTE        = 'remote'
+ATTRIB_PARENT_SHA    = 'parentSha'
+ATTRIB_FETCH_BRANCH  = 'fetchBranch'
+ELEMENT_TAG_PATCHSET = 'PatchSet'
+PATCHSET_NAME        = 'ps_name'
+OTHER_PATCHSET_NAME  = 'other_ps'
+COMMIT               = 'abc123'
+BRANCH               = 'main'
+
+PARAM_MISSING_ATTRIB      = 'missing_attrib'
+ID_REMOTE_MISSING         = 'remote_missing'
+ID_NAME_MISSING           = 'name_missing'
+ID_PARENT_SHA_MISSING     = 'parent_sha_missing'
+ID_FETCH_BRANCH_MISSING   = 'fetch_branch_missing'
+
+
+class TestPatchSet:
+
+    @staticmethod
+    def _make_full_element():
+        """Build a mock element with all four required patchset attributes."""
+        return make_mock_element({
+            ATTRIB_REMOTE:       REMOTE_NAME,
+            ATTRIB_NAME:         PATCHSET_NAME,
+            ATTRIB_PARENT_SHA:   COMMIT,
+            ATTRIB_FETCH_BRANCH: BRANCH,
+        }, tag=ELEMENT_TAG_PATCHSET)
+
+    def test_parse_required_attribs_returns_all_four_when_all_present(self):
+        """When all four required attributes are present, must return the four values."""
+        element = self._make_full_element()
+
+        remote, name, parent_sha, fetch_branch = _parse_patchset_required_attribs(element)
+
+        assert remote == REMOTE_NAME
+        assert name == PATCHSET_NAME
+        assert parent_sha == COMMIT
+        assert fetch_branch == BRANCH
+
+    @pytest.mark.parametrize(PARAM_MISSING_ATTRIB, [
+        pytest.param(ATTRIB_REMOTE,       id=ID_REMOTE_MISSING),
+        pytest.param(ATTRIB_NAME,         id=ID_NAME_MISSING),
+        pytest.param(ATTRIB_PARENT_SHA,   id=ID_PARENT_SHA_MISSING),
+        pytest.param(ATTRIB_FETCH_BRANCH, id=ID_FETCH_BRANCH_MISSING),
+    ])
+    def test_parse_required_attribs_raises_key_error_when_missing(self, missing_attrib):
+        """When any required attribute is absent, must raise KeyError with the required-attrib message."""
+        full = {
+            ATTRIB_REMOTE:       REMOTE_NAME,
+            ATTRIB_NAME:         PATCHSET_NAME,
+            ATTRIB_PARENT_SHA:   COMMIT,
+            ATTRIB_FETCH_BRANCH: BRANCH,
+        }
+        del full[missing_attrib]
+        element = make_mock_element(full, tag=ELEMENT_TAG_PATCHSET)
+        with pytest.raises(KeyError) as exc_info:
+            _parse_patchset_required_attribs(element)
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_init_sets_all_fields_from_required_attribs(self):
+        """When all required attributes are present, __init__ must set all four fields correctly."""
+        element = self._make_full_element()
+
+        ps = _PatchSet(element)
+
+        assert ps.remote == REMOTE_NAME
+        assert ps.name == PATCHSET_NAME
+        assert ps.parentSha == COMMIT
+        assert ps.fetchBranch == BRANCH
+
+    def test_eq_returns_true_for_equal_patchsets(self):
+        """Two _PatchSet instances with identical attributes must compare as equal."""
+        ps1 = _PatchSet(self._make_full_element())
+        ps2 = _PatchSet(self._make_full_element())
+
+        assert ps1 == ps2
+
+    def test_eq_returns_false_for_different_patchsets(self):
+        """Two _PatchSet instances with different attributes must not compare as equal."""
+        ps1 = _PatchSet(self._make_full_element())
+        ps2 = _PatchSet(make_mock_element({
+            ATTRIB_REMOTE:       REMOTE_NAME,
+            ATTRIB_NAME:         OTHER_PATCHSET_NAME,
+            ATTRIB_PARENT_SHA:   COMMIT,
+            ATTRIB_FETCH_BRANCH: BRANCH,
+        }, tag=ELEMENT_TAG_PATCHSET))
+
+        assert ps1 != ps2
+
+    def test_eq_returns_false_for_non_patchset_type(self):
+        """Comparing a _PatchSet to a non-_PatchSet object must return False."""
+        ps = _PatchSet(self._make_full_element())
+
+        assert ps.__eq__(object()) is False
+
+    def test_tuple_returns_correct_patchset_namedtuple(self):
+        """The tuple property must return a PatchSet namedtuple with the correct field values."""
+        ps = _PatchSet(self._make_full_element())
+
+        result = ps.tuple
+
+        assert result == PatchSet(
+            remote=REMOTE_NAME,
+            name=PATCHSET_NAME,
+            parent_sha=COMMIT,
+            fetch_branch=BRANCH,
+        )


### PR DESCRIPTION
Refactored _PatchSet.__init__ to delegate required attribute parsing to
a new module-level function _parse_patchset_required_attribs, consistent
with the pattern used by _Project, _RemoteRepo, _RepoHook, and other
private classes in edk_manifest.py. Added docstrings to __init__,
__eq__, tuple, and _parse_patchset_required_attribs.

Changes:
- Extracted _parse_patchset_required_attribs() as a module-level function in edk_manifest.py
- Refactored _PatchSet.__init__ to call _parse_patchset_required_attribs() for all four fields
- Added docstrings to _PatchSet.__init__, __eq__, tuple, and _parse_patchset_required_attribs
- Added unit_tests/test_patchset.py with 9 tests for _parse_patchset_required_attribs and _PatchSet
- Added unit_tests/PatchSet_TestCases.md documenting all test cases for _PatchSet and _parse_patchset_required_attribs

Changes: #330