### PR TITLE
EdkRepo: Create unit tests for the class _PatchSetOperations() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -928,6 +928,7 @@ class _PatchSet():
 
 class _PatchSetOperations():
     def __init__(self, element):
+        """Parse optional attributes from a patchset operation element; absent attributes default to ``None``."""
         self.type = element.tag
         try:
             self.file = element.attrib['file']
@@ -952,6 +953,7 @@ class _PatchSetOperations():
 
     @property
     def tuple(self):
+        """Return a :class:`PatchOperation` namedtuple representation of this operation."""
         return PatchOperation(self.type, self.file, self.sha, self.source_remote, self.source_branch, self.merge_strategy)
 
 class _ProjectInfo():

--- a/edkrepo_manifest_parser/unit_tests/PatchSetOperations_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/PatchSetOperations_TestCases.md
@@ -1,0 +1,56 @@
+# Test Cases for `_PatchSetOperations` Class
+
+## Test Cases
+
+### TestPatchSetOperationsInit
+Tests `_PatchSetOperations.__init__` which reads `element.tag` for the operation type and treats all five XML attributes as optional, defaulting each to `None` when absent.
+
+#### 1. Sets Type From Element Tag
+- **Description**: When element has a tag (e.g., `'CherryPick'`).
+- **Expected Outcome**: `self.type` is set to `element.tag`.
+
+#### 2. Sets All Optional Attribs When Present
+- **Description**: When `file`, `sha`, `sourceRemote`, `sourceBranch`, and `mergeStrategy` are all present in `element.attrib`.
+- **Expected Outcome**: Each corresponding field is set to its attribute value.
+
+#### 3. Sets `file` to None When Missing
+- **Description**: When `file` is absent from `element.attrib`.
+- **Expected Outcome**: `self.file` is `None`.
+
+#### 4. Sets `sha` to None When Missing
+- **Description**: When `sha` is absent from `element.attrib`.
+- **Expected Outcome**: `self.sha` is `None`.
+
+#### 5. Sets `source_remote` to None When Missing
+- **Description**: When `sourceRemote` is absent from `element.attrib`.
+- **Expected Outcome**: `self.source_remote` is `None`.
+
+#### 6. Sets `source_branch` to None When Missing
+- **Description**: When `sourceBranch` is absent from `element.attrib`.
+- **Expected Outcome**: `self.source_branch` is `None`.
+
+#### 7. Sets `merge_strategy` to None When Missing
+- **Description**: When `mergeStrategy` is absent from `element.attrib`.
+- **Expected Outcome**: `self.merge_strategy` is `None`.
+
+### TestPatchSetOperationsTuple
+Tests `_PatchSetOperations.tuple` which returns a `PatchOperation` namedtuple with all six field values.
+
+#### 1. Returns Correct PatchOperation Namedtuple
+- **Description**: When all optional attributes are present.
+- **Expected Outcome**: `tuple` returns a `PatchOperation(type, file, sha, source_remote, source_branch, merge_strategy)` with the correct values.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_patchset_operations.py
+++ b/edkrepo_manifest_parser/unit_tests/test_patchset_operations.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_patchset_operations.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+)
+from edkrepo_manifest_parser.edk_manifest import _PatchSetOperations, PatchOperation
+
+ELEMENT_TAG_CHERRY_PICK  = 'CherryPick'
+ATTRIB_FILE              = 'file'
+ATTRIB_SHA               = 'sha'
+ATTRIB_SOURCE_REMOTE     = 'sourceRemote'
+ATTRIB_SOURCE_BRANCH     = 'sourceBranch'
+ATTRIB_MERGE_STRATEGY    = 'mergeStrategy'
+OPS_FILE                 = 'some_file.patch'
+OPS_SHA                  = 'aabbcc'
+OPS_SOURCE_REMOTE        = 'upstream'
+OPS_SOURCE_BRANCH        = 'dev'
+OPS_MERGE_STRATEGY       = 'ours'
+FIELD_SOURCE_REMOTE      = 'source_remote'
+FIELD_SOURCE_BRANCH      = 'source_branch'
+FIELD_MERGE_STRATEGY     = 'merge_strategy'
+PARAM_FIELD_NAME         = 'field_name'
+
+
+class TestPatchSetOperations:
+
+    @pytest.fixture
+    def full_ops(self):
+        """Return a _PatchSetOperations instance with all optional attributes present."""
+        return _PatchSetOperations(make_mock_element({
+            ATTRIB_FILE: OPS_FILE,
+            ATTRIB_SHA: OPS_SHA,
+            ATTRIB_SOURCE_REMOTE: OPS_SOURCE_REMOTE,
+            ATTRIB_SOURCE_BRANCH: OPS_SOURCE_BRANCH,
+            ATTRIB_MERGE_STRATEGY: OPS_MERGE_STRATEGY,
+        }, tag=ELEMENT_TAG_CHERRY_PICK))
+
+    def test_init_sets_type_from_element_tag(self):
+        """__init__ must set self.type to element.tag."""
+        element = make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK)
+
+        ops = _PatchSetOperations(element)
+
+        assert ops.type == ELEMENT_TAG_CHERRY_PICK
+
+    def test_init_sets_all_optional_attribs_when_present(self, full_ops):
+        """When all optional attributes are present, __init__ must set each field to its value."""
+        assert full_ops.file == OPS_FILE
+        assert full_ops.sha == OPS_SHA
+        assert full_ops.source_remote == OPS_SOURCE_REMOTE
+        assert full_ops.source_branch == OPS_SOURCE_BRANCH
+        assert full_ops.merge_strategy == OPS_MERGE_STRATEGY
+
+    @pytest.mark.parametrize(PARAM_FIELD_NAME, [
+        pytest.param(ATTRIB_FILE,          id=ATTRIB_FILE),
+        pytest.param(ATTRIB_SHA,           id=ATTRIB_SHA),
+        pytest.param(FIELD_SOURCE_REMOTE,  id=FIELD_SOURCE_REMOTE),
+        pytest.param(FIELD_SOURCE_BRANCH,  id=FIELD_SOURCE_BRANCH),
+        pytest.param(FIELD_MERGE_STRATEGY, id=FIELD_MERGE_STRATEGY),
+    ])
+    def test_init_optional_attrib_defaults_to_none_when_missing(self, field_name):
+        """When any optional attribute is absent, __init__ must set the corresponding field to None."""
+        ops = _PatchSetOperations(make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK))
+        assert getattr(ops, field_name) is None
+
+    def test_tuple_returns_correct_patch_operation_namedtuple(self, full_ops):
+        """The tuple property must return a PatchOperation namedtuple with the correct field values."""
+        assert full_ops.tuple == PatchOperation(
+            type=ELEMENT_TAG_CHERRY_PICK,
+            file=OPS_FILE,
+            sha=OPS_SHA,
+            source_remote=OPS_SOURCE_REMOTE,
+            source_branch=OPS_SOURCE_BRANCH,
+            merge_strategy=OPS_MERGE_STRATEGY,
+        )


### PR DESCRIPTION
Added docstrings to _PatchSetOperations.__init__ and tuple. Added a complete unit test module and test case documentation for _PatchSetOperations, covering the type field, all five optional attributes (with present and missing cases), and the tuple property.

Changes:
- Added docstrings to _PatchSetOperations.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_patchset_operations.py with 8 tests for _PatchSetOperations
- Added unit_tests/PatchSetOperations_TestCases.md documenting all test cases for _PatchSetOperations

Fixes: #331