### PR TITLE
Edkrepo: Create unit tests for the class _RemoteRepo() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1015,14 +1015,10 @@ class _GeneralConfig():
     def tuple(self):
         return GeneralConfig(self.default_combo, self.curr_combo, self.pin_path, self.source_manifest_repo)
 
-
 class _RemoteRepo():
     def __init__(self, element):
-        try:
-            self.name = element.attrib['name']
-            self.url = element.text
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required and optional attributes from a ``<RemoteRepo>`` XML element."""
+        self.name, self.url = _parse_remote_repo_required_attribs(element)
         try:
             self.owner = element.attrib['owner']
         except:
@@ -1038,8 +1034,17 @@ class _RemoteRepo():
 
     @property
     def tuple(self):
+        """Return a :class:`RemoteRepo` namedtuple representation of this remote repository."""
         return RemoteRepo(self.name, self.url, self.owner, self.review_type, self.pr_strategy)
 
+def _parse_remote_repo_required_attribs(element):
+    """Return ``(name, url)`` from a ``<RemoteRepo>`` element, or raise ``KeyError`` if ``name`` is absent."""
+    try:
+        name = element.attrib['name']
+        url = element.text
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return name, url
 
 class _RepoHook():
     def __init__(self, element, remotes):

--- a/edkrepo_manifest_parser/unit_tests/RemoteRepo_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/RemoteRepo_TestCases.md
@@ -1,0 +1,67 @@
+# Test Cases for `_RemoteRepo` Class
+
+## Test Cases
+
+### TestParseRemoteRepoRequiredAttribs
+Tests `_parse_remote_repo_required_attribs(element)` which validates that the required `name` attribute is present and returns `(name, url)`.
+
+#### 1. Returns name and url When Both Attributes Present
+- **Description**: When the element contains both a `name` attribute and text content as the URL.
+- **Expected Outcome**: Returns `(name, url)` matching the element's `name` attribute and text.
+
+#### 2. Raises KeyError When name Attribute Absent
+- **Description**: When the element has no `name` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
+
+### TestRemoteRepoInit
+Tests `_RemoteRepo.__init__` which parses a `<RemoteRepo>` XML element for required and optional attributes.
+
+#### 1. Sets name and url From Required Attributes
+- **Description**: When the element has a `name` attribute and text content for the URL.
+- **Expected Outcome**: `self.name` equals the `name` attribute value; `self.url` equals the element's text.
+
+#### 2. Sets owner When owner Attribute Present
+- **Description**: When the element has an `owner` attribute.
+- **Expected Outcome**: `self.owner` is set to the `owner` attribute value.
+
+#### 3. Sets owner to None When owner Attribute Absent
+- **Description**: When the element has no `owner` attribute.
+- **Expected Outcome**: `self.owner` is `None`.
+
+#### 4. Sets review_type When reviewType Attribute Present
+- **Description**: When the element has a `reviewType` attribute.
+- **Expected Outcome**: `self.review_type` is set to the `reviewType` attribute value.
+
+#### 5. Sets review_type to None When reviewType Attribute Absent
+- **Description**: When the element has no `reviewType` attribute.
+- **Expected Outcome**: `self.review_type` is `None`.
+
+#### 6. Sets pr_strategy When prStrategy Attribute Present
+- **Description**: When the element has a `prStrategy` attribute.
+- **Expected Outcome**: `self.pr_strategy` is set to the `prStrategy` attribute value.
+
+#### 7. Sets pr_strategy to None When prStrategy Attribute Absent
+- **Description**: When the element has no `prStrategy` attribute.
+- **Expected Outcome**: `self.pr_strategy` is `None`.
+
+### TestRemoteRepoTuple
+Tests `_RemoteRepo.tuple` which returns a `RemoteRepo` namedtuple.
+
+#### 1. Returns Correct RemoteRepo Namedtuple
+- **Description**: When all attributes are present.
+- **Expected Outcome**: `tuple` returns a `RemoteRepo` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_remote_repo.py
+++ b/edkrepo_manifest_parser/unit_tests/test_remote_repo.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_remote_repo.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_text,
+    REMOTE_NAME,
+    REMOTE_URL,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _RemoteRepo,
+    _parse_remote_repo_required_attribs,
+    RemoteRepo,
+    REQUIRED_ATTRIB_ERROR_MSG,
+)
+
+ATTRIB_NAME             = 'name'
+ATTRIB_OWNER            = 'owner'
+ATTRIB_REVIEW_TYPE      = 'reviewType'
+ATTRIB_PR_STRATEGY      = 'prStrategy'
+ELEMENT_TAG_REMOTE_REPO = 'RemoteRepo'
+OWNER                   = 'Jane Doe'
+REVIEW_TYPE             = 'gerrit'
+PR_STRATEGY             = 'squash'
+FIELD_OWNER             = 'owner'
+FIELD_REVIEW_TYPE       = 'review_type'
+FIELD_PR_STRATEGY       = 'pr_strategy'
+PARAM_FIELD_NAME          = 'field_name'
+PARAM_FIELD_AND_EXPECTED  = 'field_name, expected_value'
+ID_OWNER_ABSENT           = 'owner_absent'
+ID_REVIEW_TYPE_ABSENT     = 'review_type_absent'
+ID_PR_STRATEGY_ABSENT     = 'pr_strategy_absent'
+ID_OWNER_PRESENT          = 'owner_present'
+ID_REVIEW_TYPE_PRESENT    = 'review_type_present'
+ID_PR_STRATEGY_PRESENT    = 'pr_strategy_present'
+
+
+class TestRemoteRepo:
+
+    @staticmethod
+    def _make_full_element():
+        """Build a mock element with all required and optional RemoteRepo attributes."""
+        return make_mock_element_with_text(
+            attrib={
+                ATTRIB_NAME: REMOTE_NAME,
+                ATTRIB_OWNER: OWNER,
+                ATTRIB_REVIEW_TYPE: REVIEW_TYPE,
+                ATTRIB_PR_STRATEGY: PR_STRATEGY,
+            },
+            text=REMOTE_URL,
+            tag=ELEMENT_TAG_REMOTE_REPO,
+        )
+
+    @pytest.fixture
+    def full_remote_repo(self):
+        """Return a _RemoteRepo instance with all optional attributes present."""
+        return _RemoteRepo(self._make_full_element())
+
+    def test_parse_required_attribs_returns_name_and_url_when_name_present(self):
+        """When name is present, _parse_remote_repo_required_attribs must return (name, url)."""
+        element = make_mock_element_with_text(
+            attrib={ATTRIB_NAME: REMOTE_NAME},
+            text=REMOTE_URL,
+            tag=ELEMENT_TAG_REMOTE_REPO,
+        )
+
+        name, url = _parse_remote_repo_required_attribs(element)
+
+        assert name == REMOTE_NAME
+        assert url == REMOTE_URL
+
+    def test_parse_required_attribs_raises_key_error_when_name_missing(self):
+        """When name is absent, _parse_remote_repo_required_attribs must raise KeyError with the required-attrib message."""
+        element = make_mock_element_with_text(attrib={}, text=REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO)
+
+        with pytest.raises(KeyError) as exc_info:
+            _parse_remote_repo_required_attribs(element)
+
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_init_sets_name_and_url_from_required_attribs(self):
+        """When name is present, __init__ must set self.name and self.url correctly."""
+        element = make_mock_element_with_text(
+            attrib={ATTRIB_NAME: REMOTE_NAME},
+            text=REMOTE_URL,
+            tag=ELEMENT_TAG_REMOTE_REPO,
+        )
+
+        repo = _RemoteRepo(element)
+
+        assert repo.name == REMOTE_NAME
+        assert repo.url == REMOTE_URL
+
+    @pytest.mark.parametrize(PARAM_FIELD_AND_EXPECTED, [
+        pytest.param(FIELD_OWNER, OWNER, id=ID_OWNER_PRESENT),
+        pytest.param(FIELD_REVIEW_TYPE, REVIEW_TYPE, id=ID_REVIEW_TYPE_PRESENT),
+        pytest.param(FIELD_PR_STRATEGY, PR_STRATEGY, id=ID_PR_STRATEGY_PRESENT),
+    ])
+    def test_init_sets_optional_attrib_when_present(self, full_remote_repo, field_name, expected_value):
+        """When any optional attribute is present, __init__ must set the corresponding field to its value."""
+        assert getattr(full_remote_repo, field_name) == expected_value
+
+    @pytest.mark.parametrize(PARAM_FIELD_NAME, [
+        pytest.param(FIELD_OWNER, id=ID_OWNER_ABSENT),
+        pytest.param(FIELD_REVIEW_TYPE, id=ID_REVIEW_TYPE_ABSENT),
+        pytest.param(FIELD_PR_STRATEGY, id=ID_PR_STRATEGY_ABSENT),
+    ])
+    def test_init_optional_attrib_defaults_to_none_when_absent(self, field_name):
+        """When any optional attribute is absent, __init__ must set the corresponding field to None."""
+        element = make_mock_element_with_text(
+            attrib={ATTRIB_NAME: REMOTE_NAME}, text=REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO,
+        )
+        repo = _RemoteRepo(element)
+        assert getattr(repo, field_name) is None
+
+    def test_tuple_returns_correct_remote_repo_namedtuple(self, full_remote_repo):
+        """The tuple property must return a RemoteRepo namedtuple with all field values correct."""
+        result = full_remote_repo.tuple
+
+        assert result == RemoteRepo(
+            name=REMOTE_NAME,
+            url=REMOTE_URL,
+            owner=OWNER,
+            review_type=REVIEW_TYPE,
+            pr_strategy=PR_STRATEGY,
+        )


### PR DESCRIPTION
Extracted the inline required-attribute parsing in _RemoteRepo.__init__ into a new module-level function _parse_remote_repo_required_attribs, consistent with the pattern established for _Project, _PatchSet, _ProjectInfo, and other private classes. Added docstrings to _RemoteRepo.__init__ and tuple, and introduced a complete unit test module and test case documentation for _RemoteRepo.

Changes:
- Extracted _parse_remote_repo_required_attribs from _RemoteRepo.__init__ in edk_manifest.py
- Added docstrings to _RemoteRepo.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_remote_repo.py with 10 tests for _RemoteRepo and _parse_remote_repo_required_attribs
- Added unit_tests/RemoteRepo_TestCases.md documenting all test cases for _RemoteRepo

Fixes: #334