### PR TITLE
EdkRepo: Create unit tests for the class _RepoHook() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1043,11 +1043,8 @@ class _RemoteRepo():
 
 class _RepoHook():
     def __init__(self, element, remotes):
-        try:
-            self.source = element.attrib['source']
-            self.dest_path = element.attrib['destination']
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required and optional attributes from a ``<ClientGitHook>`` element, resolving the remote URL from ``remotes``."""
+        self.source, self.dest_path = _parse_repo_hook_required_attribs(element)
         try:
             self.remote_url = remotes[element.attrib['remote']].url
         except Exception:
@@ -1059,8 +1056,17 @@ class _RepoHook():
 
     @property
     def tuple(self):
+        """Return a :class:`RepoHook` namedtuple representation of this hook."""
         return RepoHook(self.source, self.dest_path, self.dest_file, self.remote_url)
 
+def _parse_repo_hook_required_attribs(element):
+    """Return ``(source, dest_path)`` from a ``<ClientGitHook>`` element, or raise ``KeyError`` if either is absent."""
+    try:
+        source = element.attrib['source']
+        dest_path = element.attrib['destination']
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return source, dest_path
 
 class _Combination():
     def __init__(self, element):

--- a/edkrepo_manifest_parser/unit_tests/RepoHook_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/RepoHook_TestCases.md
@@ -1,0 +1,59 @@
+# Test Cases for `_RepoHook` Class
+
+## Test Cases
+
+### TestParseRepoHookRequiredAttribs
+Tests `_parse_repo_hook_required_attribs(element)` which validates that both `source` and `destination` required attributes are present, raising `KeyError` for either absence.
+
+#### 1. Returns source and dest_path When Both Attributes Present
+- **Description**: When the element contains both a `source` attribute and a `destination` attribute.
+- **Expected Outcome**: Returns `(source, dest_path)` matching the element's attribute values.
+
+#### 2. Raises KeyError When source Attribute Absent
+- **Description**: When the element has no `source` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
+
+#### 3. Raises KeyError When destination Attribute Absent
+- **Description**: When the element has no `destination` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
+
+### TestRepoHookInit
+Tests `_RepoHook.__init__` which parses a `<ClientGitHook>` XML element for required attributes and resolves the remote URL from a remotes dictionary.
+
+#### 1. Sets source and dest_path From Required Attributes
+- **Description**: When the element has valid `source` and `destination` attributes.
+- **Expected Outcome**: `self.source` and `self.dest_path` are set to the corresponding attribute values.
+
+#### 2. Sets Optional Field When Present (Parametrized)
+- **Description**: When the element's optional attribute is present and resolved, parametrized over `remote_url` (from remotes lookup) and `dest_file` (from `destination_file` attribute).
+- **Expected Outcome**: The corresponding field on the instance equals the expected value for each variant (`remote_url_found`, `dest_file_present`).
+
+#### 3. Sets remote_url to None When remote Attribute Absent
+- **Description**: When the element has no `remote` attribute.
+- **Expected Outcome**: `self.remote_url` is `None`.
+
+#### 4. Sets dest_file to None When destination_file Attribute Absent
+- **Description**: When the element has no `destination_file` attribute.
+- **Expected Outcome**: `self.dest_file` is `None`.
+
+### TestRepoHookTuple
+Tests `_RepoHook.tuple` which returns a `RepoHook` namedtuple.
+
+#### 1. Returns Correct RepoHook Namedtuple
+- **Description**: When all attributes are present and the remote URL is resolved.
+- **Expected Outcome**: `tuple` returns a `RepoHook` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_repo_hook.py
+++ b/edkrepo_manifest_parser/unit_tests/test_repo_hook.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_repo_hook.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+    make_mock_remotes,
+    REMOTE_NAME,
+    REMOTE_URL,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _RepoHook,
+    _parse_repo_hook_required_attribs,
+    RepoHook,
+    REQUIRED_ATTRIB_ERROR_MSG,
+)
+
+ATTRIB_SOURCE               = 'source'
+ATTRIB_DESTINATION          = 'destination'
+ATTRIB_REMOTE               = 'remote'
+ATTRIB_DEST_FILE            = 'destination_file'
+ELEMENT_TAG_CLIENT_GIT_HOOK = 'ClientGitHook'
+HOOK_SOURCE                 = '/scripts/pre-commit.sh'
+DEST_PATH                   = '.git/hooks'
+DEST_FILE                   = 'pre-commit'
+PARAM_MISSING_ATTRIB        = 'missing_attrib'
+PARAM_FIELD_AND_EXPECTED    = 'field_name, expected_value'
+FIELD_REMOTE_URL            = 'remote_url'
+FIELD_DEST_FILE             = 'dest_file'
+ID_SOURCE_ABSENT            = 'source_absent'
+ID_DESTINATION_ABSENT       = 'destination_absent'
+ID_REMOTE_URL_FOUND         = 'remote_url_found'
+ID_DEST_FILE_PRESENT        = 'dest_file_present'
+
+
+class TestRepoHook:
+
+    @pytest.fixture
+    def default_remotes(self):
+        """Return a remotes dict with a single entry using the class-level constants."""
+        return make_mock_remotes()
+
+    @pytest.fixture
+    def full_hook(self, default_remotes):
+        """Return a _RepoHook built from a full-attribute element and the default remotes."""
+        element = make_mock_element({
+            ATTRIB_SOURCE: HOOK_SOURCE,
+            ATTRIB_DESTINATION: DEST_PATH,
+            ATTRIB_REMOTE: REMOTE_NAME,
+            ATTRIB_DEST_FILE: DEST_FILE,
+        }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+        return _RepoHook(element, default_remotes)
+
+    def test_parse_required_attribs_returns_source_and_dest_when_both_present(self):
+        """When source and destination are present, must return (source, dest_path) without raising."""
+        element = make_mock_element({
+            ATTRIB_SOURCE: HOOK_SOURCE,
+            ATTRIB_DESTINATION: DEST_PATH,
+        }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+
+        source, dest_path = _parse_repo_hook_required_attribs(element)
+
+        assert source == HOOK_SOURCE
+        assert dest_path == DEST_PATH
+
+    @pytest.mark.parametrize(PARAM_MISSING_ATTRIB, [
+        pytest.param(ATTRIB_SOURCE, id=ID_SOURCE_ABSENT),
+        pytest.param(ATTRIB_DESTINATION, id=ID_DESTINATION_ABSENT),
+    ])
+    def test_parse_required_attribs_raises_key_error_when_missing(self, missing_attrib):
+        """When any required attribute is absent, must raise KeyError with the required-attrib message."""
+        full = {
+            ATTRIB_SOURCE: HOOK_SOURCE,
+            ATTRIB_DESTINATION: DEST_PATH,
+        }
+        del full[missing_attrib]
+        element = make_mock_element(full, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+        with pytest.raises(KeyError) as exc_info:
+            _parse_repo_hook_required_attribs(element)
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_init_sets_source_and_dest_path(self, full_hook):
+        """When all required attributes are present, __init__ must set self.source and self.dest_path correctly."""
+        assert full_hook.source == HOOK_SOURCE
+        assert full_hook.dest_path == DEST_PATH
+
+    @pytest.mark.parametrize(PARAM_FIELD_AND_EXPECTED, [
+        pytest.param(FIELD_REMOTE_URL, REMOTE_URL, id=ID_REMOTE_URL_FOUND),
+        pytest.param(FIELD_DEST_FILE, DEST_FILE, id=ID_DEST_FILE_PRESENT),
+    ])
+    def test_init_sets_optional_field_when_present(self, full_hook, field_name, expected_value):
+        """When the optional attribute is present and resolved, __init__ must set the corresponding field to its value."""
+        assert getattr(full_hook, field_name) == expected_value
+
+    def test_init_sets_remote_url_to_none_when_remote_absent(self):
+        """When the remote attribute is absent from the element, __init__ must set self.remote_url to None."""
+        element = make_mock_element({
+            ATTRIB_SOURCE: HOOK_SOURCE,
+            ATTRIB_DESTINATION: DEST_PATH,
+        }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+
+        hook = _RepoHook(element, {})
+
+        assert hook.remote_url is None
+
+    def test_init_sets_dest_file_to_none_when_absent(self, default_remotes):
+        """When the destination_file attribute is absent, __init__ must set self.dest_file to None."""
+        element = make_mock_element({
+            ATTRIB_SOURCE: HOOK_SOURCE,
+            ATTRIB_DESTINATION: DEST_PATH,
+            ATTRIB_REMOTE: REMOTE_NAME,
+        }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+
+        hook = _RepoHook(element, default_remotes)
+
+        assert hook.dest_file is None
+
+    def test_tuple_returns_correct_repo_hook_namedtuple(self, full_hook):
+        """The tuple property must return a RepoHook namedtuple with the correct field values."""
+        assert full_hook.tuple == RepoHook(
+            source=HOOK_SOURCE,
+            dest_path=DEST_PATH,
+            dest_file=DEST_FILE,
+            remote_url=REMOTE_URL,
+        )


### PR DESCRIPTION
Extracted the inline required-attribute parsing in _RepoHook.__init__ into a new module-level function _parse_repo_hook_required_attribs, consistent with the pattern established for _RemoteRepo, _Project, _PatchSet, and other private classes. Added docstrings to _RepoHook.__init__ and tuple, and introduced a complete unit test module and test case documentation for _RepoHook.

Changes:
- Extracted _parse_repo_hook_required_attribs from _RepoHook.__init__ in edk_manifest.py
- Added docstrings to _RepoHook.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_repo_hook.py with 9 tests for _RepoHook and _parse_repo_hook_required_attribs
- Added unit_tests/RepoHook_TestCases.md documenting all test cases for _RepoHook

Fixes: #335