### PR TITLE
EdkRepo: Create unit tests for the class _Combination() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1101,14 +1101,12 @@ class _RepoHook():
 
 class _Combination():
     def __init__(self, element):
-        try:
-            self.name = element.attrib['name']
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required and optional attributes from a ``<Combination>`` XML element."""
+        self.name = _parse_combination_required_attribs(element)
         try:
             self.description = element.attrib['description']
         except Exception:
-            self.description = None   # description is optional attribute
+            self.description = None
         try:
             self.archived = (element.attrib['archived'].lower() == 'true')
         except Exception:
@@ -1120,8 +1118,16 @@ class _Combination():
 
     @property
     def tuple(self):
+        """Return a :class:`Combination` namedtuple representation of this combination."""
         return Combination(self.name, self.description, self.venv_enable)
 
+def _parse_combination_required_attribs(element):
+    """Return the ``name`` attribute from a ``<Combination>`` element, or raise ``KeyError`` if absent."""
+    try:
+        name = element.attrib['name']
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return name
 
 class _RepoSource():
     def __init__(self, element, remotes):

--- a/edkrepo_manifest_parser/unit_tests/Combination_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/Combination_TestCases.md
@@ -1,0 +1,79 @@
+# Test Cases for `_Combination` Class
+
+## Test Cases
+
+### TestParseCombinationRequiredAttribs
+Tests `_parse_combination_required_attribs(element)` which validates that the required `name` attribute is present and returns it.
+
+#### 1. Returns name When name Attribute Present
+- **Description**: When the element has a `name` attribute.
+- **Expected Outcome**: Returns the `name` attribute value as a string.
+
+#### 2. Raises KeyError When name Attribute Absent
+- **Description**: When the element has no `name` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
+
+### TestCombinationInit
+Tests `_Combination.__init__` which parses a `<Combination>` XML element for the required `name` and several optional attributes including boolean flags.
+
+#### 1. Sets name From Required Attribute
+- **Description**: When the element has only the required `name` attribute, `self.name` must be set.
+- **Expected Outcome**: `self.name` equals the `name` attribute value.
+
+#### 2. Sets description to None When description Attribute Absent
+- **Description**: When the element has only the required `name` attribute and no `description` attribute.
+- **Expected Outcome**: `self.description` is `None`.
+
+#### 3. Sets description When description Attribute Present
+- **Description**: When the element has a `description` attribute.
+- **Expected Outcome**: `self.description` is set to the `description` attribute value.
+
+#### 4. Sets archived to True When archived Attribute is "true" (lowercase)
+- **Description**: When the element has an `archived` attribute with value `"true"`.
+- **Expected Outcome**: `self.archived` is `True`.
+
+#### 5. Sets archived to False When archived Attribute is "false" (lowercase)
+- **Description**: When the element has an `archived` attribute with value `"false"`.
+- **Expected Outcome**: `self.archived` is `False`.
+
+#### 6. Sets archived to False When archived Attribute is Absent
+- **Description**: When the element has no `archived` attribute.
+- **Expected Outcome**: `self.archived` is `False`.
+
+#### 7. Sets archived to True When archived Attribute is "TRUE" (uppercase)
+- **Description**: When the element has an `archived` attribute with value `"TRUE"`.
+- **Expected Outcome**: `self.archived` is `True`.
+
+#### 8. Sets venv_enable to True When venv_enable Attribute is "true"
+- **Description**: When the element has a `venv_enable` attribute with value `"true"`.
+- **Expected Outcome**: `self.venv_enable` is `True`.
+
+#### 9. Sets venv_enable to False When venv_enable Attribute is "false"
+- **Description**: When the element has a `venv_enable` attribute with value `"false"`.
+- **Expected Outcome**: `self.venv_enable` is `False`.
+
+#### 10. Sets venv_enable to False When venv_enable Attribute is Absent
+- **Description**: When the element has no `venv_enable` attribute.
+- **Expected Outcome**: `self.venv_enable` is `False`.
+
+### TestCombinationTuple
+Tests `_Combination.tuple` which returns a `Combination` namedtuple.
+
+#### 1. Returns Correct Combination Namedtuple
+- **Description**: When all attributes are present.
+- **Expected Outcome**: `tuple` returns a `Combination` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_combination.py
+++ b/edkrepo_manifest_parser/unit_tests/test_combination.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_combination.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _Combination,
+    _parse_combination_required_attribs,
+    Combination,
+    REQUIRED_ATTRIB_ERROR_MSG,
+)
+
+ATTRIB_NAME                     = 'name'
+ATTRIB_DESCRIPTION               = 'description'
+ATTRIB_ARCHIVED                  = 'archived'
+ATTRIB_VENV_ENABLE               = 'venv_enable'
+ATTRIB_BOOL_TRUE                 = 'true'
+ATTRIB_BOOL_FALSE                = 'false'
+ARCHIVED_TRUE_UPPER              = 'TRUE'
+ELEMENT_TAG_COMBINATION          = 'Combination'
+COMBO_NAME                       = 'TestCombo'
+COMBO_DESCRIPTION                = 'A test combination'
+FIELD_NAME                       = 'name'
+FIELD_DESCRIPTION                = 'description'
+PARAM_MINIMAL_FIELD              = 'field_name, expected'
+PARAM_BOOL_FLAG                  = 'attrib_name, attrib_value, field_name, expected'
+ID_NAME_SET                      = 'name_set'
+ID_DESCRIPTION_ABSENT            = 'description_absent'
+ID_ARCHIVED_TRUE_LOWER           = 'archived_true_lower'
+ID_ARCHIVED_FALSE_LOWER          = 'archived_false_lower'
+ID_ARCHIVED_MISSING              = 'archived_missing'
+ID_ARCHIVED_TRUE_UPPER           = 'archived_true_upper'
+ID_VENV_TRUE                     = 'venv_true'
+ID_VENV_FALSE                    = 'venv_false'
+ID_VENV_MISSING                  = 'venv_missing'
+
+
+class TestCombination:
+
+    @staticmethod
+    def _make_required_element():
+        """Build a mock element with only the required name attribute."""
+        return make_mock_element({ATTRIB_NAME: COMBO_NAME}, tag=ELEMENT_TAG_COMBINATION)
+
+    def test_parse_required_attribs_returns_name_when_present(self):
+        """When name is present, _parse_combination_required_attribs must return the name string."""
+        element = self._make_required_element()
+
+        name = _parse_combination_required_attribs(element)
+
+        assert name == COMBO_NAME
+
+    def test_parse_required_attribs_raises_key_error_when_name_missing(self):
+        """When name is absent, _parse_combination_required_attribs must raise KeyError with the required-attrib message."""
+        element = make_mock_element({}, tag=ELEMENT_TAG_COMBINATION)
+
+        with pytest.raises(KeyError) as exc_info:
+            _parse_combination_required_attribs(element)
+
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    @pytest.mark.parametrize(PARAM_MINIMAL_FIELD, [
+        pytest.param(FIELD_NAME,        COMBO_NAME, id=ID_NAME_SET),
+        pytest.param(FIELD_DESCRIPTION, None,       id=ID_DESCRIPTION_ABSENT),
+    ])
+    def test_init_sets_field_on_minimal_element(self, field_name, expected):
+        """On an element with only the required name attribute, each field must equal the expected value after __init__."""
+        combo = _Combination(self._make_required_element())
+        assert getattr(combo, field_name) == expected
+
+    def test_init_sets_description_when_present(self):
+        """When the description attribute is present, __init__ must set self.description to its value."""
+        element = make_mock_element({
+            ATTRIB_NAME: COMBO_NAME,
+            ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
+        }, tag=ELEMENT_TAG_COMBINATION)
+
+        combo = _Combination(element)
+
+        assert combo.description == COMBO_DESCRIPTION
+
+    @pytest.mark.parametrize(PARAM_BOOL_FLAG, [
+        pytest.param(ATTRIB_ARCHIVED,    ATTRIB_BOOL_TRUE,    ATTRIB_ARCHIVED,    True,  id=ID_ARCHIVED_TRUE_LOWER),
+        pytest.param(ATTRIB_ARCHIVED,    ATTRIB_BOOL_FALSE,   ATTRIB_ARCHIVED,    False, id=ID_ARCHIVED_FALSE_LOWER),
+        pytest.param(ATTRIB_ARCHIVED,    None,                ATTRIB_ARCHIVED,    False, id=ID_ARCHIVED_MISSING),
+        pytest.param(ATTRIB_ARCHIVED,    ARCHIVED_TRUE_UPPER, ATTRIB_ARCHIVED,    True,  id=ID_ARCHIVED_TRUE_UPPER),
+        pytest.param(ATTRIB_VENV_ENABLE, ATTRIB_BOOL_TRUE,    ATTRIB_VENV_ENABLE, True,  id=ID_VENV_TRUE),
+        pytest.param(ATTRIB_VENV_ENABLE, ATTRIB_BOOL_FALSE,   ATTRIB_VENV_ENABLE, False, id=ID_VENV_FALSE),
+        pytest.param(ATTRIB_VENV_ENABLE, None,                ATTRIB_VENV_ENABLE, False, id=ID_VENV_MISSING),
+    ])
+    def test_init_sets_bool_flag(self, attrib_name, attrib_value, field_name, expected):
+        """Each combination of attrib_name/attrib_value must produce the expected boolean on the named field."""
+        attrib = {ATTRIB_NAME: COMBO_NAME}
+        if attrib_value is not None:
+            attrib[attrib_name] = attrib_value
+        element = make_mock_element(attrib, tag=ELEMENT_TAG_COMBINATION)
+        combo = _Combination(element)
+        assert getattr(combo, field_name) is expected
+
+    def test_tuple_returns_correct_combination_namedtuple(self):
+        """The tuple property must return a Combination namedtuple with name, description, and venv_enable."""
+        element = make_mock_element({
+            ATTRIB_NAME: COMBO_NAME,
+            ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
+            ATTRIB_VENV_ENABLE: ATTRIB_BOOL_TRUE,
+        }, tag=ELEMENT_TAG_COMBINATION)
+        combo = _Combination(element)
+
+        result = combo.tuple
+
+        assert result == Combination(
+            name=COMBO_NAME,
+            description=COMBO_DESCRIPTION,
+            venv_enable=True,
+        )


### PR DESCRIPTION
Extracted the inline required-attribute parsing in _Combination.__init__ into a new module-level function _parse_combination_required_attribs, consistent with the pattern established for _RemoteRepo, _RepoHook, _Project, _PatchSet, and other private classes. Added docstrings to _Combination.__init__ and tuple, and introduced a complete unit test
module and test case documentation for _Combination.

Changes:
- Extracted _parse_combination_required_attribs from _Combination.__init__ in edk_manifest.py
- Added docstrings to _Combination.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_combination.py with 13 tests for _Combination and _parse_combination_required_attribs
- Added unit_tests/Combination_TestCases.md documenting all test cases for _Combination

Fixes: #336