### PR TITLE
EdkRepo: Create unit tests for the class _RepoSource() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -937,12 +937,12 @@ class ManifestXml(BaseXmlHelper):
                 raise ValueError(PATCHSET_PARENT_CIRCULAR_DEPENDENCY)
             return patch_set_operations
         raise ValueError(PATCHSET_UNKNOWN_ERROR.format(name, self._fileref))
-    
+
 def _validate_repo_local_root_or_raise(repo_local_root):
     """Raise ValueError if repo_local_root has only one path component."""
     if len(os.path.normpath(repo_local_root).split(os.sep)) <= 1:
         raise ValueError(INVALID_REPO_PATH_ERROR.format(repo_local_root))
-        
+
 class _PatchSet():
     def __init__(self, element):
         try:
@@ -1125,12 +1125,8 @@ class _Combination():
 
 class _RepoSource():
     def __init__(self, element, remotes):
-        try:
-            self.root = element.attrib['localRoot']
-            self.remote_name = element.attrib['remote']
-            self.remote_url = remotes[element.attrib['remote']].url
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required and optional attributes from a ``<Source>`` XML element, resolving the remote URL from ``remotes``."""
+        self.root, self.remote_name, self.remote_url = _parse_repo_source_required_attribs(element, remotes)
         try:
             self.branch = element.attrib['branch']
         except Exception:
@@ -1179,7 +1175,7 @@ class _RepoSource():
 
         if self.patch_set is not None and (self.branch is not None or self.commit is not None or self.tag is not None):
             raise ValueError(INVALID_COMBO_DEFINITION_ERROR)
-        
+
         if len(os.path.normpath(self.root).split(os.path.sep)) > 1:
             self.nested_repo = True
         else:
@@ -1187,10 +1183,20 @@ class _RepoSource():
 
     @property
     def tuple(self):
+        """Return a :class:`RepoSource` namedtuple representation of this repository source."""
         return RepoSource(self.root, self.remote_name, self.remote_url, self.branch,
                           self.commit, self.sparse, self.enableSub, self.tag, self.venv_cfg, self.patch_set, self.blobless, self.treeless,
                           self.nested_repo)
 
+def _parse_repo_source_required_attribs(element, remotes):
+    """Return ``(root, remote_name, remote_url)`` from a ``<Source>`` element, or raise ``KeyError`` if any required attribute or remote lookup fails."""
+    try:
+        root = element.attrib['localRoot']
+        remote_name = element.attrib['remote']
+        remote_url = remotes[element.attrib['remote']].url
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return root, remote_name, remote_url
 
 class _SparseSettings():
     def __init__(self, element):

--- a/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
@@ -1,52 +1,168 @@
-# Test Cases for `RepoSource` Class
+# Test Cases for `_RepoSource` Class
 
 ## Test Cases
 
-### 1. Valid Data with Branch, Commit, and Tag
-- **Description**: Tests the initialization of a `RepoSource` object with valid data containing `branch`, `commit`, and `tag` attributes.
-- **Expected Outcome**: The object is initialized successfully, and all attributes are set correctly.
+### TestParseRepoSourceRequiredAttribs
+Tests `_parse_repo_source_required_attribs(element, remotes)` which validates required attributes `localRoot` and `remote`, raising `KeyError` for any missing required data.
 
-### 2. Valid Data with Only Branch
-- **Description**: Tests the initialization of a `RepoSource` object with only the `branch` attribute provided.
-- **Expected Outcome**: The object is initialized successfully, and `branch` is set while `commit` and `tag` are `None`.
+#### 1. Returns root, remote_name, and remote_url When All Required Data Present
+- **Description**: When the element has a `localRoot` attribute and a `remote` attribute that matches a key in the remotes dict.
+- **Expected Outcome**: Returns `(root, remote_name, remote_url)` with correct values.
 
-### 3. Valid Data with Only Commit
-- **Description**: Tests the initialization of a `RepoSource` object with only the `commit` attribute provided.
-- **Expected Outcome**: The object is initialized successfully, and `commit` is set while `branch` and `tag` are `None`.
+#### 2. Raises KeyError When localRoot Attribute Absent
+- **Description**: When the element has no `localRoot` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
 
-### 4. Valid Data with Only Tag
-- **Description**: Tests the initialization of a `RepoSource` object with only the `tag` attribute provided.
-- **Expected Outcome**: The object is initialized successfully, and `tag` is set while `branch` and `commit` are `None`.
+#### 3. Raises KeyError When remote Attribute Absent
+- **Description**: When the element has no `remote` attribute.
+- **Expected Outcome**: Raises `KeyError` whose string representation contains the expected `REQUIRED_ATTRIB_ERROR_MSG` prefix.
 
-### 5. Invalid Data with None of Branch, Commit, or Tag
-- **Description**: Tests the initialization of a `RepoSource` object with none of `branch`, `commit`, or `tag` provided.
-- **Expected Outcome**: A `KeyError` is raised with the message `ATTRIBUTE_MISSING_ERROR`.
+#### 4. Raises KeyError When remote Does Not Match Any Key in Remotes
+- **Description**: When the element has a `remote` attribute that does not correspond to any key in the remotes dict.
+- **Expected Outcome**: Raises `KeyError`.
 
-### 6. Nested Repository (nested_repo = True)
-- **Description**: Tests the initialization of a `RepoSource` object with a `localRoot` path indicating a nested repository.
-- **Expected Outcome**: The `nested_repo` attribute is set to `True`.
+### TestRepoSourceInit
+Tests `_RepoSource.__init__` which parses a `<Source>` XML element including required fields, optional reference fields, boolean flags, and mutual-exclusivity guards.
 
-### 7. Non-Nested Repository (nested_repo = False)
-- **Description**: Tests the initialization of a `RepoSource` object with a `localRoot` path indicating a non-nested repository.
-- **Expected Outcome**: The `nested_repo` attribute is set to `False`.
+#### 1. Sets root and remote_name and remote_url From Required Attributes
+- **Description**: When the element has valid `localRoot` and `remote` attributes with a matching remotes entry.
+- **Expected Outcome**: `self.root`, `self.remote_name`, and `self.remote_url` are set correctly.
 
-### 8. Mutual Exclusivity of PatchSet and Branch/Commit/Tag
-- **Description**: Tests the initialization of a `RepoSource` object to ensure that `patchSet` is mutually exclusive with `branch`, `commit`, and `tag`.
-- **Expected Outcome**: If `patchSet` is provided, `branch`, `commit`, and `tag` must be `None`. If not, an exception is raised.
+#### 2. Sets branch When branch Attribute Present
+- **Description**: When the element has a `branch` attribute.
+- **Expected Outcome**: `self.branch` is set to the `branch` attribute value.
 
-## Notes
-- The `ATTRIBUTE_MISSING_ERROR` string is defined in the `edk_manifest.py` file and is used to validate the presence of at least one of `branch`, `commit`, or `tag`.
+#### 3. Sets branch to None When branch Attribute Absent
+- **Description**: When the element has no `branch` attribute.
+- **Expected Outcome**: `self.branch` is `None`.
+
+#### 4. Sets commit When commit Attribute Present
+- **Description**: When the element has a `commit` attribute.
+- **Expected Outcome**: `self.commit` is set to the `commit` attribute value.
+
+#### 5. Sets tag When tag Attribute Present
+- **Description**: When the element has a `tag` attribute.
+- **Expected Outcome**: `self.tag` is set to the `tag` attribute value.
+
+#### 6. Sets enableSub From Legacy enable_submodule Attribute
+- **Description**: When the element uses the legacy `enable_submodule` attribute (underscore form) with value `"true"`.
+- **Expected Outcome**: `self.enableSub` is `True`.
+
+#### 7. Sets venv_cfg When venv_cfg Attribute Present
+- **Description**: When the element has a `venv_cfg` attribute.
+- **Expected Outcome**: `self.venv_cfg` is set to the `venv_cfg` attribute value.
+
+#### 8. Sets commit to None When commit Attribute Absent
+- **Description**: When the element has no `commit` attribute.
+- **Expected Outcome**: `self.commit` is `None`.
+
+#### 9. Sets tag to None When tag Attribute Absent
+- **Description**: When the element has no `tag` attribute.
+- **Expected Outcome**: `self.tag` is `None`.
+
+#### 10. Sets patch_set to None When patchSet Attribute Absent
+- **Description**: When the element has no `patchSet` attribute.
+- **Expected Outcome**: `self.patch_set` is `None`.
+
+#### 11. Sets venv_cfg to None When venv_cfg Attribute Absent
+- **Description**: When the element has no `venv_cfg` attribute.
+- **Expected Outcome**: `self.venv_cfg` is `None`.
+
+#### 12. Sets patch_set When patchSet Attribute Present
+- **Description**: When the element has a `patchSet` attribute (without branch/commit/tag).
+- **Expected Outcome**: `self.patch_set` is set to the `patchSet` attribute value.
+
+#### 13. Sets sparse to False When sparseCheckout Attribute Absent
+- **Description**: When the element has no `sparseCheckout` attribute.
+- **Expected Outcome**: `self.sparse` is `False`.
+
+#### 14. Sets sparse to True When sparseCheckout Attribute is "true"
+- **Description**: When the element has a `sparseCheckout` attribute with value `"true"`.
+- **Expected Outcome**: `self.sparse` is `True`.
+
+#### 15. Sets sparse to False When sparseCheckout Attribute is "false"
+- **Description**: When the element has a `sparseCheckout` attribute with value `"false"`.
+- **Expected Outcome**: `self.sparse` is `False`.
+
+#### 16. Sets enableSub to False When enableSubmodule Attribute Absent
+- **Description**: When the element has neither `enableSubmodule` nor `enable_submodule` attribute.
+- **Expected Outcome**: `self.enableSub` is `False`.
+
+#### 17. Sets enableSub to True When enableSubmodule Attribute is "true"
+- **Description**: When the element has an `enableSubmodule` attribute with value `"true"`.
+- **Expected Outcome**: `self.enableSub` is `True`.
+
+#### 18. Sets enableSub to False When enableSubmodule Attribute is "false"
+- **Description**: When the element has an `enableSubmodule` attribute with value `"false"`.
+- **Expected Outcome**: `self.enableSub` is `False`.
+
+#### 19. Sets blobless to False When blobless Attribute Absent
+- **Description**: When the element has no `blobless` attribute.
+- **Expected Outcome**: `self.blobless` is `False`.
+
+#### 20. Sets blobless to True When blobless Attribute is "true"
+- **Description**: When the element has a `blobless` attribute with value `"true"`.
+- **Expected Outcome**: `self.blobless` is `True`.
+
+#### 21. Sets blobless to False When blobless Attribute is "false"
+- **Description**: When the element has a `blobless` attribute with value `"false"`.
+- **Expected Outcome**: `self.blobless` is `False`.
+
+#### 22. Sets treeless to False When treeless Attribute Absent
+- **Description**: When the element has no `treeless` attribute.
+- **Expected Outcome**: `self.treeless` is `False`.
+
+#### 23. Sets treeless to True When treeless Attribute is "true"
+- **Description**: When the element has a `treeless` attribute with value `"true"`.
+- **Expected Outcome**: `self.treeless` is `True`.
+
+#### 24. Sets treeless to False When treeless Attribute is "false"
+- **Description**: When the element has a `treeless` attribute with value `"false"`.
+- **Expected Outcome**: `self.treeless` is `False`.
+
+#### 25. Sets nested_repo to True When localRoot Contains a Path Separator
+- **Description**: When the `localRoot` value contains a `/` path separator (nested directory).
+- **Expected Outcome**: `self.nested_repo` is `True`.
+
+#### 26. Sets nested_repo to False When localRoot Is a Simple Name
+- **Description**: When the `localRoot` value is a plain name with no path separator.
+- **Expected Outcome**: `self.nested_repo` is `False`.
+
+#### 27. Raises KeyError When No Reference Attribute Provided
+- **Description**: When the element has no `branch`, `commit`, `tag`, or `patchSet` attribute.
+- **Expected Outcome**: Raises `KeyError` indicating that a reference attribute is required.
+
+#### 28. Raises ValueError When patchSet and branch Are Both Present
+- **Description**: When the element has both a `patchSet` attribute and a `branch` attribute.
+- **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
+
+#### 29. Raises ValueError When patchSet and commit Are Both Present
+- **Description**: When the element has both a `patchSet` attribute and a `commit` attribute.
+- **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
+
+#### 30. Raises ValueError When patchSet and tag Are Both Present
+- **Description**: When the element has both a `patchSet` attribute and a `tag` attribute.
+- **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
+
+### TestRepoSourceTuple
+Tests `_RepoSource.tuple` which returns a `RepoSource` namedtuple.
+
+#### 1. Returns Correct RepoSource Namedtuple
+- **Description**: When all required attributes are present and a `branch` is set.
+- **Expected Outcome**: `tuple` returns a `RepoSource` namedtuple with all fields correctly populated.
+
 
 ## Running the Tests
 
 1. **Required Dependencies**:
    Ensure that the following third-party Python libraries are installed:
    - `pytest`
-   - To generate HTML report output `pytest-html` must be installed.
+   - To generate HTML report output, `pytest-html` must be installed.
 
 2. **Run the Tests**:
-   From the `edkrepo_manifest_parser\unit_tests\` directory run:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
    ```bash
    python3 -m pytest
    ```
-   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.
+   

--- a/edkrepo_manifest_parser/unit_tests/test_repo_source.py
+++ b/edkrepo_manifest_parser/unit_tests/test_repo_source.py
@@ -3,143 +3,294 @@
 ## @file
 # test_repo_source.py
 #
-# Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2025 - 2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
-import pytest
-from collections import namedtuple
 import sys
 import os
+import pytest
 
-# Add the parent directory to the system path to resolve imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element,
+    make_mock_remotes,
+    REMOTE_NAME,
+    REMOTE_URL,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _RepoSource,
+    _parse_repo_source_required_attribs,
+    RepoSource,
+    REQUIRED_ATTRIB_ERROR_MSG,
+    ATTRIBUTE_MISSING_ERROR,
+    INVALID_COMBO_DEFINITION_ERROR,
+)
 
-from edk_manifest import _RepoSource, RepoSource, ATTRIBUTE_MISSING_ERROR
+# XML attribute names
+ATTRIB_LOCAL_ROOT        = 'localRoot'
+ATTRIB_REMOTE            = 'remote'
+ATTRIB_BRANCH            = 'branch'
+ATTRIB_COMMIT            = 'commit'
+ATTRIB_TAG               = 'tag'
+ATTRIB_PATCH_SET         = 'patchSet'
+ATTRIB_SPARSE            = 'sparseCheckout'
+ATTRIB_ENABLE_SUB        = 'enableSubmodule'
+ATTRIB_ENABLE_SUB_LEGACY = 'enable_submodule'
+ATTRIB_VENV_CFG          = 'venv_cfg'
+ATTRIB_BLOBLESS          = 'blobless'
+ATTRIB_TREELESS          = 'treeless'
+ATTRIB_BOOL_TRUE         = 'true'
+ATTRIB_BOOL_FALSE        = 'false'
 
-# Mock classes and data for testing
-class MockElement:
-    def __init__(self, attrib):
-        self.attrib = attrib
+# Element tag
+ELEMENT_TAG_SOURCE       = 'Source'
 
-class MockRemote:
-    def __init__(self, url):
-        self.url = url
+# Test data values
+LOCAL_ROOT               = 'MyRepo'
+NESTED_LOCAL_ROOT        = 'parent/MyRepo'
+BRANCH                   = 'main'
+COMMIT                   = 'abc123'
+TAG                      = 'v1.0.0'
+PATCH_SET                = 'ps-debug'
+VENV_CFG                 = 'venv.cfg'
+FIELD_SPARSE             = 'sparse'
+FIELD_ENABLE_SUB         = 'enableSub'
+FIELD_NESTED_REPO        = 'nested_repo'
+FIELD_COMMIT             = 'commit'
+FIELD_TAG                = 'tag'
+FIELD_PATCH_SET          = 'patch_set'
+FIELD_VENV_CFG           = 'venv_cfg'
+FIELD_BLOBLESS           = 'blobless'
+FIELD_TREELESS           = 'treeless'
+PARAM_BOOL_FIELD         = 'extra, field_name, expected'
+PARAM_PATCH_SET_COMBO    = 'ref_attrib_key, ref_attrib_val'
+PARAM_OPTIONAL_REF       = 'attrib_key, attrib_val, field_name, expected'
+PARAM_PARSE_RAISES       = 'attrib, remotes'
+PARAM_ABSENT_REF         = 'field_name'
+ID_SPARSE_MISSING        = 'sparse_missing'
+ID_SPARSE_TRUE           = 'sparse_true'
+ID_SPARSE_FALSE          = 'sparse_false'
+ID_ENABLE_SUB_MISSING    = 'enable_sub_missing'
+ID_ENABLE_SUB_TRUE       = 'enable_sub_true'
+ID_ENABLE_SUB_FALSE      = 'enable_sub_false'
+ID_BLOBLESS_MISSING      = 'blobless_missing'
+ID_BLOBLESS_TRUE         = 'blobless_true'
+ID_BLOBLESS_FALSE        = 'blobless_false'
+ID_TREELESS_MISSING      = 'treeless_missing'
+ID_TREELESS_TRUE         = 'treeless_true'
+ID_TREELESS_FALSE        = 'treeless_false'
+ID_NESTED_REPO_TRUE      = 'nested_repo_true'
+ID_NESTED_REPO_FALSE     = 'nested_repo_false'
+ID_PATCH_SET_WITH_BRANCH = 'patch_set_with_branch'
+ID_PATCH_SET_WITH_COMMIT = 'patch_set_with_commit'
+ID_PATCH_SET_WITH_TAG    = 'patch_set_with_tag'
+ID_COMMIT_PRESENT        = 'commit_present'
+ID_TAG_PRESENT           = 'tag_present'
+ID_COMMIT_ABSENT         = 'commit_absent'
+ID_TAG_ABSENT            = 'tag_absent'
+ID_PATCH_SET_ABSENT      = 'patch_set_absent'
+ID_LOCAL_ROOT_MISSING        = 'local_root_missing'
+ID_REMOTE_ATTRIB_MISSING     = 'remote_attrib_missing'
+ID_REMOTE_NOT_IN_REMOTES     = 'remote_not_in_remotes'
+ID_ENABLE_SUB_LEGACY_COMPAT  = 'enable_sub_legacy_compat'
+ID_VENV_CFG_PRESENT          = 'venv_cfg_present'
+ID_VENV_CFG_ABSENT           = 'venv_cfg_absent'
 
-def test_repo_source_init_valid_with_branch_commit_tag():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin',
-        'branch': 'main',
-        'commit': 'abc123',
-        'tag': 'v1.0',
-        'sparseCheckout': 'true',
-        'enableSubmodule': 'true',
-        'venv_cfg': 'config.yaml',
-        'blobless': 'false',
-        'treeless': 'true'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
 
-    repo_source = _RepoSource(element, remotes)
+class TestRepoSource:
 
-    assert repo_source.root == 'root_path'
-    assert repo_source.remote_name == 'origin'
-    assert repo_source.remote_url == 'https://example.com/repo.git'
-    assert repo_source.branch == 'main'
-    assert repo_source.commit == 'abc123'
-    assert repo_source.tag == 'v1.0'
-    assert repo_source.patch_set is None
-    assert repo_source.sparse is True
-    assert repo_source.enableSub is True
-    assert repo_source.venv_cfg == 'config.yaml'
-    assert repo_source.blobless is False
-    assert repo_source.treeless is True
+    @staticmethod
+    def _make_single_ref_element(ref_key, ref_val):
+        """Build a mock element with only the required fields (localRoot, remote) and one ref attribute."""
+        return make_mock_element({
+            ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
+            ATTRIB_REMOTE: REMOTE_NAME,
+            ref_key: ref_val,
+        }, tag=ELEMENT_TAG_SOURCE)
 
-def test_repo_source_init_valid_with_only_branch():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin',
-        'branch': 'main'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
+    @pytest.fixture
+    def base_attrib(self):
+        """Return minimum valid attributes dict (mutable - tests can modify as needed)."""
+        return {
+            ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
+            ATTRIB_REMOTE: REMOTE_NAME,
+            ATTRIB_BRANCH: BRANCH,
+        }
 
-    repo_source = _RepoSource(element, remotes)
+    @pytest.fixture
+    def default_remotes(self):
+        """Return a remotes dict with a single entry."""
+        return make_mock_remotes()
 
-    assert repo_source.branch == 'main'
-    assert repo_source.commit is None
-    assert repo_source.tag is None
+    @pytest.fixture
+    def base_source(self, base_attrib, default_remotes):
+        """Return a _RepoSource built from minimum valid attributes."""
+        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        return _RepoSource(element, default_remotes)
 
-def test_repo_source_init_valid_with_only_commit():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin',
-        'commit': 'abc123'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
+    def test_parse_required_attribs_returns_all_three_when_all_present(self, default_remotes):
+        """When all required attributes and the remote key are present, must return (root, remote_name, remote_url)."""
+        element = make_mock_element({
+            ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
+            ATTRIB_REMOTE: REMOTE_NAME,
+        }, tag=ELEMENT_TAG_SOURCE)
 
-    repo_source = _RepoSource(element, remotes)
+        root, remote_name, remote_url = _parse_repo_source_required_attribs(element, default_remotes)
 
-    assert repo_source.branch is None
-    assert repo_source.commit == 'abc123'
-    assert repo_source.tag is None
+        assert root == LOCAL_ROOT
+        assert remote_name == REMOTE_NAME
+        assert remote_url == REMOTE_URL
 
-def test_repo_source_init_valid_with_only_tag():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin',
-        'tag': 'v1.0'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
+    @pytest.mark.parametrize(PARAM_PARSE_RAISES, [
+        pytest.param(
+            {ATTRIB_REMOTE: REMOTE_NAME},
+            make_mock_remotes(),
+            id=ID_LOCAL_ROOT_MISSING,
+        ),
+        pytest.param(
+            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT},
+            make_mock_remotes(),
+            id=ID_REMOTE_ATTRIB_MISSING,
+        ),
+        pytest.param(
+            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT, ATTRIB_REMOTE: REMOTE_NAME},
+            {},
+            id=ID_REMOTE_NOT_IN_REMOTES,
+        ),
+    ])
+    def test_parse_required_attribs_raises_key_error(self, attrib, remotes):
+        """When any required attribute or remote lookup is missing, must raise KeyError with the required-attrib message."""
+        element = make_mock_element(attrib, tag=ELEMENT_TAG_SOURCE)
 
-    repo_source = _RepoSource(element, remotes)
+        with pytest.raises(KeyError) as exc_info:
+            _parse_repo_source_required_attribs(element, remotes)
 
-    assert repo_source.branch is None
-    assert repo_source.commit is None
-    assert repo_source.tag == 'v1.0'
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
-def test_repo_source_init_invalid_data():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
+    def test_init_sets_all_required_fields(self, base_source):
+        """When all required attributes are present, __init__ must set root, remote_name, and remote_url correctly."""
+        assert base_source.root == LOCAL_ROOT
+        assert base_source.remote_name == REMOTE_NAME
+        assert base_source.remote_url == REMOTE_URL
 
-    with pytest.raises(KeyError) as excinfo:
-        _RepoSource(element, remotes)
+    def test_init_sets_branch_when_present(self, base_source):
+        """When the branch attribute is present, __init__ must set self.branch to its value."""
+        assert base_source.branch == BRANCH
 
-    assert str(excinfo.value.args[0]) == ATTRIBUTE_MISSING_ERROR
+    def test_init_sets_branch_to_none_when_absent(self):
+        """When the branch attribute is absent, __init__ must set self.branch to None."""
+        element = self._make_single_ref_element(ATTRIB_COMMIT, COMMIT)
+        assert _RepoSource(element, make_mock_remotes()).branch is None
 
-# Test the tuple property
-def test_repo_source_tuple():
-    element = MockElement({
-        'localRoot': 'root_path',
-        'remote': 'origin',
-        'branch': 'main',
-        'commit': 'abc123',
-        'sparseCheckout': 'true',
-        'enableSubmodule': 'false'
-    })
-    remotes = {'origin': MockRemote('https://example.com/repo.git')}
+    @pytest.mark.parametrize(PARAM_OPTIONAL_REF, [
+        pytest.param(ATTRIB_COMMIT,            COMMIT,           FIELD_COMMIT,     COMMIT,   id=ID_COMMIT_PRESENT),
+        pytest.param(ATTRIB_TAG,               TAG,              FIELD_TAG,        TAG,      id=ID_TAG_PRESENT),
+        pytest.param(ATTRIB_ENABLE_SUB_LEGACY, ATTRIB_BOOL_TRUE, FIELD_ENABLE_SUB, True,     id=ID_ENABLE_SUB_LEGACY_COMPAT),
+        pytest.param(ATTRIB_VENV_CFG,          VENV_CFG,         FIELD_VENV_CFG,   VENV_CFG, id=ID_VENV_CFG_PRESENT),
+    ])
+    def test_init_sets_optional_field_when_present(self, base_attrib, default_remotes, attrib_key, attrib_val, field_name, expected):
+        """When an optional attribute is present, __init__ must set the corresponding field to its value."""
+        base_attrib[attrib_key] = attrib_val
+        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = _RepoSource(element, default_remotes)
+        assert getattr(rs, field_name) == expected
 
-    repo_source = _RepoSource(element, remotes)
-    repo_tuple = repo_source.tuple
+    @pytest.mark.parametrize(PARAM_ABSENT_REF, [
+        pytest.param(FIELD_COMMIT,    id=ID_COMMIT_ABSENT),
+        pytest.param(FIELD_TAG,       id=ID_TAG_ABSENT),
+        pytest.param(FIELD_PATCH_SET, id=ID_PATCH_SET_ABSENT),
+        pytest.param(FIELD_VENV_CFG,  id=ID_VENV_CFG_ABSENT),
+    ])
+    def test_init_sets_optional_field_to_none_when_absent(self, base_source, field_name):
+        """When any optional attribute is absent, __init__ must set the corresponding field to None."""
+        assert getattr(base_source, field_name) is None
 
-    expected_tuple = RepoSource(
-        root='root_path',
-        remote_name='origin',
-        remote_url='https://example.com/repo.git',
-        branch='main',
-        commit='abc123',
-        sparse=True,
-        enable_submodule=False,
-        tag=None,
-        venv_cfg=None,
-        patch_set=None,
-        blobless=False,
-        treeless=False,
-        nested_repo=False
-    )
+    def test_init_sets_patch_set_when_present(self):
+        """When the patchSet attribute is present and no other ref is given, __init__ must set self.patch_set to its value."""
+        element = self._make_single_ref_element(ATTRIB_PATCH_SET, PATCH_SET)
+        assert _RepoSource(element, make_mock_remotes()).patch_set == PATCH_SET
 
-    assert repo_tuple == expected_tuple
+    @pytest.mark.parametrize(PARAM_BOOL_FIELD, [
+        pytest.param({},                                      FIELD_SPARSE,      False, id=ID_SPARSE_MISSING),
+        pytest.param({ATTRIB_SPARSE:      ATTRIB_BOOL_TRUE},  FIELD_SPARSE,      True,  id=ID_SPARSE_TRUE),
+        pytest.param({ATTRIB_SPARSE:      ATTRIB_BOOL_FALSE}, FIELD_SPARSE,      False, id=ID_SPARSE_FALSE),
+        pytest.param({},                                      FIELD_ENABLE_SUB,  False, id=ID_ENABLE_SUB_MISSING),
+        pytest.param({ATTRIB_ENABLE_SUB:  ATTRIB_BOOL_TRUE},  FIELD_ENABLE_SUB,  True,  id=ID_ENABLE_SUB_TRUE),
+        pytest.param({ATTRIB_ENABLE_SUB:  ATTRIB_BOOL_FALSE}, FIELD_ENABLE_SUB,  False, id=ID_ENABLE_SUB_FALSE),
+        pytest.param({},                                      FIELD_BLOBLESS,    False, id=ID_BLOBLESS_MISSING),
+        pytest.param({ATTRIB_BLOBLESS:    ATTRIB_BOOL_TRUE},  FIELD_BLOBLESS,    True,  id=ID_BLOBLESS_TRUE),
+        pytest.param({ATTRIB_BLOBLESS:    ATTRIB_BOOL_FALSE}, FIELD_BLOBLESS,    False, id=ID_BLOBLESS_FALSE),
+        pytest.param({},                                      FIELD_TREELESS,    False, id=ID_TREELESS_MISSING),
+        pytest.param({ATTRIB_TREELESS:    ATTRIB_BOOL_TRUE},  FIELD_TREELESS,    True,  id=ID_TREELESS_TRUE),
+        pytest.param({ATTRIB_TREELESS:    ATTRIB_BOOL_FALSE}, FIELD_TREELESS,    False, id=ID_TREELESS_FALSE),
+        pytest.param({ATTRIB_LOCAL_ROOT:  NESTED_LOCAL_ROOT}, FIELD_NESTED_REPO, True,  id=ID_NESTED_REPO_TRUE),
+        pytest.param({},                                      FIELD_NESTED_REPO, False, id=ID_NESTED_REPO_FALSE),
+    ])
+    def test_init_sets_bool_field(self, base_attrib, extra, field_name, expected):
+        """Each boolean attribute must default to False when absent and map 'true'/'false' to True/False correctly."""
+        base_attrib.update(extra)
+        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = _RepoSource(element, make_mock_remotes())
+        assert getattr(rs, field_name) is expected
+
+    def test_init_raises_key_error_when_no_ref_specified(self):
+        """When none of branch, commit, tag, or patchSet is specified, __init__ must raise KeyError."""
+        element = make_mock_element({ATTRIB_LOCAL_ROOT: LOCAL_ROOT, ATTRIB_REMOTE: REMOTE_NAME}, tag=ELEMENT_TAG_SOURCE)
+
+        with pytest.raises(KeyError) as exc_info:
+            _RepoSource(element, make_mock_remotes())
+
+        assert exc_info.value.args[0] == ATTRIBUTE_MISSING_ERROR
+
+    @pytest.mark.parametrize(PARAM_PATCH_SET_COMBO, [
+        pytest.param(ATTRIB_BRANCH, BRANCH, id=ID_PATCH_SET_WITH_BRANCH),
+        pytest.param(ATTRIB_COMMIT, COMMIT, id=ID_PATCH_SET_WITH_COMMIT),
+        pytest.param(ATTRIB_TAG,    TAG,    id=ID_PATCH_SET_WITH_TAG),
+    ])
+    def test_init_raises_value_error_when_patch_set_combined_with_ref(self, default_remotes, ref_attrib_key, ref_attrib_val):
+        """When patchSet is specified alongside any other ref attribute, __init__ must raise ValueError."""
+        element = make_mock_element({
+            ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
+            ATTRIB_REMOTE: REMOTE_NAME,
+            ATTRIB_PATCH_SET: PATCH_SET,
+            ref_attrib_key: ref_attrib_val,
+        }, tag=ELEMENT_TAG_SOURCE)
+
+        with pytest.raises(ValueError) as exc_info:
+            _RepoSource(element, default_remotes)
+
+        assert str(exc_info.value) == INVALID_COMBO_DEFINITION_ERROR
+
+    def test_tuple_returns_correct_repo_source_namedtuple(self, base_attrib, default_remotes):
+        """The tuple property must return a RepoSource namedtuple with all field values correct."""
+        base_attrib.update({
+            ATTRIB_COMMIT:     COMMIT,
+            ATTRIB_SPARSE:     ATTRIB_BOOL_TRUE,
+            ATTRIB_ENABLE_SUB: ATTRIB_BOOL_FALSE,
+            ATTRIB_VENV_CFG:   VENV_CFG,
+            ATTRIB_BLOBLESS:   ATTRIB_BOOL_FALSE,
+            ATTRIB_TREELESS:   ATTRIB_BOOL_FALSE,
+        })
+        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = _RepoSource(element, default_remotes)
+
+        result = rs.tuple
+
+        assert result == RepoSource(
+            root=LOCAL_ROOT,
+            remote_name=REMOTE_NAME,
+            remote_url=REMOTE_URL,
+            branch=BRANCH,
+            commit=COMMIT,
+            sparse=True,
+            enable_submodule=False,
+            tag=None,
+            venv_cfg=VENV_CFG,
+            patch_set=None,
+            blobless=False,
+            treeless=False,
+            nested_repo=False,
+        )
 


### PR DESCRIPTION
Extracted the inline required-attribute parsing in _RepoSource.__init__ into a new module-level function _parse_repo_source_required_attribs, consistent with the pattern established for _RemoteRepo, _RepoHook, _Combination, and other private classes. Added docstrings to _RepoSource.__init__ and tuple. Rewrote the legacy test module with a
comprehensive class-based test suite and expanded the test case documentation to match.

Changes:
- Extracted _parse_repo_source_required_attribs from _RepoSource.__init__ in edk_manifest.py
- Added docstrings to _RepoSource.__init__ and tuple in edk_manifest.py
- Rewrote unit_tests/test_repo_source.py with 35 tests covering _RepoSource and _parse_repo_source_required_attribs
- Expanded unit_tests/RepoSource_TestCases.md from 8 legacy cases to 35 documented test cases
- Removed trailing whitespace from blank lines in edk_manifest.py

Fixes: #337