### PR TITLE
EdkRepo: Create unit tests for the class _SparseSettings() and modularize its existing methods if needed 

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1194,6 +1194,7 @@ class _RepoSource():
 
 class _SparseSettings():
     def __init__(self, element):
+        """Parse optional sparseByDefault attribute from a ``<SparseSettings>`` element; defaults to ``False``."""
         self.sparse_by_default = False
         try:
             self.sparse_by_default = (element.attrib['sparseByDefault'].lower() == 'true')
@@ -1202,6 +1203,7 @@ class _SparseSettings():
 
     @property
     def tuple(self):
+        """Return a :class:`SparseSettings` namedtuple representation of this sparse settings."""
         return SparseSettings(self.sparse_by_default)
 
 

--- a/edkrepo_manifest_parser/unit_tests/SparseSettings_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/SparseSettings_TestCases.md
@@ -1,0 +1,40 @@
+# Test Cases for the `_SparseSettings` Class
+
+## Test Cases
+
+### TestSparseSettingsInit
+Tests `_SparseSettings.__init__` which parses the optional `sparseByDefault` attribute from a `<SparseSettings>` element, defaulting to `False` when absent.
+
+#### 1. Sets sparse_by_default to False When sparseByDefault Absent
+- **Description**: When the `sparseByDefault` attribute is absent.
+- **Expected Outcome**: `self.sparse_by_default` is `False`.
+
+#### 2. Sets sparse_by_default to True When sparseByDefault is "true"
+- **Description**: When the `sparseByDefault` attribute is `"true"`.
+- **Expected Outcome**: `self.sparse_by_default` is `True`.
+
+#### 3. Sets sparse_by_default to False When sparseByDefault is "false"
+- **Description**: When the `sparseByDefault` attribute is `"false"`.
+- **Expected Outcome**: `self.sparse_by_default` is `False`.
+
+### TestSparseSettingsTuple
+Tests `_SparseSettings.tuple` which returns a `SparseSettings` namedtuple.
+
+#### 1. Returns Correct SparseSettings Namedtuple
+- **Description**: When `sparseByDefault` is `"true"`.
+- **Expected Outcome**: `tuple` returns `SparseSettings(sparse_by_default=True)`.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_sparse_settings.py
+++ b/edkrepo_manifest_parser/unit_tests/test_sparse_settings.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_sparse_settings.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_iter,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _SparseSettings,
+    SparseSettings,
+)
+
+ATTRIB_SPARSE_BY_DEFAULT        = 'sparseByDefault'
+ATTRIB_BOOL_TRUE                = 'true'
+ATTRIB_BOOL_FALSE               = 'false'
+PARAM_SPARSE_BY_DEFAULT         = 'attrib, expected'
+ID_SPARSE_BY_DEFAULT_ABSENT     = 'sparse_by_default_absent'
+ID_SPARSE_BY_DEFAULT_TRUE       = 'sparse_by_default_true'
+ID_SPARSE_BY_DEFAULT_FALSE      = 'sparse_by_default_false'
+
+
+class TestSparseSettings:
+
+    @pytest.mark.parametrize(PARAM_SPARSE_BY_DEFAULT, [
+        pytest.param({},                                              False, id=ID_SPARSE_BY_DEFAULT_ABSENT),
+        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_TRUE},  True,  id=ID_SPARSE_BY_DEFAULT_TRUE),
+        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_FALSE}, False, id=ID_SPARSE_BY_DEFAULT_FALSE),
+    ])
+    def test_init_sets_sparse_by_default(self, attrib, expected):
+        """When sparseByDefault is absent, 'true', or 'false', __init__ must set self.sparse_by_default correctly."""
+        element = make_mock_element_with_iter(attrib)
+        assert _SparseSettings(element).sparse_by_default is expected
+
+    def test_tuple_returns_correct_sparse_settings_namedtuple(self):
+        """The tuple property must return a SparseSettings namedtuple with the correct sparse_by_default value."""
+        element = make_mock_element_with_iter({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_TRUE})
+        ss = _SparseSettings(element)
+
+        assert ss.tuple == SparseSettings(sparse_by_default=True)


### PR DESCRIPTION
Added docstrings to _SparseSettings.__init__ and tuple. Added a
complete unit test module and test case documentation for _SparseSettings,
covering the optional sparseByDefault boolean attribute (present and
absent) and the tuple property.

Changes:
- Added docstrings to _SparseSettings.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_sparse_settings.py with 4 tests for _SparseSettings
- Added unit_tests/SparseSettings_TestCases.md documenting all test cases for _SparseSettings

Fixes: #338