### PR TITLE
Edkrepo: Create unit tests for the class _SparseData() and modularize its existing methods if needed 

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1207,6 +1207,7 @@ class _SparseSettings():
 
 class _SparseData():
     def __init__(self, element):
+        """Parse optional attributes and AlwaysInclude/AlwaysExclude children from a ``<SparseData>`` element."""
         self.combination = None
         self.remote_name = None
         self.always_include = []
@@ -1226,6 +1227,7 @@ class _SparseData():
 
     @property
     def tuple(self):
+        """Return a :class:`SparseData` namedtuple representation of this sparse data."""
         return SparseData(self.combination, self.remote_name, self.always_include, self.always_exclude)
 
 

--- a/edkrepo_manifest_parser/unit_tests/SparseData_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/SparseData_TestCases.md
@@ -1,0 +1,56 @@
+# Test Cases for the `_SparseData` Class
+
+## Test Cases
+
+### TestSparseDataInit
+Tests `_SparseData.__init__` which parses optional attributes and iterates `AlwaysInclude` / `AlwaysExclude` children from a `<SparseData>` element.
+
+#### 1. All Fields Default When All Attributes and Children Absent
+- **Description**: When all optional attributes (`combination`, `remote`) and all child elements (`AlwaysInclude`, `AlwaysExclude`) are absent.
+- **Expected Outcome**: `self.combination` is `None`, `self.remote_name` is `None`, `self.always_include` is `[]`, and `self.always_exclude` is `[]`.
+
+#### 2. Sets combination When combination Attribute Present
+- **Description**: When the `combination` attribute is present.
+- **Expected Outcome**: `self.combination` equals the attribute value.
+
+#### 3. Sets remote_name When remote Attribute Present
+- **Description**: When the `remote` attribute is present.
+- **Expected Outcome**: `self.remote_name` equals the attribute value.
+
+#### 4. Populates always_include From Single AlwaysInclude Child
+- **Description**: When one `AlwaysInclude` child is present with a single path.
+- **Expected Outcome**: `self.always_include` contains that path as its sole entry.
+
+#### 5. Populates always_exclude From Single AlwaysExclude Child
+- **Description**: When one `AlwaysExclude` child is present with a single path.
+- **Expected Outcome**: `self.always_exclude` contains that path as its sole entry.
+
+#### 6. Splits Pipe-Separated Values for always_include
+- **Description**: When an `AlwaysInclude` child contains multiple paths separated by `|`.
+- **Expected Outcome**: Each path is added as a separate entry in `self.always_include`.
+
+#### 7. Splits Pipe-Separated Values for always_exclude
+- **Description**: When an `AlwaysExclude` child contains multiple paths separated by `|`.
+- **Expected Outcome**: Each path is added as a separate entry in `self.always_exclude`.
+
+### TestSparseDataTuple
+Tests `_SparseData.tuple` which returns a `SparseData` namedtuple.
+
+#### 1. Returns Correct SparseData Namedtuple
+- **Description**: When all optional fields and both include/exclude children are present.
+- **Expected Outcome**: `tuple` returns a `SparseData` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_sparse_data.py
+++ b/edkrepo_manifest_parser/unit_tests/test_sparse_data.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_sparse_data.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_iter,
+    make_text_element,
+    make_empty_element,
+    REMOTE_NAME,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _SparseData,
+    SparseData,
+)
+
+ATTRIB_COMBINATION          = 'combination'
+ATTRIB_REMOTE               = 'remote'
+TAG_ALWAYS_INCLUDE          = 'AlwaysInclude'
+TAG_ALWAYS_EXCLUDE          = 'AlwaysExclude'
+COMBINATION                 = 'mycombo'
+INCLUDE_VALUE               = 'path/to/include'
+EXCLUDE_VALUE               = 'path/to/exclude'
+INCLUDE_MULTI               = 'path/a|path/b'
+EXCLUDE_MULTI               = 'path/c|path/d'
+PIPE_SEPARATOR              = '|'
+FIELD_COMBINATION           = 'combination'
+FIELD_REMOTE_NAME           = 'remote_name'
+FIELD_ALWAYS_INCLUDE        = 'always_include'
+FIELD_ALWAYS_EXCLUDE        = 'always_exclude'
+PARAM_OPTIONAL_ATTRIB       = 'attrib_key, attrib_val, field_name, expected'
+PARAM_LIST_FIELD            = 'tag, text_value, field_name, expected'
+ID_COMBINATION_PRESENT      = 'combination_present'
+ID_REMOTE_NAME_PRESENT      = 'remote_name_present'
+ID_ALWAYS_INCLUDE           = 'always_include'
+ID_ALWAYS_EXCLUDE           = 'always_exclude'
+ID_ALWAYS_INCLUDE_SPLIT     = 'always_include_split'
+ID_ALWAYS_EXCLUDE_SPLIT     = 'always_exclude_split'
+
+
+class TestSparseData:
+
+    @staticmethod
+    def _assert_child_list_field(tag, text_value, field_name, expected):
+        """Build a _SparseData element with one child under tag and assert the named list field equals expected."""
+        child = make_text_element(text_value)
+        element = make_mock_element_with_iter({}, {tag: [child]})
+        sd = _SparseData(element)
+        assert getattr(sd, field_name) == expected
+
+    def test_all_fields_default_when_absent(self):
+        """When all optional attributes and child elements are absent, __init__ must apply all defaults."""
+        sd = _SparseData(make_empty_element())
+
+        assert sd.combination is None
+        assert sd.remote_name is None
+        assert sd.always_include == []
+        assert sd.always_exclude == []
+
+    @pytest.mark.parametrize(PARAM_OPTIONAL_ATTRIB, [
+        pytest.param(ATTRIB_COMBINATION, COMBINATION, FIELD_COMBINATION, COMBINATION, id=ID_COMBINATION_PRESENT),
+        pytest.param(ATTRIB_REMOTE,      REMOTE_NAME, FIELD_REMOTE_NAME, REMOTE_NAME, id=ID_REMOTE_NAME_PRESENT),
+    ])
+    def test_init_sets_optional_attrib_when_present(self, attrib_key, attrib_val, field_name, expected):
+        """When an optional attribute is present, __init__ must set the corresponding field to its value."""
+        element = make_mock_element_with_iter({attrib_key: attrib_val})
+        sd = _SparseData(element)
+        assert getattr(sd, field_name) == expected
+
+    @pytest.mark.parametrize(PARAM_LIST_FIELD, [
+        pytest.param(TAG_ALWAYS_INCLUDE, INCLUDE_VALUE, FIELD_ALWAYS_INCLUDE, [INCLUDE_VALUE], id=ID_ALWAYS_INCLUDE),
+        pytest.param(TAG_ALWAYS_EXCLUDE, EXCLUDE_VALUE, FIELD_ALWAYS_EXCLUDE, [EXCLUDE_VALUE], id=ID_ALWAYS_EXCLUDE),
+    ])
+    def test_init_populates_list_field_from_single_child(self, tag, text_value, field_name, expected):
+        """When one child element is present, __init__ must append its text to the corresponding list field."""
+        self._assert_child_list_field(tag, text_value, field_name, expected)
+
+    @pytest.mark.parametrize(PARAM_LIST_FIELD, [
+        pytest.param(TAG_ALWAYS_INCLUDE, INCLUDE_MULTI, FIELD_ALWAYS_INCLUDE, INCLUDE_MULTI.split(PIPE_SEPARATOR), id=ID_ALWAYS_INCLUDE_SPLIT),
+        pytest.param(TAG_ALWAYS_EXCLUDE, EXCLUDE_MULTI, FIELD_ALWAYS_EXCLUDE, EXCLUDE_MULTI.split(PIPE_SEPARATOR), id=ID_ALWAYS_EXCLUDE_SPLIT),
+    ])
+    def test_init_splits_pipe_separated_values(self, tag, text_value, field_name, expected):
+        """When a child element contains pipe-separated paths, __init__ must add each path as a separate entry."""
+        self._assert_child_list_field(tag, text_value, field_name, expected)
+
+    def test_tuple_returns_correct_sparse_data_namedtuple(self):
+        """The tuple property must return a SparseData namedtuple with all field values correct."""
+        include_elem = make_text_element(INCLUDE_VALUE)
+        exclude_elem = make_text_element(EXCLUDE_VALUE)
+        element = make_mock_element_with_iter(
+            {ATTRIB_COMBINATION: COMBINATION, ATTRIB_REMOTE: REMOTE_NAME},
+            {TAG_ALWAYS_INCLUDE: [include_elem], TAG_ALWAYS_EXCLUDE: [exclude_elem]},
+        )
+        result = _SparseData(element).tuple
+
+        assert result == SparseData(
+            combination=COMBINATION,
+            remote_name=REMOTE_NAME,
+            always_include=[INCLUDE_VALUE],
+            always_exclude=[EXCLUDE_VALUE],
+        )
+


### PR DESCRIPTION
Added docstrings to _SparseData.__init__ and tuple. Added a completeunit test module and test case documentation for _SparseData, covering all optional attributes (combination, remote_name), AlwaysInclude and AlwaysExclude child element parsing including pipe-separated values, and the tuple property.

Changes:
- Added docstrings to _SparseData.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_sparse_data.py with 7 tests for _SparseData
- Added unit_tests/SparseData_TestCases.md documenting all test cases for _SparseData

Fixes: #339