### PR TITLE
Edkrepo: Create unit tests for the class _FolderToFolderMappingFolderExclude() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1231,6 +1231,7 @@ class _SparseData():
 
 class _FolderToFolderMappingFolderExclude():
     def __init__(self, element):
+        """Parse optional path attribute from a ``<Exclude>`` element; defaults to ``None``."""
         self.path = None
         try:
             self.path = element.attrib['path']
@@ -1239,6 +1240,7 @@ class _FolderToFolderMappingFolderExclude():
 
     @property
     def tuple(self):
+        """Return a :class:`FolderToFolderMappingFolderExclude` namedtuple representation of this exclude entry."""
         return FolderToFolderMappingFolderExclude(self.path)
 
 

--- a/edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolderExclude_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolderExclude_TestCases.md
@@ -1,0 +1,36 @@
+# Test Cases for the `_FolderToFolderMappingFolderExclude` Class
+
+## Test Cases
+
+### TestFolderToFolderMappingFolderExcludeInit
+Tests `_FolderToFolderMappingFolderExclude.__init__` which parses the optional `path` attribute from an `<Exclude>` element.
+
+#### 1. path Defaults to None When Absent
+- **Description**: When the `path` attribute is absent.
+- **Expected Outcome**: `self.path` is `None`.
+
+#### 2. path Set When Present
+- **Description**: When the `path` attribute is present.
+- **Expected Outcome**: `self.path` equals the attribute value.
+
+### TestFolderToFolderMappingFolderExcludeTuple
+Tests `_FolderToFolderMappingFolderExclude.tuple` which returns a `FolderToFolderMappingFolderExclude` namedtuple.
+
+#### 1. Returns Correct FolderToFolderMappingFolderExclude Namedtuple
+- **Description**: When the `path` attribute is present.
+- **Expected Outcome**: `tuple` returns `FolderToFolderMappingFolderExclude(path=<value>)`.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder_exclude.py
+++ b/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder_exclude.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_folder_to_folder_mapping_folder_exclude.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_iter,
+    make_empty_element,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _FolderToFolderMappingFolderExclude,
+    FolderToFolderMappingFolderExclude,
+)
+
+ATTRIB_PATH  = 'path'
+EXCLUDE_PATH = 'exclude/some/path'
+
+
+class TestFolderToFolderMappingFolderExclude:
+
+    @pytest.fixture
+    def full_folder_exclude(self):
+        """Return a _FolderToFolderMappingFolderExclude built from an element with EXCLUDE_PATH set."""
+        element = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
+        return _FolderToFolderMappingFolderExclude(element)
+
+    def test_path_defaults_to_none_when_absent(self):
+        """When the path attribute is absent, __init__ must set self.path to None."""
+        exc = _FolderToFolderMappingFolderExclude(make_empty_element())
+
+        assert exc.path is None
+
+    def test_path_when_present(self, full_folder_exclude):
+        """When the path attribute is present, __init__ must set self.path to its value."""
+        assert full_folder_exclude.path == EXCLUDE_PATH
+
+    def test_tuple_returns_correct_folder_to_folder_mapping_folder_exclude_namedtuple(self, full_folder_exclude):
+        """The tuple property must return a FolderToFolderMappingFolderExclude namedtuple with the correct path."""
+        assert full_folder_exclude.tuple == FolderToFolderMappingFolderExclude(path=EXCLUDE_PATH)
+


### PR DESCRIPTION
Added docstrings to _FolderToFolderMappingFolderExclude.__init__ and
tuple. Added a complete unit test module and test case documentation for
_FolderToFolderMappingFolderExclude, covering the optional path attribute
(present and absent) and the tuple property.

Changes:
- Added docstrings to _FolderToFolderMappingFolderExclude.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_folder_to_folder_mapping_folder_exclude.py with 3 tests for _FolderToFolderMappingFolderExclude
- Added unit_tests/FolderToFolderMappingFolderExclude_TestCases.md documenting all test cases for _FolderToFolderMappingFolderExclude

Fixes: #340