### PR TITLE
Edkrepo: Create unit tests for the class _FolderToFolderMappingFolder() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1244,6 +1244,7 @@ class _FolderToFolderMappingFolderExclude():
 
 class _FolderToFolderMappingFolder():
     def __init__(self, element):
+        """Parse optional folder attributes and Exclude children from a ``<Folder>`` or ``<File>`` element."""
         self.project1_folder = None
         self.project2_folder = None
         self.excludes = []
@@ -1260,6 +1261,7 @@ class _FolderToFolderMappingFolder():
 
     @property
     def tuple(self):
+        """Return a :class:`FolderToFolderMappingFolder` namedtuple representation of this folder entry."""
         return FolderToFolderMappingFolder(self.project1_folder, self.project2_folder, self.excludes)
 
 

--- a/edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolder_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolder_TestCases.md
@@ -1,0 +1,45 @@
+# Test Cases for the `_FolderToFolderMappingFolder` Class
+
+## Test Cases
+
+### TestFolderToFolderMappingFolderInit
+Tests `_FolderToFolderMappingFolder.__init__` which parses optional `project1`/`project2` attributes and builds an excludes list from `<Exclude>` children.
+
+#### 1. All Fields Default When All Attributes and Children Absent
+- **Description**: When all optional attributes (`project1`, `project2`) and `<Exclude>` child elements are absent.
+- **Expected Outcome**: `self.project1_folder` is `None`, `self.project2_folder` is `None`, and `self.excludes` is `[]`.
+
+#### 2. Sets project1_folder When project1 Attribute Present
+- **Description**: When the `project1` attribute is present.
+- **Expected Outcome**: `self.project1_folder` equals the attribute value.
+
+#### 3. Sets project2_folder When project2 Attribute Present
+- **Description**: When the `project2` attribute is present.
+- **Expected Outcome**: `self.project2_folder` equals the attribute value.
+
+#### 4. Populates excludes From Exclude Children
+- **Description**: When one `<Exclude>` child is present.
+- **Expected Outcome**: `self.excludes` contains one `_FolderToFolderMappingFolderExclude` with the correct path.
+
+### TestFolderToFolderMappingFolderTuple
+Tests `_FolderToFolderMappingFolder.tuple` which returns a `FolderToFolderMappingFolder` namedtuple.
+
+#### 1. Returns Correct FolderToFolderMappingFolder Namedtuple
+- **Description**: When both project folder attributes and one Exclude child are present.
+- **Expected Outcome**: `tuple` returns a `FolderToFolderMappingFolder` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.
+

--- a/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder.py
+++ b/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_folder_to_folder_mapping_folder.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_iter,
+    make_empty_element,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _FolderToFolderMappingFolder,
+)
+
+ATTRIB_PATH                 = 'path'
+ATTRIB_PROJECT1             = 'project1'
+ATTRIB_PROJECT2             = 'project2'
+TAG_EXCLUDE                 = 'Exclude'
+FIELD_PROJECT1_FOLDER       = 'project1_folder'
+FIELD_PROJECT2_FOLDER       = 'project2_folder'
+PROJECT1_FOLDER             = 'project1/path'
+PROJECT2_FOLDER             = 'project2/path'
+EXCLUDE_PATH                = 'exclude/some/path'
+PARAM_PROJECT_FOLDER        = 'attrib_key, attrib_value, field_name'
+ID_PROJECT1_FOLDER_PRESENT  = 'project1_folder_present'
+ID_PROJECT2_FOLDER_PRESENT  = 'project2_folder_present'
+
+
+class TestFolderToFolderMappingFolder:
+
+    def test_all_fields_default_when_absent(self):
+        """When all optional attributes and child elements are absent, __init__ must apply all defaults."""
+        folder = _FolderToFolderMappingFolder(make_empty_element())
+
+        assert folder.project1_folder is None
+        assert folder.project2_folder is None
+        assert folder.excludes == []
+
+    @pytest.mark.parametrize(PARAM_PROJECT_FOLDER, [
+        pytest.param(ATTRIB_PROJECT1, PROJECT1_FOLDER, FIELD_PROJECT1_FOLDER, id=ID_PROJECT1_FOLDER_PRESENT),
+        pytest.param(ATTRIB_PROJECT2, PROJECT2_FOLDER, FIELD_PROJECT2_FOLDER, id=ID_PROJECT2_FOLDER_PRESENT),
+    ])
+    def test_init_sets_project_folder_when_present(self, attrib_key, attrib_value, field_name):
+        """When a project folder attribute is present, __init__ must set the corresponding field to its value."""
+        element = make_mock_element_with_iter(
+            {attrib_key: attrib_value},
+            {TAG_EXCLUDE: []},
+        )
+        folder = _FolderToFolderMappingFolder(element)
+        assert getattr(folder, field_name) == attrib_value
+
+    def test_init_populates_excludes_from_exclude_children(self):
+        """When Exclude children are present, __init__ must create a _FolderToFolderMappingFolderExclude for each."""
+        exclude_elem = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
+        element = make_mock_element_with_iter({}, {TAG_EXCLUDE: [exclude_elem]})
+        folder = _FolderToFolderMappingFolder(element)
+
+        assert len(folder.excludes) == 1
+        assert folder.excludes[0].path == EXCLUDE_PATH
+
+    def test_tuple_returns_correct_folder_to_folder_mapping_folder_namedtuple(self):
+        """The tuple property must return a FolderToFolderMappingFolder namedtuple with all field values correct."""
+        exclude_elem = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
+        element = make_mock_element_with_iter(
+            {ATTRIB_PROJECT1: PROJECT1_FOLDER, ATTRIB_PROJECT2: PROJECT2_FOLDER},
+            {TAG_EXCLUDE: [exclude_elem]},
+        )
+        result = _FolderToFolderMappingFolder(element).tuple
+
+        assert result.project1_folder == PROJECT1_FOLDER
+        assert result.project2_folder == PROJECT2_FOLDER
+        assert len(result.excludes) == 1
+        assert result.excludes[0].path == EXCLUDE_PATH
+


### PR DESCRIPTION
Added docstrings to _FolderToFolderMappingFolder.__init__ and tuple. Added a complete unit test module and test case documentation for _FolderToFolderMappingFolder, covering the optional project1/project2 folder attributes (present and absent), Exclude child element parsing, and the tuple property.

Changes:
- Added docstrings to _FolderToFolderMappingFolder.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_folder_to_folder_mapping_folder.py with 5 tests for _FolderToFolderMappingFolder
- Added unit_tests/FolderToFolderMappingFolder_TestCases.md documenting all test cases for _FolderToFolderMappingFolder

Fixes: #341 