### PR TITLE
Edkrepo: Create unit tests for the class _SubmoduleAlternateRemote() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1290,23 +1290,27 @@ class _FolderToFolderMapping():
     def tuple(self):
         return FolderToFolderMapping(self.project1, self.project2, self.remote_name, self.folders)
 
-
 class _SubmoduleAlternateRemote():
     def __init__(self, element, remotes):
-        try:
-            self.remote_name = element.attrib['remote']
-            self.originalUrl = element.attrib['originalUrl']
-            self.altUrl = element.text
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
-
-        if self.remote_name not in remotes:
-            raise KeyError(NO_REMOTE_EXISTS_WITH_NAME.format(self.remote_name))
+        """Parse required attributes and validate the remote from a ``<SubmoduleAlternateRemote>`` element."""
+        self.remote_name, self.originalUrl, self.altUrl = _parse_submodule_alternate_remote_attribs(element, remotes)
 
     @property
     def tuple(self):
+        """Return a :class:`SubmoduleAlternateRemote` namedtuple representation."""
         return SubmoduleAlternateRemote(self.remote_name, self.originalUrl, self.altUrl)
 
+def _parse_submodule_alternate_remote_attribs(element, remotes):
+    """Return ``(remote_name, original_url, alt_url)`` or raise ``KeyError`` if any required attribute is missing or the remote name is not in ``remotes``."""
+    try:
+        remote_name = element.attrib['remote']
+        original_url = element.attrib['originalUrl']
+        alt_url = element.text
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    if remote_name not in remotes:
+        raise KeyError(NO_REMOTE_EXISTS_WITH_NAME.format(remote_name))
+    return remote_name, original_url, alt_url
 
 class _SubmoduleInitEntry():
     def __init__(self, element):

--- a/edkrepo_manifest_parser/unit_tests/SubmoduleAlternateRemote_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/SubmoduleAlternateRemote_TestCases.md
@@ -1,0 +1,51 @@
+# Test Cases for the `_SubmoduleAlternateRemote` Class
+
+## Test Cases
+
+### TestParseSubmoduleAlternateRemoteAttribs
+Tests `_parse_submodule_alternate_remote_attribs` which returns `(remote_name, original_url, alt_url)` or raises `KeyError` if any required attribute is missing or the remote name is not in `remotes`.
+
+#### 1. Returns All Fields When All Present
+- **Description**: When all required attributes (`remote`, `originalUrl`) are present and the remote name is a key in the remotes dict.
+- **Expected Outcome**: Returns a tuple of `(remote_name, original_url, alt_url)` with the correct values.
+
+#### 2. Raises When remote Missing
+- **Description**: When the `remote` attribute is absent from the element.
+- **Expected Outcome**: Raises `KeyError` whose message contains the required-attribute error prefix.
+
+#### 3. Raises When originalUrl Missing
+- **Description**: When the `originalUrl` attribute is absent from the element.
+- **Expected Outcome**: Raises `KeyError` whose message contains the required-attribute error prefix.
+
+#### 4. Raises When Remote Not in Remotes
+- **Description**: When the `remote` attribute value is not a key in the remotes dict.
+- **Expected Outcome**: Raises `KeyError` whose message contains the no-remote-exists error prefix.
+
+### TestSubmoduleAlternateRemoteInit
+Tests `_SubmoduleAlternateRemote.__init__` which parses required attributes and validates the remote from a `<SubmoduleAlternateRemote>` element.
+
+#### 1. Sets All Fields
+- **Description**: When all required attributes are valid and the remote is present in the remotes dict.
+- **Expected Outcome**: `self.remote_name`, `self.originalUrl`, and `self.altUrl` are set to the correct values.
+
+### TestSubmoduleAlternateRemoteTuple
+Tests `_SubmoduleAlternateRemote.tuple` which returns a `SubmoduleAlternateRemote` namedtuple.
+
+#### 1. Returns Correct SubmoduleAlternateRemote Namedtuple
+- **Description**: When the object has been fully initialized with valid attributes.
+- **Expected Outcome**: `tuple` returns a `SubmoduleAlternateRemote` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_submodule_alternate_remote.py
+++ b/edkrepo_manifest_parser/unit_tests/test_submodule_alternate_remote.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_submodule_alternate_remote.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_text,
+    make_mock_remotes,
+    REMOTE_NAME,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _SubmoduleAlternateRemote,
+    _parse_submodule_alternate_remote_attribs,
+    SubmoduleAlternateRemote,
+    REQUIRED_ATTRIB_ERROR_MSG,
+    NO_REMOTE_EXISTS_WITH_NAME,
+)
+
+ATTRIB_REMOTE               = 'remote'
+ATTRIB_ORIGINAL_URL         = 'originalUrl'
+ELEMENT_TAG_SUBMODULE_ALT   = 'SubmoduleAlternateRemote'
+ORIGINAL_URL                = 'https://original.example.com/repo.git'
+ALT_URL                     = 'https://alt.example.com/repo.git'
+FIELD_REMOTE_NAME           = 'remote_name'
+FIELD_ORIGINAL_URL          = 'originalUrl'
+FIELD_ALT_URL               = 'altUrl'
+NO_REMOTE_SPLIT_CHAR        = '{'
+PARAM_PARSE_RAISES          = 'attrib'
+ID_REMOTE_MISSING           = 'remote_missing'
+ID_ORIGINAL_URL_MISSING     = 'original_url_missing'
+
+
+class TestSubmoduleAlternateRemote:
+
+    @pytest.fixture
+    def default_remotes(self):
+        """Return a remotes dict with a single entry using REMOTE_NAME."""
+        return make_mock_remotes(REMOTE_NAME)
+
+    @pytest.fixture
+    def full_element(self):
+        """Return a mock element with all required attributes set for a SubmoduleAlternateRemote."""
+        return make_mock_element_with_text(
+            {ATTRIB_REMOTE: REMOTE_NAME, ATTRIB_ORIGINAL_URL: ORIGINAL_URL},
+            text=ALT_URL,
+            tag=ELEMENT_TAG_SUBMODULE_ALT,
+        )
+
+    @pytest.fixture
+    def full_sar(self, full_element, default_remotes):
+        """Return a _SubmoduleAlternateRemote built from an element with all required attributes set."""
+        return _SubmoduleAlternateRemote(full_element, default_remotes)
+
+    def test_parse_returns_all_fields_when_all_present(self, full_element, default_remotes):
+        """When all required attributes are present and the remote is in remotes, must return (remote_name, original_url, alt_url)."""
+        remote_name, original_url, alt_url = _parse_submodule_alternate_remote_attribs(full_element, default_remotes)
+
+        assert remote_name == REMOTE_NAME
+        assert original_url == ORIGINAL_URL
+        assert alt_url == ALT_URL
+
+    @pytest.mark.parametrize(PARAM_PARSE_RAISES, [
+        pytest.param({ATTRIB_ORIGINAL_URL: ORIGINAL_URL}, id=ID_REMOTE_MISSING),
+        pytest.param({ATTRIB_REMOTE: REMOTE_NAME}, id=ID_ORIGINAL_URL_MISSING),
+    ])
+    def test_parse_raises_when_required_attrib_missing(self, default_remotes, attrib):
+        """When any required attribute is absent, must raise KeyError with the required-attrib message."""
+        element = make_mock_element_with_text(attrib, tag=ELEMENT_TAG_SUBMODULE_ALT)
+        with pytest.raises(KeyError) as exc_info:
+            _parse_submodule_alternate_remote_attribs(element, default_remotes)
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_parse_raises_when_remote_not_in_remotes(self, full_element):
+        """When the remote attribute value is not a key in the remotes dict, must raise KeyError with the no-remote message."""
+        with pytest.raises(KeyError) as exc_info:
+            _parse_submodule_alternate_remote_attribs(full_element, {})
+
+        assert NO_REMOTE_EXISTS_WITH_NAME.split(NO_REMOTE_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_init_sets_all_fields(self, full_sar):
+        """When all required attributes are valid, __init__ must correctly set remote_name, originalUrl, and altUrl."""
+        assert getattr(full_sar, FIELD_REMOTE_NAME) == REMOTE_NAME
+        assert getattr(full_sar, FIELD_ORIGINAL_URL) == ORIGINAL_URL
+        assert getattr(full_sar, FIELD_ALT_URL) == ALT_URL
+
+    def test_tuple_returns_correct_submodule_alternate_remote_namedtuple(self, full_sar):
+        """The tuple property must return a SubmoduleAlternateRemote namedtuple with all field values correct."""
+        assert full_sar.tuple == SubmoduleAlternateRemote(
+            remote_name=REMOTE_NAME,
+            original_url=ORIGINAL_URL,
+            alternate_url=ALT_URL,
+        )
+


### PR DESCRIPTION
Extracted the inline required-attribute and remote-validation logic from _SubmoduleAlternateRemote.__init__ into a new module-level function _parse_submodule_alternate_remote_attribs, consistent with the pattern established for all other private classes. Added docstrings to __init__ and tuple, and added a complete unit test module and test case documentation covering all parsing, validation, and tuple behaviors.

Changes:
- Extracted _parse_submodule_alternate_remote_attribs from _SubmoduleAlternateRemote.__init__ in edk_manifest.py
- Added docstrings to _SubmoduleAlternateRemote.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_submodule_alternate_remote.py with 6 tests for _SubmoduleAlternateRemote
- Added unit_tests/SubmoduleAlternateRemote_TestCases.md documenting all test cases for _SubmoduleAlternateRemote

Fixes #343