### PR TITLE
EdkRepo: Create unit tests for the class _SubmoduleInitEntry() and modularize its existing methods if needed

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -1310,11 +1310,8 @@ class _SubmoduleAlternateRemote():
 
 class _SubmoduleInitEntry():
     def __init__(self, element):
-        try:
-            self.remote_name = element.attrib['remote']
-            self.path = element.text
-        except KeyError as k:
-            raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+        """Parse required and optional attributes from a ``<SubmoduleInitEntry>`` element."""
+        self.remote_name, self.path = _parse_submodule_init_required_attribs(element)
         try:
             self.combo = element.attrib['combo']
         except Exception:
@@ -1326,8 +1323,17 @@ class _SubmoduleInitEntry():
 
     @property
     def tuple(self):
+        """Return a :class:`SubmoduleInitPath` namedtuple representation."""
         return SubmoduleInitPath(self.remote_name, self.combo, self.recursive, self.path)
 
+def _parse_submodule_init_required_attribs(element):
+    """Return ``(remote_name, path)`` or raise ``KeyError`` if the required ``remote`` attribute is missing."""
+    try:
+        remote_name = element.attrib['remote']
+        path = element.text
+    except KeyError as k:
+        raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, element.tag))
+    return remote_name, path
 
 #
 # Optional entry point for debug and validation of the CiIndexXml & ManifestXml classes

--- a/edkrepo_manifest_parser/unit_tests/SubmoduleInitEntry_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/SubmoduleInitEntry_TestCases.md
@@ -1,0 +1,59 @@
+# Test Cases for the `_SubmoduleInitEntry` Class
+
+## Test Cases
+
+### TestParseSubmoduleInitRequiredAttribs
+Tests `_parse_submodule_init_required_attribs` which returns `(remote_name, path)` or raises `KeyError` if the required `remote` attribute is missing.
+
+#### 1. Returns All Fields When All Present
+- **Description**: When the required `remote` attribute is present and `element.text` provides the path.
+- **Expected Outcome**: Returns a tuple of `(remote_name, path)` with the correct values.
+
+#### 2. Raises When remote Missing
+- **Description**: When the `remote` attribute is absent from the element.
+- **Expected Outcome**: Raises `KeyError` whose message contains the required-attribute error prefix.
+
+### TestSubmoduleInitEntryInit
+Tests `_SubmoduleInitEntry.__init__` which parses required and optional attributes from a `<SubmoduleInitEntry>` element.
+
+#### 1. Sets All Required Fields
+- **Description**: When the required `remote` attribute and element text are present.
+- **Expected Outcome**: `self.remote_name` and `self.path` are set to the correct values.
+
+#### 2. All Optional Fields Default When Absent
+- **Description**: When the `combo` and `recursive` attributes are both absent.
+- **Expected Outcome**: `self.combo` is `None` and `self.recursive` is `False`.
+
+#### 3. combo Set When Present
+- **Description**: When the `combo` attribute is present.
+- **Expected Outcome**: `self.combo` equals the attribute value.
+
+#### 4. recursive True When Attribute Is "true"
+- **Description**: When the `recursive` attribute is `"true"`.
+- **Expected Outcome**: `self.recursive` is `True`.
+
+#### 5. recursive False When Attribute Is "false"
+- **Description**: When the `recursive` attribute is `"false"`.
+- **Expected Outcome**: `self.recursive` is `False`.
+
+### TestSubmoduleInitEntryTuple
+Tests `_SubmoduleInitEntry.tuple` which returns a `SubmoduleInitPath` namedtuple.
+
+#### 1. Returns Correct SubmoduleInitPath Namedtuple
+- **Description**: When the object has been initialized with required fields and no optional fields.
+- **Expected Outcome**: `tuple` returns a `SubmoduleInitPath` namedtuple with all fields correctly populated.
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run the Tests**:
+   From the `edkrepo_manifest_parser\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest
+   ```
+   See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.

--- a/edkrepo_manifest_parser/unit_tests/test_submodule_init_entry.py
+++ b/edkrepo_manifest_parser/unit_tests/test_submodule_init_entry.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_submodule_init_entry.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
+    make_mock_element_with_text,
+    REMOTE_NAME,
+    REQUIRED_ATTRIB_SPLIT_CHAR,
+)
+from edkrepo_manifest_parser.edk_manifest import (
+    _SubmoduleInitEntry,
+    _parse_submodule_init_required_attribs,
+    SubmoduleInitPath,
+    REQUIRED_ATTRIB_ERROR_MSG,
+)
+
+ATTRIB_REMOTE               = 'remote'
+ATTRIB_COMBO                = 'combo'
+ATTRIB_RECURSIVE            = 'recursive'
+ATTRIB_BOOL_TRUE            = 'true'
+ATTRIB_BOOL_FALSE           = 'false'
+ELEMENT_TAG_SUBMODULE_INIT  = 'SubmoduleInitEntry'
+SUBMODULE_PATH_VALUE        = 'some/submodule/path'
+SUBMODULE_COMBO             = 'combo_a'
+FIELD_REMOTE_NAME           = 'remote_name'
+FIELD_PATH                  = 'path'
+PARAM_RECURSIVE_FLAG        = 'attrib_val, expected'
+ID_RECURSIVE_TRUE           = 'recursive_true'
+ID_RECURSIVE_FALSE          = 'recursive_false'
+
+
+class TestSubmoduleInitEntry:
+
+    @staticmethod
+    def _make_required_element(**extra):
+        """Build a mock element with the required remote attrib and SUBMODULE_PATH_VALUE text, plus any extra attribs."""
+        attrib = {ATTRIB_REMOTE: REMOTE_NAME}
+        attrib.update(extra)
+        return make_mock_element_with_text(attrib, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
+
+    @pytest.fixture
+    def full_sie(self):
+        """Return a _SubmoduleInitEntry built from an element with required fields only and no optional fields."""
+        return _SubmoduleInitEntry(self._make_required_element())
+
+    def test_parse_returns_all_fields_when_all_present(self):
+        """When the required remote attribute is present, must return (remote_name, path) with the correct values."""
+        element = self._make_required_element()
+
+        remote_name, path = _parse_submodule_init_required_attribs(element)
+
+        assert remote_name == REMOTE_NAME
+        assert path == SUBMODULE_PATH_VALUE
+
+    def test_parse_raises_when_remote_missing(self):
+        """When the remote attribute is absent, must raise KeyError with the required-attrib message."""
+        element = make_mock_element_with_text({}, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
+
+        with pytest.raises(KeyError) as exc_info:
+            _parse_submodule_init_required_attribs(element)
+
+        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+
+    def test_init_sets_all_required_fields(self, full_sie):
+        """When all required attributes are present, __init__ must correctly set remote_name and path."""
+        assert getattr(full_sie, FIELD_REMOTE_NAME) == REMOTE_NAME
+        assert getattr(full_sie, FIELD_PATH) == SUBMODULE_PATH_VALUE
+
+    def test_all_optional_fields_default_when_absent(self, full_sie):
+        """When all optional attributes are absent, __init__ must set combo to None and recursive to False."""
+        assert full_sie.combo is None
+        assert full_sie.recursive is False
+
+    def test_combo_when_present(self):
+        """When the combo attribute is present, __init__ must set self.combo to its value."""
+        element = self._make_required_element(**{ATTRIB_COMBO: SUBMODULE_COMBO})
+        sie = _SubmoduleInitEntry(element)
+        assert sie.combo == SUBMODULE_COMBO
+
+    @pytest.mark.parametrize(PARAM_RECURSIVE_FLAG, [
+        pytest.param(ATTRIB_BOOL_TRUE,  True,  id=ID_RECURSIVE_TRUE),
+        pytest.param(ATTRIB_BOOL_FALSE, False, id=ID_RECURSIVE_FALSE),
+    ])
+    def test_init_sets_recursive_flag(self, attrib_val, expected):
+        """When recursive is 'true' or 'false', __init__ must set self.recursive to the expected boolean."""
+        element = self._make_required_element(**{ATTRIB_RECURSIVE: attrib_val})
+        sie = _SubmoduleInitEntry(element)
+        assert sie.recursive is expected
+
+    def test_tuple_returns_correct_submodule_init_path_namedtuple(self, full_sie):
+        """The tuple property must return a SubmoduleInitPath namedtuple with all field values correct."""
+        assert full_sie.tuple == SubmoduleInitPath(
+            remote_name=REMOTE_NAME,
+            combo=None,
+            recursive=False,
+            path=SUBMODULE_PATH_VALUE,
+        )
+


### PR DESCRIPTION
Extracted the inline required-attribute parsing logic from _SubmoduleInitEntry.__init__ into a new module-level function
_parse_submodule_init_required_attribs, consistent with the pattern established for all other private classes. Added docstrings to __init__ and tuple, and added a complete unit test module and test case documentation covering required-attribute parsing, missing-attribute errors, optional combo and recursive fields, and the tuple property.

Changes:
- Extracted _parse_submodule_init_required_attribs from _SubmoduleInitEntry.__init__ in edk_manifest.py
- Added docstrings to _SubmoduleInitEntry.__init__ and tuple in edk_manifest.py
- Added unit_tests/test_submodule_init_entry.py with 8 tests for _SubmoduleInitEntry
- Added unit_tests/SubmoduleInitEntry_TestCases.md documenting all test cases for _SubmoduleInitEntry

Fixes: #344