### PR TITLE
Edkrepo: Consolidate shared constants into helpers and clean up test suite

### DIFF
--- a/docs/doc_index.md
+++ b/docs/doc_index.md
@@ -24,9 +24,45 @@
 
 #### `edkrepo_manifest_parser/unit_tests/`
 
-- [RepoSource Test Cases](../edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md)\
-  Test case descriptions and expected behaviors for tests defined in [test_repo_source.py](../edkrepo_manifest_parser/unit_tests/test_repo_source.py)
-- [ManifestXml Test Cases](../edkrepo_manifest_parser/unit_tests/ManifestXml_TestCases.md)\
-  Test case descriptions and expected behaviors for tests defined in [test_manifestxml.py](../edkrepo_manifest_parser/unit_tests/test_manifestxml.py)
+- [BaseXmlHelper Test Cases](../edkrepo_manifest_parser/unit_tests/BaseXmlHelper_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_base_xml_helper.py](../edkrepo_manifest_parser/unit_tests/test_base_xml_helper.py)
 - [CiIndexXml Test Cases](../edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md)\
   Test case descriptions and expected behaviors for tests defined in [test_ci_index_xml.py](../edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py)
+- [Combination Test Cases](../edkrepo_manifest_parser/unit_tests/Combination_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_combination.py](../edkrepo_manifest_parser/unit_tests/test_combination.py)
+- [EdkManifestValidation Test Cases](../edkrepo_manifest_parser/unit_tests/EdkManifestValidation_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_edk_manifest_validation.py](../edkrepo_manifest_parser/unit_tests/test_edk_manifest_validation.py)
+- [FolderToFolderMapping Test Cases](../edkrepo_manifest_parser/unit_tests/FolderToFolderMapping_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_folder_to_folder_mapping.py](../edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping.py)
+- [FolderToFolderMappingFolder Test Cases](../edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolder_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_folder_to_folder_mapping_folder.py](../edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder.py)
+- [FolderToFolderMappingFolderExclude Test Cases](../edkrepo_manifest_parser/unit_tests/FolderToFolderMappingFolderExclude_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_folder_to_folder_mapping_folder_exclude.py](../edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder_exclude.py)
+- [GeneralConfig Test Cases](../edkrepo_manifest_parser/unit_tests/GeneralConfig_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_general_config.py](../edkrepo_manifest_parser/unit_tests/test_general_config.py)
+- [ManifestXml Test Cases](../edkrepo_manifest_parser/unit_tests/ManifestXml_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_manifestxml.py](../edkrepo_manifest_parser/unit_tests/test_manifestxml.py)
+- [PatchSet Test Cases](../edkrepo_manifest_parser/unit_tests/PatchSet_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_patchset.py](../edkrepo_manifest_parser/unit_tests/test_patchset.py)
+- [PatchSetOperations Test Cases](../edkrepo_manifest_parser/unit_tests/PatchSetOperations_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_patchset_operations.py](../edkrepo_manifest_parser/unit_tests/test_patchset_operations.py)
+- [Project Test Cases](../edkrepo_manifest_parser/unit_tests/Project_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_project.py](../edkrepo_manifest_parser/unit_tests/test_project.py)
+- [ProjectInfo Test Cases](../edkrepo_manifest_parser/unit_tests/ProjectInfo_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_project_info.py](../edkrepo_manifest_parser/unit_tests/test_project_info.py)
+- [RemoteRepo Test Cases](../edkrepo_manifest_parser/unit_tests/RemoteRepo_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_remote_repo.py](../edkrepo_manifest_parser/unit_tests/test_remote_repo.py)
+- [RepoHook Test Cases](../edkrepo_manifest_parser/unit_tests/RepoHook_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_repo_hook.py](../edkrepo_manifest_parser/unit_tests/test_repo_hook.py)
+- [RepoSource Test Cases](../edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_repo_source.py](../edkrepo_manifest_parser/unit_tests/test_repo_source.py)
+- [SparseData Test Cases](../edkrepo_manifest_parser/unit_tests/SparseData_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_sparse_data.py](../edkrepo_manifest_parser/unit_tests/test_sparse_data.py)
+- [SparseSettings Test Cases](../edkrepo_manifest_parser/unit_tests/SparseSettings_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_sparse_settings.py](../edkrepo_manifest_parser/unit_tests/test_sparse_settings.py)
+- [SubmoduleAlternateRemote Test Cases](../edkrepo_manifest_parser/unit_tests/SubmoduleAlternateRemote_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_submodule_alternate_remote.py](../edkrepo_manifest_parser/unit_tests/test_submodule_alternate_remote.py)
+- [SubmoduleInitEntry Test Cases](../edkrepo_manifest_parser/unit_tests/SubmoduleInitEntry_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_submodule_init_entry.py](../edkrepo_manifest_parser/unit_tests/test_submodule_init_entry.py)
+- [ValidateManifest Test Cases](../edkrepo_manifest_parser/unit_tests/ValidateManifest_TestCases.md)\
+  Test case descriptions and expected behaviors for tests defined in [test_validatemanifest.py](../edkrepo_manifest_parser/unit_tests/test_validatemanifest.py)

--- a/edkrepo_manifest_parser/edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/edk_manifest_validation.py
@@ -48,7 +48,7 @@ class ValidateManifest:
             return ("DUPLICATE", False, INDEX_DUPLICATE_NAMES.format(project, ci_index_filename))
         else:
             return ("DUPLICATE", True, None)
-    
+
     def list_entries(self, project, project_list):
         """Return all entries in project_list that case-insensitively match project."""
         return [x for x in project_list if self.case_insensitive_equal(project, x)]
@@ -163,4 +163,4 @@ if __name__ == '__main__':
     except Exception as e:
         traceback.print_exc()
         sys.exit(1)
-        
+

--- a/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/helpers.py
+++ b/edkrepo_manifest_parser/manifest_parser_unit_test_helpers/helpers.py
@@ -10,14 +10,64 @@
 from unittest.mock import MagicMock
 
 MANIFEST_PATH = '/fake/manifest.xml'
+MANIFEST_FILE_PATH = '/fake/path/manifest.xml'
 CI_INDEX_PATH = '/fake/CiIndex.xml'
 PROJECT1_NAME = 'ProjectA'
 PROJECT2_NAME = 'ProjectB'
 
 REMOTE_NAME = 'origin'
-REMOTE_URL  = 'https://example.com/repo.git'
+REMOTE_URL = 'https://example.com/repo.git'
 
 REQUIRED_ATTRIB_SPLIT_CHAR = '<'
+
+# Common XML attribute key names shared across multiple test modules
+ATTRIB_NAME = 'name'
+ATTRIB_REMOTE = 'remote'
+FIELD_ATTRIB = 'attrib'
+ATTRIB_ARCHIVED = 'archived'
+ATTRIB_BOOL_TRUE = 'true'
+ATTRIB_BOOL_FALSE = 'false'
+ATTRIB_PATH = 'path'
+ATTRIB_DESCRIPTION = 'description'
+ATTRIB_FILE = 'file'
+ATTRIB_SOURCE = 'source'
+ARCHIVED_TRUE_UPPER = 'TRUE'
+TAG_EXCLUDE = 'Exclude'
+EXCLUDE_PATH = 'exclude/some/path'
+FIELD_REMOTE_NAME = 'remote_name'
+ATTRIB_PROJECT1 = 'project1'
+ATTRIB_PROJECT2 = 'project2'
+PROJECT1_FOLDER = 'project1/path'
+PROJECT2_FOLDER = 'project2/path'
+ATTRIB_COMBINATION = 'combination'
+COMMIT = 'abc123'
+BRANCH = 'main'
+PATCHSET_NAME = 'ps_name'
+TAG_MANIFEST = 'Manifest'
+TAG_PIN = 'Pin'
+UNKNOWN = 'Unknown'
+HELLO = 'hello'
+UPSTREAM = 'upstream'
+DEV = 'dev'
+
+# Common parametrize field strings shared across multiple test modules
+PARAM_FIELD_NAME = 'field_name'
+PARAM_FIELD_AND_EXPECTED = 'field_name, expected_value'
+PARAM_MISSING_ATTRIB = 'missing_attrib'
+PARAM_ATTRIB_VALUE_FIELD = 'attrib_key, attrib_value, field_name'
+PARAM_ATTRIB_VAL_FIELD_EXPECTED = 'attrib_key, attrib_val, field_name, expected'
+
+# Common pytest parametrize IDs shared across multiple test modules
+ID_NO_MATCH = 'no_match'
+ID_MISSING = 'missing'
+ID_REMOTE_MISSING = 'remote_missing'
+ID_REMOTE_NAME_PRESENT = 'remote_name_present'
+
+# Common validation result strings shared across multiple test modules
+BAD_XML_MSG = 'bad xml'
+RESULT_PARSING = 'PARSING'
+RESULT_CODENAME = 'CODENAME'
+RESULT_DUPLICATE = 'DUPLICATE'
 
 def make_mock_element(attrib, tag=None):
     """Build a mock element with the given *attrib* dict and an optional *tag*; leave tag unset when ``None``."""
@@ -69,4 +119,14 @@ def make_mock_remotes(remote_name=None, url=None):
 def make_empty_element():
     """Build a mock element with no attributes and no iter children."""
     return make_mock_element_with_iter({})
+
+def make_find_map_element(find_map=None, dev_leads=None, tag=None):
+    """Build a mock element whose ``find()`` returns from *find_map* and ``findall()`` returns *dev_leads*; *dev_leads* defaults to ``[]``."""
+    elem = MagicMock()
+    if tag is not None:
+        elem.tag = tag
+    fm = find_map if find_map is not None else {}
+    elem.find.side_effect = lambda t: fm.get(t)
+    elem.findall.return_value = dev_leads if dev_leads is not None else []
+    return elem
 

--- a/edkrepo_manifest_parser/unit_tests/BaseXmlHelper_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/BaseXmlHelper_TestCases.md
@@ -24,60 +24,60 @@ Tests `BaseXmlHelper.__init__` which loads and validates the file (XML or JSON),
 ### TestJsonToXml
 Tests `_json_to_xml` which reads a JSON file, converts it to an `ElementTree` via `_build_etree_node` and `_pretty_format`, and returns the tree.
 
-#### 5. Valid JSON File — Returns Converted ElementTree and Calls Pretty Format
+#### 1. Valid JSON File — Returns Converted ElementTree and Calls Pretty Format
 - **Description**: `open` and `json.load` are mocked to supply a valid JSON dict; `_build_etree_node` appends a real `SubElement`; `_pretty_format` is a no-op mock.
 - **Expected Outcome**: The returned tree's root tag matches the element appended by the mock `_build_etree_node` and `_pretty_format` is called exactly once.
 
 ### TestBuildEtreeNode
 Tests `_build_etree_node` which builds an `ElementTree SubElement` from a dict and attaches it as a child of parent, recursing into children.
 
-#### 6. Dict With All Optional Fields
+#### 1. Dict With All Optional Fields
 - **Description**: The input dict contains `name`, `attrib`, `text`, `tail`, and a single child dict with `name` only.
 - **Expected Outcome**: The `SubElement` is created with the correct tag, attributes, text, and tail; a nested `SubElement` is created for the child.
 
-#### 7. Dict With Name Only
+#### 2. Dict With Name Only
 - **Description**: The input dict contains only the `name` key.
 - **Expected Outcome**: The `SubElement` is created with the correct tag, empty `attrib` dict, `None` text, `None` tail, and no children.
 
 ### TestPrettyFormat
 Tests `_pretty_format` which recursively adds indentation whitespace to all nodes in the `ElementTree` for human-readable formatting.
 
-#### 8. Called With Parent and index=0 — Sets parent.text
+#### 1. Called With Parent and index=0 — Sets parent.text
 - **Description**: A leaf element is passed along with its parent and `index=0` at a specific depth.
 - **Expected Outcome**: `parent.text` is set to a newline followed by the correct number of two-space indents for the given depth.
 
-#### 9. Called With Parent and index != 0 — Does Not Modify parent.text
+#### 2. Called With Parent and index != 0 — Does Not Modify parent.text
 - **Description**: A leaf element is passed along with its parent and `index=1`.
 - **Expected Outcome**: `parent.text` is not modified.
 
-#### 10. Called Without Parent — Completes Without Error
+#### 3. Called Without Parent — Completes Without Error
 - **Description**: `_pretty_format` is called on the root element with the default `parent=None`.
 - **Expected Outcome**: The call completes without raising any exception.
 
-#### 11. Recurses Into Children — Sets Indentation at Every Level
+#### 4. Recurses Into Children — Sets Indentation at Every Level
 - **Description**: `_pretty_format` is called on a root that has a child which itself has a grandchild.
 - **Expected Outcome**: `root.text` and `child.text` are each set to the correct newline-plus-indent string for their respective depths.
 
 ### TestLoadTree
 Tests `_load_tree` which loads an `ElementTree` from a `.xml` or `.json` file, raising `TypeError` if the extension is unsupported or parsing fails.
 
-#### 12. XML Extension — Returns ElementTree
+#### 1. XML Extension — Returns ElementTree
 - **Description**: `fileref` has a `.xml` extension; `ET.ElementTree` is patched to return a mock tree.
 - **Expected Outcome**: `ET.ElementTree` is called with `file=fileref` and its return value is returned.
 
-#### 13. JSON Extension — Delegates to _json_to_xml
+#### 2. JSON Extension — Delegates to _json_to_xml
 - **Description**: `fileref` has a `.json` extension; `_json_to_xml` is mocked on the instance.
 - **Expected Outcome**: `self._json_to_xml` is called with `fileref` and its return value is returned.
 
-#### 14. Unsupported Extension — Raises TypeError
+#### 3. Unsupported Extension — Raises TypeError
 - **Description**: `fileref` has an extension other than `.xml` or `.json` (e.g., `.xyz`).
 - **Expected Outcome**: `TypeError` is raised.
 
-#### 15. File Parse Error — Raises TypeError
+#### 4. File Parse Error — Raises TypeError
 - **Description**: `ET.ElementTree` is patched to raise an `Exception` during parsing.
 - **Expected Outcome**: The exception is caught and re-raised as a `TypeError`.
 
-#### 16. JSON Parse Error — Raises TypeError
+#### 5. JSON Parse Error — Raises TypeError
 - **Description**: `_json_to_xml` is mocked to raise an `Exception` during JSON parsing.
 - **Expected Outcome**: The exception is caught and re-raised as a `TypeError`.
 

--- a/edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/CiIndexXml_TestCases.md
@@ -20,41 +20,41 @@ Tests `CiIndexXml.__init__` which parses a CiIndex XML file and builds the inter
 ### TestProjectList
 Tests the `project_list` property which returns the names of all non-archived projects.
 
-#### 4. Returns Only Active Project Names
+#### 1. Returns Only Active Project Names
 - **Description**: When the projects map contains a mix of active and archived projects.
 - **Expected Outcome**: Only the names of non-archived projects are returned.
 
-#### 5. Returns Empty List When All Projects Are Archived
+#### 2. Returns Empty List When All Projects Are Archived
 - **Description**: When every project in the map has `archived` set to `True`.
 - **Expected Outcome**: Returns an empty list.
 
-#### 6. Returns All Names When No Projects Are Archived
+#### 3. Returns All Names When No Projects Are Archived
 - **Description**: When every project in the map has `archived` set to `False`.
 - **Expected Outcome**: All project names are returned.
 
 ### TestArchivedProjectList
 Tests the `archived_project_list` property which returns the names of all archived projects.
 
-#### 7. Returns Only Archived Project Names
+#### 1. Returns Only Archived Project Names
 - **Description**: When the projects map contains a mix of active and archived projects.
 - **Expected Outcome**: Only the names of archived projects are returned.
 
-#### 8. Returns Empty List When No Projects Are Archived
+#### 2. Returns Empty List When No Projects Are Archived
 - **Description**: When every project in the map has `archived` set to `False`.
 - **Expected Outcome**: Returns an empty list.
 
-#### 9. Returns All Names When All Projects Are Archived
+#### 3. Returns All Names When All Projects Are Archived
 - **Description**: When every project in the map has `archived` set to `True`.
 - **Expected Outcome**: All project names are returned.
 
 ### TestGetProjectXml
 Tests `get_project_xml` which returns the XML path for a project or raises `ValueError` if the project is not found.
 
-#### 10. Returns XmlPath When Project Found
+#### 1. Returns XmlPath When Project Found
 - **Description**: When the requested project name exists in the internal projects map.
 - **Expected Outcome**: Returns the `xmlPath` attribute of the corresponding `_Project`.
 
-#### 11. Raises ValueError When Project Not Found
+#### 2. Raises ValueError When Project Not Found
 - **Description**: When the requested project name does not exist in the internal projects map.
 - **Expected Outcome**: Raises `ValueError` containing the project name.
 

--- a/edkrepo_manifest_parser/unit_tests/EdkManifestValidation_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/EdkManifestValidation_TestCases.md
@@ -16,70 +16,70 @@ Tests the `_collect_file_validation_results` helper which validates parsing and 
 ### TestResolveProjectManifestPath
 Tests the `_resolve_project_manifest_path` helper which computes the absolute path to a project manifest file.
 
-#### 3. Returns Normalized Joined Path
+#### 1. Returns Normalized Joined Path
 - **Description**: Given a `CiIndexXml` mock whose `get_project_xml` returns a relative path, and a `global_manifest_directory`.
 - **Expected Outcome**: Returns `os.path.join(global_manifest_directory, os.path.normpath(relative_path))`.
 
 ### TestCollectProjectValidationResults
 Tests the `_collect_project_validation_results` helper which runs parsing, codename, and deduplication validations for one project.
 
-#### 4. All Validations Pass — Three Results Returned
+#### 1. All Validations Pass — Three Results Returned
 - **Description**: When all three `ValidateManifest` methods return passing tuples.
 - **Expected Outcome**: The result list has exactly three entries, all with a `True` status.
 
-#### 5. Parsing Fails — Three Results Still Returned
+#### 2. Parsing Fails — Three Results Still Returned
 - **Description**: When `validate_parsing` returns a failure tuple; the other validators still run.
 - **Expected Outcome**: The result list has exactly three entries; the first has `False` status.
 
 ### TestValidateManifestFiles
 Tests `validate_manifestfiles` which validates every manifest file in a provided list.
 
-#### 6. Empty List Returns Empty Dict
+#### 1. Empty List Returns Empty Dict
 - **Description**: Called with an empty `manifestfile_list`.
 - **Expected Outcome**: Returns an empty dictionary; `_collect_file_validation_results` is never called.
 
-#### 7. Single Manifest — Helper Called Once
+#### 2. Single Manifest — Helper Called Once
 - **Description**: Called with a list containing one manifest filepath.
 - **Expected Outcome**: Returns a dict with one entry keyed by the filepath whose value is the list returned by `_collect_file_validation_results`.
 
-#### 8. Multiple Manifests — Helper Called for Each
+#### 3. Multiple Manifests — Helper Called for Each
 - **Description**: Called with a list containing two manifest filepaths.
 - **Expected Outcome**: Returns a dict with two entries; `_collect_file_validation_results` is called once per filepath with the correct argument.
 
 ### TestValidateManifestRepo
 Tests `validate_manifestrepo` which validates all manifest files referenced by `CiIndex.xml`.
 
-#### 9. Without Archived — Only Active Projects Processed
+#### 1. Without Archived — Only Active Projects Processed
 - **Description**: Called with `verify_archived=False`; `CiIndex.xml` contains one active project and one archived project.
 - **Expected Outcome**: Returns a dict with one entry; `archived_project_list` is not included.
 
-#### 10. With Archived — Active and Archived Projects Processed
+#### 2. With Archived — Active and Archived Projects Processed
 - **Description**: Called with `verify_archived=True`; `CiIndex.xml` contains one active project and one archived project.
 - **Expected Outcome**: Returns a dict with two entries, one per project.
 
 ### TestGetManifestValidationStatus
 Tests `get_manifest_validation_status` which verifies the validation status of all manifest files; parametrized over all-pass, one-fail, and empty-dict inputs.
 
-#### 11. All Results Pass — Returns False
+#### 1. All Results Pass — Returns False
 - **Description**: Every result tuple in the dict has a `True` status.
 - **Expected Outcome**: Returns `False`.
 
-#### 12. One Result Fails — Returns True
+#### 2. One Result Fails — Returns True
 - **Description**: At least one result tuple in the dict has a `False` status.
 - **Expected Outcome**: Returns `True`.
 
-#### 13. Empty Dict — Returns False
+#### 3. Empty Dict — Returns False
 - **Description**: Called with an empty dictionary.
 - **Expected Outcome**: Returns `False`.
 
 ### TestPrintManifestErrors
 Tests `print_manifest_errors` which prints error details for every failed validation result.
 
-#### 14. Prints Header and Details for Each Failure
+#### 1. Prints Header and Details for Each Failure
 - **Description**: The dict contains one manifest file with one failing result and one passing result.
 - **Expected Outcome**: `VERIFY_ERROR_HEADER` is printed once, followed by three print calls for the failing result (file name, error type, error message); the passing result is skipped.
 
-#### 15. All Passing — Only Header Printed
+#### 2. All Passing — Only Header Printed
 - **Description**: The dict contains one manifest file where all results are passing.
 - **Expected Outcome**: `print` is called exactly once with `VERIFY_ERROR_HEADER`; no error detail lines are printed.
 

--- a/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
@@ -165,4 +165,4 @@ Tests `_RepoSource.tuple` which returns a `RepoSource` namedtuple.
    python3 -m pytest
    ```
    See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for additional command line options.
-   
+

--- a/edkrepo_manifest_parser/unit_tests/ValidateManifest_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/ValidateManifest_TestCases.md
@@ -16,67 +16,67 @@ Tests `_try_parse_manifest_xml` which attempts to construct a `ManifestXml` from
 ### TestValidateParsing
 Tests `validate_parsing` which attempts to parse the manifest XML file and returns a `(type, status, message)` result tuple.
 
-#### 3. Success Returns Correct Tuple and Sets Xmldata
+#### 1. Success Returns Correct Tuple and Sets Xmldata
 - **Description**: When `ManifestXml` is successfully constructed.
 - **Expected Outcome**: Returns `("PARSING", True, None)` and `_manifest_xmldata` is set to the constructed instance.
 
-#### 4. Failure Returns Correct Tuple and Clears Xmldata
+#### 2. Failure Returns Correct Tuple and Clears Xmldata
 - **Description**: When `ManifestXml` raises an exception.
 - **Expected Outcome**: Returns `("PARSING", False, <exception>)` and `_manifest_xmldata` is set to `None`.
 
 ### TestValidateCodename
 Tests `validate_codename` which verifies the manifest codename matches the expected project name and returns a `(type, status, message)` result tuple.
 
-#### 5. Fails When No Manifest Data
+#### 1. Fails When No Manifest Data
 - **Description**: When `_manifest_xmldata` is `None`.
 - **Expected Outcome**: Returns `('CODENAME', False, <message containing the project name>)`.
 
-#### 6. Succeeds When Codename Matches
+#### 2. Succeeds When Codename Matches
 - **Description**: When `_manifest_xmldata.project_info.codename` equals the given project name.
 - **Expected Outcome**: Returns `("CODENAME", True, None)`.
 
-#### 7. Fails When Codename Mismatches
+#### 3. Fails When Codename Mismatches
 - **Description**: When `_manifest_xmldata.project_info.codename` differs from the given project name.
 - **Expected Outcome**: Returns `("CODENAME", False, <non-None message>)`.
 
 ### TestValidateCaseInsensitiveSingleMatch
 Tests `validate_case_insensitive_single_match` which verifies the project name appears exactly once in the project list using case-insensitive comparison and returns a `(type, status, message)` result tuple.
 
-#### 8. Exactly One Match Returns Duplicate True
+#### 1. Exactly One Match Returns Duplicate True
 - **Description**: When exactly one case-insensitive match is found in the project list.
 - **Expected Outcome**: Returns `("DUPLICATE", True, None)`.
 
-#### 9. No Match Returns Duplicate False
+#### 2. No Match Returns Duplicate False
 - **Description**: When no case-insensitive match is found in the project list.
 - **Expected Outcome**: Returns `("DUPLICATE", False, <message containing project name>)`.
 
-#### 10. Multiple Matches Returns Duplicate False
+#### 3. Multiple Matches Returns Duplicate False
 - **Description**: When more than one case-insensitive match is found in the project list.
 - **Expected Outcome**: Returns `("DUPLICATE", False, <message containing project name>)`.
 
 ### TestListEntries
 Tests `list_entries` which returns all entries in the project list that case-insensitively match the given project name.
 
-#### 11. Returns Matching Entries
+#### 1. Returns Matching Entries
 - **Description**: When the project list contains entries that match the project name case-insensitively.
 - **Expected Outcome**: Returns a list containing all matching entries and no non-matching entries.
 
-#### 12. Returns Empty List When No Matches
+#### 2. Returns Empty List When No Matches
 - **Description**: When no entries in the project list match the project name.
 - **Expected Outcome**: Returns an empty list.
 
 ### TestCaseInsensitiveEqual
 Tests `case_insensitive_equal` which returns `True` if two strings are equal under Unicode NFKD case-folding normalization.
 
-#### 13. Equal Strings Same Case
+#### 1. Equal Strings Same Case
 - **Description**: When both arguments are identical strings (same casing).
 - **Expected Outcome**: Returns `True`.
 
-#### 14. Equal Strings Different Case
+#### 2. Equal Strings Different Case
 - **Description**: When both arguments represent the same word with different casing.
 - **Expected Outcome**: Returns `True`.
 
-#### 15. Unequal Strings
+#### 3. Unequal Strings
 - **Description**: When both arguments are completely different words.
 - **Expected Outcome**: Returns `False`.
 

--- a/edkrepo_manifest_parser/unit_tests/test_base_xml_helper.py
+++ b/edkrepo_manifest_parser/unit_tests/test_base_xml_helper.py
@@ -14,40 +14,34 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.edk_manifest import BaseXmlHelper
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
 
-MANIFEST_XML      = '/fake/path/manifest.xml'
-PIN_XML           = '/fake/path/pin.xml'
-MANIFEST_JSON     = '/fake/path/manifest.json'
-MANIFEST_XYZ      = '/fake/path/manifest.xyz'
-MANIFEST_ROOT_TAG = 'Manifest'
-PIN_ROOT_TAG      = 'Pin'
-UNKNOWN_ROOT_TAG  = 'Unknown'
-NODE_SOLO         = 'Solo'
-NODE_PARENT       = 'Parent'
-NODE_CHILD        = 'Child'
-NODE_KEY_NAME     = 'name'
-NODE_KEY_ATTRIB   = 'attrib'
-NODE_KEY_TEXT     = 'text'
-NODE_KEY_TAIL     = 'tail'
+PIN_XML = '/fake/path/pin.xml'
+MANIFEST_JSON = '/fake/path/manifest.json'
+MANIFEST_XYZ = '/fake/path/manifest.xyz'
+NODE_SOLO = 'Solo'
+NODE_PARENT = 'Parent'
+NODE_CHILD = 'Child'
+NODE_KEY_TEXT = 'text'
+NODE_KEY_TAIL = 'tail'
 NODE_KEY_CHILDREN = 'children'
-ELEMENT_ROOT_TAG  = 'root'
+ELEMENT_ROOT_TAG = 'root'
 ELEMENT_CHILD_TAG = 'child'
-ATTRIB_KEY        = 'key'
-ATTRIB_VAL        = 'val'
-TEXT_VALUE        = 'hello'
-TAIL_VALUE        = ' world'
-ORIGINAL_TEXT     = 'original'
-PARSE_ERROR_MSG            = 'parse error'
-INVALID_FILE_MSG           = 'invalid file'
+ATTRIB_KEY = 'key'
+ATTRIB_VAL = 'val'
+TAIL_VALUE = ' world'
+ORIGINAL_TEXT = 'original'
+PARSE_ERROR_MSG = 'parse error'
+INVALID_FILE_MSG = 'invalid file'
 PRETTY_FORMAT_INDEX_FIELDS = 'index,expected'
-ID_INDEX_ZERO              = 'index_zero'
-ID_INDEX_NONZERO           = 'index_nonzero'
-INIT_SUCCESS_FIELDS        = 'tag,fileref,xml_types'
-ID_MANIFEST_TYPE           = 'manifest_type'
-ID_PIN_TYPE                = 'pin_type'
-INDENT_DEPTH_1             = '\n  '
-INDENT_DEPTH_2             = '\n    '
+ID_INDEX_ZERO = 'index_zero'
+ID_INDEX_NONZERO = 'index_nonzero'
+INIT_SUCCESS_FIELDS = 'tag,fileref,xml_types'
+ID_MANIFEST_TYPE = 'manifest_type'
+ID_PIN_TYPE = 'pin_type'
+INDENT_DEPTH_1 = '\n  '
+INDENT_DEPTH_2 = '\n    '
 
 
 class TestBaseXmlHelper:
@@ -62,16 +56,16 @@ class TestBaseXmlHelper:
     @staticmethod
     def _build_node(current_dict):
         """Build an ET node from current_dict via _build_etree_node and return the first child of the parent."""
-        instance = object.__new__(BaseXmlHelper)
+        instance = object.__new__(edk_manifest.BaseXmlHelper)
         parent = ET.Element(ELEMENT_ROOT_TAG)
         instance._build_etree_node(current_dict, parent)
         return parent[0]
 
     @staticmethod
     def _assert_init_raises_typeerror(xml_types):
-        """Assert that BaseXmlHelper(MANIFEST_XML, xml_types) raises TypeError."""
+        """Assert that edk_manifest.BaseXmlHelper(MANIFEST_FILE_PATH, xml_types) raises TypeError."""
         with pytest.raises(TypeError):
-            BaseXmlHelper(MANIFEST_XML, xml_types)
+            edk_manifest.BaseXmlHelper(helpers.MANIFEST_FILE_PATH, xml_types)
 
     @pytest.fixture
     def mock_et(self):
@@ -81,8 +75,8 @@ class TestBaseXmlHelper:
 
     @pytest.fixture
     def mock_load_tree(self):
-        """Patch BaseXmlHelper._load_tree for the duration of a test; yields the mock."""
-        with patch.object(BaseXmlHelper, '_load_tree') as mock:
+        """Patch edk_manifest.BaseXmlHelper._load_tree for the duration of a test; yields the mock."""
+        with patch.object(edk_manifest.BaseXmlHelper, '_load_tree') as mock:
             yield mock
 
     @pytest.fixture
@@ -94,18 +88,18 @@ class TestBaseXmlHelper:
 
     @pytest.fixture
     def bare_instance(self):
-        """Return a bare BaseXmlHelper instance bypassing __init__."""
-        return object.__new__(BaseXmlHelper)
+        """Return a bare edk_manifest.BaseXmlHelper instance bypassing __init__."""
+        return object.__new__(edk_manifest.BaseXmlHelper)
 
     @pytest.mark.parametrize(INIT_SUCCESS_FIELDS, [
-        pytest.param(MANIFEST_ROOT_TAG, MANIFEST_XML, [MANIFEST_ROOT_TAG, PIN_ROOT_TAG], id=ID_MANIFEST_TYPE),
-        pytest.param(PIN_ROOT_TAG,      PIN_XML,      [PIN_ROOT_TAG],                    id=ID_PIN_TYPE),
+        pytest.param(helpers.TAG_MANIFEST, helpers.MANIFEST_FILE_PATH, [helpers.TAG_MANIFEST, helpers.TAG_PIN], id=ID_MANIFEST_TYPE),
+        pytest.param(helpers.TAG_PIN, PIN_XML, [helpers.TAG_PIN], id=ID_PIN_TYPE),
     ])
     def test_init_valid_root_tag_sets_attributes(self, mock_load_tree, tag, fileref, xml_types):
         """When _load_tree returns a tree whose root tag is in xml_types, __init__ must set _fileref, _tree, and _xml_type."""
         mock_load_tree.return_value = self._make_mock_tree(tag)
 
-        instance = BaseXmlHelper(fileref, xml_types)
+        instance = edk_manifest.BaseXmlHelper(fileref, xml_types)
 
         assert instance._fileref == fileref
         assert instance._tree is mock_load_tree.return_value
@@ -113,50 +107,50 @@ class TestBaseXmlHelper:
 
     def test_root_tag_not_in_xml_types_raises_typeerror(self, mock_load_tree):
         """When the root tag is not in xml_types, __init__ must raise TypeError."""
-        mock_load_tree.return_value = self._make_mock_tree(UNKNOWN_ROOT_TAG)
-        self._assert_init_raises_typeerror([MANIFEST_ROOT_TAG, PIN_ROOT_TAG])
+        mock_load_tree.return_value = self._make_mock_tree(helpers.UNKNOWN)
+        self._assert_init_raises_typeerror([helpers.TAG_MANIFEST, helpers.TAG_PIN])
 
     def test_load_tree_raises_typeerror_propagates(self, mock_load_tree):
         """When _load_tree raises TypeError, the exception must propagate out of __init__ unchanged."""
         mock_load_tree.side_effect = TypeError(INVALID_FILE_MSG)
-        self._assert_init_raises_typeerror([MANIFEST_ROOT_TAG])
+        self._assert_init_raises_typeerror([helpers.TAG_MANIFEST])
 
     def test_valid_json_returns_converted_element_tree(self, bare_instance, mock_json_open):
         """When open and json.load succeed, _json_to_xml must return a tree whose root tag matches the JSON node name and call _pretty_format and _build_etree_node each exactly once."""
         mock_open, mock_json_load = mock_json_open
-        mock_json_load.return_value = {NODE_KEY_NAME: MANIFEST_ROOT_TAG}
+        mock_json_load.return_value = {helpers.ATTRIB_NAME: helpers.TAG_MANIFEST}
 
         def mock_build_node(d, p):
-            return ET.SubElement(p, MANIFEST_ROOT_TAG)
+            return ET.SubElement(p, helpers.TAG_MANIFEST)
 
         bare_instance._build_etree_node = MagicMock(side_effect=mock_build_node)
         bare_instance._pretty_format = MagicMock()
 
         result = bare_instance._json_to_xml(MANIFEST_JSON)
 
-        assert result.getroot().tag == MANIFEST_ROOT_TAG
+        assert result.getroot().tag == helpers.TAG_MANIFEST
         bare_instance._pretty_format.assert_called_once()
         bare_instance._build_etree_node.assert_called_once()
 
     def test_dict_with_all_optional_fields(self):
         """When the dict contains name, attrib, text, tail, and children, _build_etree_node must set all fields and recurse."""
         node = self._build_node({
-            NODE_KEY_NAME:     NODE_PARENT,
-            NODE_KEY_ATTRIB:   {ATTRIB_KEY: ATTRIB_VAL},
-            NODE_KEY_TEXT:     TEXT_VALUE,
-            NODE_KEY_TAIL:     TAIL_VALUE,
-            NODE_KEY_CHILDREN: [{NODE_KEY_NAME: NODE_CHILD}],
+            helpers.ATTRIB_NAME: NODE_PARENT,
+            helpers.FIELD_ATTRIB: {ATTRIB_KEY: ATTRIB_VAL},
+            NODE_KEY_TEXT: helpers.HELLO,
+            NODE_KEY_TAIL: TAIL_VALUE,
+            NODE_KEY_CHILDREN: [{helpers.ATTRIB_NAME: NODE_CHILD}],
         })
 
         assert node.tag == NODE_PARENT
         assert node.attrib == {ATTRIB_KEY: ATTRIB_VAL}
-        assert node.text == TEXT_VALUE
+        assert node.text == helpers.HELLO
         assert node.tail == TAIL_VALUE
         assert node[0].tag == NODE_CHILD
 
     def test_dict_with_name_only(self):
         """When the dict contains only the name key, _build_etree_node must create a SubElement with empty attrib, None text, None tail, and no children."""
-        node = self._build_node({NODE_KEY_NAME: NODE_SOLO})
+        node = self._build_node({helpers.ATTRIB_NAME: NODE_SOLO})
 
         assert node.tag == NODE_SOLO
         assert node.attrib == {}
@@ -166,7 +160,7 @@ class TestBaseXmlHelper:
 
     @pytest.mark.parametrize(PRETTY_FORMAT_INDEX_FIELDS, [
         pytest.param(0, INDENT_DEPTH_2, id=ID_INDEX_ZERO),
-        pytest.param(1, ORIGINAL_TEXT,  id=ID_INDEX_NONZERO),
+        pytest.param(1, ORIGINAL_TEXT, id=ID_INDEX_NONZERO),
     ])
     def test_pretty_format_parent_text_by_index(self, bare_instance, index, expected):
         """When called with a given index and depth=2, _pretty_format must set parent.text to the expected value."""
@@ -200,9 +194,9 @@ class TestBaseXmlHelper:
         mock_tree = MagicMock()
         mock_et.return_value = mock_tree
 
-        result = bare_instance._load_tree(MANIFEST_XML)
+        result = bare_instance._load_tree(helpers.MANIFEST_FILE_PATH)
 
-        mock_et.assert_called_once_with(file=MANIFEST_XML)
+        mock_et.assert_called_once_with(file=helpers.MANIFEST_FILE_PATH)
         assert result is mock_tree
 
     def test_json_extension_delegates_to_json_to_xml(self, bare_instance):
@@ -225,7 +219,7 @@ class TestBaseXmlHelper:
         mock_et.side_effect = Exception(PARSE_ERROR_MSG)
 
         with pytest.raises(TypeError):
-            bare_instance._load_tree(MANIFEST_XML)
+            bare_instance._load_tree(helpers.MANIFEST_FILE_PATH)
 
     def test_json_parse_error_raises_typeerror(self, bare_instance):
         """When _json_to_xml raises an exception during JSON parsing, _load_tree must catch it and raise TypeError."""

--- a/edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py
+++ b/edkrepo_manifest_parser/unit_tests/test_ci_index_xml.py
@@ -13,21 +13,16 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.edk_manifest import CiIndexXml, INVALID_PROJECTNAME_ERROR
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    CI_INDEX_PATH,
-    PROJECT1_NAME,
-    PROJECT2_NAME,
-)
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
 
-PROJECT_XML_A             = f'{PROJECT1_NAME}/{PROJECT1_NAME}.xml'
-CI_UNKNOWN_PROJECT        = 'Unknown'
+PROJECT_XML_A = f'{helpers.PROJECT1_NAME}/{helpers.PROJECT1_NAME}.xml'
 ELEMENT_TAG_CI_PROJECT_LIST = 'ProjectList'
-CI_DEFAULT_XML_PATH       = 'fake_path.xml'
-CI_PARAMETRIZE_FIELDS     = 'archived_a,archived_b,expected'
-ID_MIXED                  = 'mixed'
-ID_ALL_ARCHIVED           = 'all_archived'
-ID_NONE_ARCHIVED          = 'none_archived'
+CI_DEFAULT_XML_PATH = 'fake_path.xml'
+CI_PARAMETRIZE_FIELDS = 'archived_a,archived_b,expected'
+ID_MIXED = 'mixed'
+ID_ALL_ARCHIVED = 'all_archived'
+ID_NONE_ARCHIVED = 'none_archived'
 
 
 class TestCiIndexXml:
@@ -57,14 +52,14 @@ class TestCiIndexXml:
     def _make_two_project_map(archived_a, archived_b):
         """Build a _projects dict with PROJECT1_NAME and PROJECT2_NAME using the given archived flags."""
         return {
-            PROJECT1_NAME: TestCiIndexXml._make_mock_project(PROJECT1_NAME, archived_a),
-            PROJECT2_NAME: TestCiIndexXml._make_mock_project(PROJECT2_NAME, archived_b),
+            helpers.PROJECT1_NAME: TestCiIndexXml._make_mock_project(helpers.PROJECT1_NAME, archived_a),
+            helpers.PROJECT2_NAME: TestCiIndexXml._make_mock_project(helpers.PROJECT2_NAME, archived_b),
         }
 
     @pytest.fixture
     def ci_instance(self):
-        """Return a bare CiIndexXml instance with an empty _projects map ready for per-test configuration."""
-        return CiIndexXml(CI_INDEX_PATH)
+        """Return a bare edk_manifest.CiIndexXml instance with an empty _projects map ready for per-test configuration."""
+        return edk_manifest.CiIndexXml(helpers.CI_INDEX_PATH)
 
     @pytest.fixture
     def mock_project_cls(self):
@@ -74,7 +69,7 @@ class TestCiIndexXml:
 
     def test_init_empty_tree_results_in_empty_project_map(self, mock_project_cls):
         """When the XML tree has no Project elements, _projects must be empty and _Project never called."""
-        ci = CiIndexXml(CI_INDEX_PATH)
+        ci = edk_manifest.CiIndexXml(helpers.CI_INDEX_PATH)
 
         assert ci._projects == {}
         mock_project_cls.assert_not_called()
@@ -83,30 +78,30 @@ class TestCiIndexXml:
         """When the tree has one Project element, _projects must contain exactly that entry keyed by name."""
         mock_elem = MagicMock()
         mock_et.return_value.iter.return_value = [mock_elem]
-        proj_a = self._make_mock_project(PROJECT1_NAME, False, PROJECT_XML_A)
+        proj_a = self._make_mock_project(helpers.PROJECT1_NAME, False, PROJECT_XML_A)
         mock_project_cls.return_value = proj_a
 
-        ci = CiIndexXml(CI_INDEX_PATH)
+        ci = edk_manifest.CiIndexXml(helpers.CI_INDEX_PATH)
 
-        assert ci._projects == {PROJECT1_NAME: proj_a}
+        assert ci._projects == {helpers.PROJECT1_NAME: proj_a}
         mock_project_cls.assert_called_once_with(mock_elem)
 
     def test_init_multiple_projects_all_keyed_by_name(self, mock_project_cls, mock_et):
         """When the tree has multiple Project elements, _projects must contain one entry per project."""
         mock_elem_a, mock_elem_b = MagicMock(), MagicMock()
         mock_et.return_value.iter.return_value = [mock_elem_a, mock_elem_b]
-        proj_a = self._make_mock_project(PROJECT1_NAME, False)
-        proj_b = self._make_mock_project(PROJECT2_NAME, True)
+        proj_a = self._make_mock_project(helpers.PROJECT1_NAME, False)
+        proj_b = self._make_mock_project(helpers.PROJECT2_NAME, True)
         mock_project_cls.side_effect = [proj_a, proj_b]
 
-        ci = CiIndexXml(CI_INDEX_PATH)
+        ci = edk_manifest.CiIndexXml(helpers.CI_INDEX_PATH)
 
-        assert ci._projects == {PROJECT1_NAME: proj_a, PROJECT2_NAME: proj_b}
+        assert ci._projects == {helpers.PROJECT1_NAME: proj_a, helpers.PROJECT2_NAME: proj_b}
 
     @pytest.mark.parametrize(CI_PARAMETRIZE_FIELDS, [
-        pytest.param(False, True,  [PROJECT1_NAME],                id=ID_MIXED),
-        pytest.param(True,  True,  [],                             id=ID_ALL_ARCHIVED),
-        pytest.param(False, False, [PROJECT1_NAME, PROJECT2_NAME], id=ID_NONE_ARCHIVED),
+        pytest.param(False, True, [helpers.PROJECT1_NAME], id=ID_MIXED),
+        pytest.param(True, True, [], id=ID_ALL_ARCHIVED),
+        pytest.param(False, False, [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME], id=ID_NONE_ARCHIVED),
     ])
     def test_project_list(self, ci_instance, archived_a, archived_b, expected):
         """project_list must return only non-archived project names for each combination of archived flags."""
@@ -115,9 +110,9 @@ class TestCiIndexXml:
         assert set(ci_instance.project_list) == set(expected)
 
     @pytest.mark.parametrize(CI_PARAMETRIZE_FIELDS, [
-        pytest.param(False, True,  [PROJECT2_NAME],                id=ID_MIXED),
-        pytest.param(False, False, [],                             id=ID_NONE_ARCHIVED),
-        pytest.param(True,  True,  [PROJECT1_NAME, PROJECT2_NAME], id=ID_ALL_ARCHIVED),
+        pytest.param(False, True, [helpers.PROJECT2_NAME], id=ID_MIXED),
+        pytest.param(False, False, [], id=ID_NONE_ARCHIVED),
+        pytest.param(True, True, [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME], id=ID_ALL_ARCHIVED),
     ])
     def test_archived_project_list(self, ci_instance, archived_a, archived_b, expected):
         """archived_project_list must return only archived project names for each combination of archived flags."""
@@ -128,13 +123,13 @@ class TestCiIndexXml:
     def test_get_project_xml_returns_path_when_project_found(self, ci_instance):
         """When the requested project exists in _projects, get_project_xml must return its xmlPath."""
         ci_instance._projects = {
-            PROJECT1_NAME: self._make_mock_project(PROJECT1_NAME, False, PROJECT_XML_A),
+            helpers.PROJECT1_NAME: self._make_mock_project(helpers.PROJECT1_NAME, False, PROJECT_XML_A),
         }
 
-        assert ci_instance.get_project_xml(PROJECT1_NAME) == PROJECT_XML_A
+        assert ci_instance.get_project_xml(helpers.PROJECT1_NAME) == PROJECT_XML_A
 
     def test_get_project_xml_raises_value_error_when_not_found(self, ci_instance):
         """When the requested project is absent from _projects, get_project_xml must raise ValueError."""
         with pytest.raises(ValueError) as exc_info:
-            ci_instance.get_project_xml(CI_UNKNOWN_PROJECT)
-        assert str(exc_info.value) == INVALID_PROJECTNAME_ERROR.format(CI_UNKNOWN_PROJECT)
+            ci_instance.get_project_xml(helpers.UNKNOWN)
+        assert str(exc_info.value) == edk_manifest.INVALID_PROJECTNAME_ERROR.format(helpers.UNKNOWN)

--- a/edkrepo_manifest_parser/unit_tests/test_combination.py
+++ b/edkrepo_manifest_parser/unit_tests/test_combination.py
@@ -12,116 +12,98 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _Combination,
-    _parse_combination_required_attribs,
-    Combination,
-    REQUIRED_ATTRIB_ERROR_MSG,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_NAME                     = 'name'
-ATTRIB_DESCRIPTION               = 'description'
-ATTRIB_ARCHIVED                  = 'archived'
-ATTRIB_VENV_ENABLE               = 'venv_enable'
-ATTRIB_BOOL_TRUE                 = 'true'
-ATTRIB_BOOL_FALSE                = 'false'
-ARCHIVED_TRUE_UPPER              = 'TRUE'
-ELEMENT_TAG_COMBINATION          = 'Combination'
-COMBO_NAME                       = 'TestCombo'
-COMBO_DESCRIPTION                = 'A test combination'
-FIELD_NAME                       = 'name'
-FIELD_DESCRIPTION                = 'description'
-PARAM_MINIMAL_FIELD              = 'field_name, expected'
-PARAM_BOOL_FLAG                  = 'attrib_name, attrib_value, field_name, expected'
-ID_NAME_SET                      = 'name_set'
-ID_DESCRIPTION_ABSENT            = 'description_absent'
-ID_ARCHIVED_TRUE_LOWER           = 'archived_true_lower'
-ID_ARCHIVED_FALSE_LOWER          = 'archived_false_lower'
-ID_ARCHIVED_MISSING              = 'archived_missing'
-ID_ARCHIVED_TRUE_UPPER           = 'archived_true_upper'
-ID_VENV_TRUE                     = 'venv_true'
-ID_VENV_FALSE                    = 'venv_false'
-ID_VENV_MISSING                  = 'venv_missing'
+ATTRIB_VENV_ENABLE = 'venv_enable'
+ELEMENT_TAG_COMBINATION = 'edk_manifest.Combination'
+COMBO_NAME = 'TestCombo'
+COMBO_DESCRIPTION = 'A test combination'
+PARAM_MINIMAL_FIELD = 'field_name, expected'
+PARAM_BOOL_FLAG = 'attrib_name, attrib_value, field_name, expected'
+ID_NAME_SET = 'name_set'
+ID_DESCRIPTION_ABSENT = 'description_absent'
+ID_ARCHIVED_TRUE_LOWER = 'archived_true_lower'
+ID_ARCHIVED_FALSE_LOWER = 'archived_false_lower'
+ID_ARCHIVED_MISSING = 'archived_missing'
+ID_ARCHIVED_TRUE_UPPER = 'archived_true_upper'
+ID_VENV_TRUE = 'venv_true'
+ID_VENV_FALSE = 'venv_false'
+ID_VENV_MISSING = 'venv_missing'
 
 
 class TestCombination:
 
-    @staticmethod
-    def _make_required_element():
-        """Build a mock element with only the required name attribute."""
-        return make_mock_element({ATTRIB_NAME: COMBO_NAME}, tag=ELEMENT_TAG_COMBINATION)
+    @pytest.fixture
+    def required_element(self):
+        """Return a fresh mock element with only the required name attribute."""
+        return helpers.make_mock_element({helpers.ATTRIB_NAME: COMBO_NAME}, tag=ELEMENT_TAG_COMBINATION)
 
-    def test_parse_required_attribs_returns_name_when_present(self):
-        """When name is present, _parse_combination_required_attribs must return the name string."""
-        element = self._make_required_element()
-
-        name = _parse_combination_required_attribs(element)
+    def test_parse_required_attribs_returns_name_when_present(self, required_element):
+        """When name is present, edk_manifest._parse_combination_required_attribs must return the name string."""
+        name = edk_manifest._parse_combination_required_attribs(required_element)
 
         assert name == COMBO_NAME
 
     def test_parse_required_attribs_raises_key_error_when_name_missing(self):
-        """When name is absent, _parse_combination_required_attribs must raise KeyError with the required-attrib message."""
-        element = make_mock_element({}, tag=ELEMENT_TAG_COMBINATION)
+        """When name is absent, edk_manifest._parse_combination_required_attribs must raise KeyError with the required-attrib message."""
+        element = helpers.make_mock_element({}, tag=ELEMENT_TAG_COMBINATION)
 
         with pytest.raises(KeyError) as exc_info:
-            _parse_combination_required_attribs(element)
+            edk_manifest._parse_combination_required_attribs(element)
 
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     @pytest.mark.parametrize(PARAM_MINIMAL_FIELD, [
-        pytest.param(FIELD_NAME,        COMBO_NAME, id=ID_NAME_SET),
-        pytest.param(FIELD_DESCRIPTION, None,       id=ID_DESCRIPTION_ABSENT),
+        pytest.param(helpers.ATTRIB_NAME, COMBO_NAME, id=ID_NAME_SET),
+        pytest.param(helpers.ATTRIB_DESCRIPTION, None, id=ID_DESCRIPTION_ABSENT),
     ])
-    def test_init_sets_field_on_minimal_element(self, field_name, expected):
+    def test_init_sets_field_on_minimal_element(self, required_element, field_name, expected):
         """On an element with only the required name attribute, each field must equal the expected value after __init__."""
-        combo = _Combination(self._make_required_element())
+        combo = edk_manifest._Combination(required_element)
         assert getattr(combo, field_name) == expected
 
     def test_init_sets_description_when_present(self):
         """When the description attribute is present, __init__ must set self.description to its value."""
-        element = make_mock_element({
-            ATTRIB_NAME: COMBO_NAME,
-            ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_NAME: COMBO_NAME,
+            helpers.ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
         }, tag=ELEMENT_TAG_COMBINATION)
 
-        combo = _Combination(element)
+        combo = edk_manifest._Combination(element)
 
         assert combo.description == COMBO_DESCRIPTION
 
     @pytest.mark.parametrize(PARAM_BOOL_FLAG, [
-        pytest.param(ATTRIB_ARCHIVED,    ATTRIB_BOOL_TRUE,    ATTRIB_ARCHIVED,    True,  id=ID_ARCHIVED_TRUE_LOWER),
-        pytest.param(ATTRIB_ARCHIVED,    ATTRIB_BOOL_FALSE,   ATTRIB_ARCHIVED,    False, id=ID_ARCHIVED_FALSE_LOWER),
-        pytest.param(ATTRIB_ARCHIVED,    None,                ATTRIB_ARCHIVED,    False, id=ID_ARCHIVED_MISSING),
-        pytest.param(ATTRIB_ARCHIVED,    ARCHIVED_TRUE_UPPER, ATTRIB_ARCHIVED,    True,  id=ID_ARCHIVED_TRUE_UPPER),
-        pytest.param(ATTRIB_VENV_ENABLE, ATTRIB_BOOL_TRUE,    ATTRIB_VENV_ENABLE, True,  id=ID_VENV_TRUE),
-        pytest.param(ATTRIB_VENV_ENABLE, ATTRIB_BOOL_FALSE,   ATTRIB_VENV_ENABLE, False, id=ID_VENV_FALSE),
-        pytest.param(ATTRIB_VENV_ENABLE, None,                ATTRIB_VENV_ENABLE, False, id=ID_VENV_MISSING),
+        pytest.param(helpers.ATTRIB_ARCHIVED, helpers.ATTRIB_BOOL_TRUE, helpers.ATTRIB_ARCHIVED, True, id=ID_ARCHIVED_TRUE_LOWER),
+        pytest.param(helpers.ATTRIB_ARCHIVED, helpers.ATTRIB_BOOL_FALSE, helpers.ATTRIB_ARCHIVED, False, id=ID_ARCHIVED_FALSE_LOWER),
+        pytest.param(helpers.ATTRIB_ARCHIVED, None, helpers.ATTRIB_ARCHIVED, False, id=ID_ARCHIVED_MISSING),
+        pytest.param(helpers.ATTRIB_ARCHIVED, helpers.ARCHIVED_TRUE_UPPER, helpers.ATTRIB_ARCHIVED, True, id=ID_ARCHIVED_TRUE_UPPER),
+        pytest.param(ATTRIB_VENV_ENABLE, helpers.ATTRIB_BOOL_TRUE, ATTRIB_VENV_ENABLE, True, id=ID_VENV_TRUE),
+        pytest.param(ATTRIB_VENV_ENABLE, helpers.ATTRIB_BOOL_FALSE, ATTRIB_VENV_ENABLE, False, id=ID_VENV_FALSE),
+        pytest.param(ATTRIB_VENV_ENABLE, None, ATTRIB_VENV_ENABLE, False, id=ID_VENV_MISSING),
     ])
     def test_init_sets_bool_flag(self, attrib_name, attrib_value, field_name, expected):
         """Each combination of attrib_name/attrib_value must produce the expected boolean on the named field."""
-        attrib = {ATTRIB_NAME: COMBO_NAME}
+        attrib = {helpers.ATTRIB_NAME: COMBO_NAME}
         if attrib_value is not None:
             attrib[attrib_name] = attrib_value
-        element = make_mock_element(attrib, tag=ELEMENT_TAG_COMBINATION)
-        combo = _Combination(element)
+        element = helpers.make_mock_element(attrib, tag=ELEMENT_TAG_COMBINATION)
+        combo = edk_manifest._Combination(element)
         assert getattr(combo, field_name) is expected
 
     def test_tuple_returns_correct_combination_namedtuple(self):
-        """The tuple property must return a Combination namedtuple with name, description, and venv_enable."""
-        element = make_mock_element({
-            ATTRIB_NAME: COMBO_NAME,
-            ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
-            ATTRIB_VENV_ENABLE: ATTRIB_BOOL_TRUE,
+        """The tuple property must return a edk_manifest.Combination namedtuple with name, description, and venv_enable."""
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_NAME: COMBO_NAME,
+            helpers.ATTRIB_DESCRIPTION: COMBO_DESCRIPTION,
+            ATTRIB_VENV_ENABLE: helpers.ATTRIB_BOOL_TRUE,
         }, tag=ELEMENT_TAG_COMBINATION)
-        combo = _Combination(element)
+        combo = edk_manifest._Combination(element)
 
         result = combo.tuple
 
-        assert result == Combination(
+        assert result == edk_manifest.Combination(
             name=COMBO_NAME,
             description=COMBO_DESCRIPTION,
             venv_enable=True,

--- a/edkrepo_manifest_parser/unit_tests/test_edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/unit_tests/test_edk_manifest_validation.py
@@ -13,46 +13,32 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.edk_manifest_validation import (
-    _collect_file_validation_results,
-    _resolve_project_manifest_path,
-    _collect_project_validation_results,
-    validate_manifestfiles,
-    validate_manifestrepo,
-    get_manifest_validation_status,
-    print_manifest_errors,
-)
-from edkrepo.common.humble import VERIFY_ERROR_HEADER
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest_validation as emv
+import edkrepo.common.humble as humble
 
-MANIFEST_PATH            = '/fake/path/manifest.xml'
-MANIFEST_PATH_2          = '/fake/path/manifest2.xml'
-MANIFEST_DIR             = '/fake/manifest/dir'
-CI_INDEX_PATH            = '/fake/manifest/dir/CiIndex.xml'
-PROJECT_XML_RELATIVE     = 'ProjectA/ProjectA.xml'
-PROJECT_A                = 'ProjectA'
-PROJECT_B                = 'ProjectB'
-PROJECT_LIST             = [PROJECT_A, PROJECT_B]
-BAD_XML_MSG              = 'bad xml'
-CANNOT_PROCESS_MSG       = 'Cannot process codename validation'
-RESULT_PARSING           = 'PARSING'
-RESULT_CODENAME          = 'CODENAME'
-RESULT_DUPLICATE         = 'DUPLICATE'
-PARSE_PASS               = (RESULT_PARSING, True, None)
-PARSE_FAIL               = (RESULT_PARSING, False, BAD_XML_MSG)
-CODENAME_PASS            = (RESULT_CODENAME, True, None)
-DUPLICATE_PASS           = (RESULT_DUPLICATE, True, None)
-CODENAME_HARDCODED_FAIL  = (RESULT_CODENAME, False, CANNOT_PROCESS_MSG)
-FILE_RESULTS             = [PARSE_PASS, CODENAME_PASS]
-FAILURE_RESULTS          = [PARSE_FAIL, CODENAME_PASS]
-PROJECT_RESULTS          = [PARSE_PASS, CODENAME_PASS, DUPLICATE_PASS]
-FILE_NAME_FMT            = 'File name: {} '
-ERROR_TYPE_FMT           = 'Error type: {} '
-ERROR_MSG_FMT            = 'Error message: {} \n'
+MANIFEST_PATH_2 = '/fake/path/manifest2.xml'
+MANIFEST_DIR = '/fake/manifest/dir'
+CI_INDEX_PATH = '/fake/manifest/dir/CiIndex.xml'
+PROJECT_XML_RELATIVE = 'ProjectA/ProjectA.xml'
+PROJECT_LIST = [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME]
+CANNOT_PROCESS_MSG = 'Cannot process codename validation'
+PARSE_PASS = (helpers.RESULT_PARSING, True, None)
+PARSE_FAIL = (helpers.RESULT_PARSING, False, helpers.BAD_XML_MSG)
+CODENAME_PASS = (helpers.RESULT_CODENAME, True, None)
+DUPLICATE_PASS = (helpers.RESULT_DUPLICATE, True, None)
+CODENAME_HARDCODED_FAIL = (helpers.RESULT_CODENAME, False, CANNOT_PROCESS_MSG)
+FILE_RESULTS = [PARSE_PASS, CODENAME_PASS]
+FAILURE_RESULTS = [PARSE_FAIL, CODENAME_PASS]
+PROJECT_RESULTS = [PARSE_PASS, CODENAME_PASS, DUPLICATE_PASS]
+FILE_NAME_FMT = 'File name: {} '
+ERROR_TYPE_FMT = 'Error type: {} '
+ERROR_MSG_FMT = 'Error message: {} \n'
 
-VALIDATION_STATUS_FIELDS   = 'data, expected'
-ID_ALL_PASS                = 'all_pass'
-ID_ONE_FAIL                = 'one_fail'
-ID_EMPTY_DICT              = 'empty_dict'
+VALIDATION_STATUS_FIELDS = 'data, expected'
+ID_ALL_PASS = 'all_pass'
+ID_ONE_FAIL = 'one_fail'
+ID_EMPTY_DICT = 'empty_dict'
 
 
 class TestEdkManifestValidation:
@@ -65,7 +51,7 @@ class TestEdkManifestValidation:
 
     @pytest.fixture
     def mock_collect_file_results(self):
-        """Patch _collect_file_validation_results for the duration of a test; yields the mock for per-test configuration."""
+        """Patch emv._collect_file_validation_results for the duration of a test; yields the mock for per-test configuration."""
         with patch('edkrepo_manifest_parser.edk_manifest_validation._collect_file_validation_results') as mock:
             yield mock
 
@@ -77,13 +63,13 @@ class TestEdkManifestValidation:
 
     @pytest.fixture
     def mock_resolve_path(self):
-        """Patch _resolve_project_manifest_path for the duration of a test; yields the mock for per-test configuration."""
+        """Patch emv._resolve_project_manifest_path for the duration of a test; yields the mock for per-test configuration."""
         with patch('edkrepo_manifest_parser.edk_manifest_validation._resolve_project_manifest_path') as mock:
             yield mock
 
     @pytest.fixture
     def mock_collect_project_results(self):
-        """Patch _collect_project_validation_results for the duration of a test; yields the mock for per-test configuration."""
+        """Patch emv._collect_project_validation_results for the duration of a test; yields the mock for per-test configuration."""
         with patch('edkrepo_manifest_parser.edk_manifest_validation._collect_project_validation_results') as mock:
             yield mock
 
@@ -120,40 +106,40 @@ class TestEdkManifestValidation:
 
     @staticmethod
     def _call_collect_project_results(mock_validate_manifest, parse_result):
-        """Set up the ValidateManifest mock, invoke _collect_project_validation_results, assert three results, and return (mock_vm, result)."""
+        """Set up the ValidateManifest mock, invoke emv._collect_project_validation_results, assert three results, and return (mock_vm, result)."""
         mock_vm = TestEdkManifestValidation._make_mock_project_validator(mock_validate_manifest, parse_result)
-        result = _collect_project_validation_results(MANIFEST_PATH, PROJECT_A, PROJECT_LIST, CI_INDEX_PATH)
+        result = emv._collect_project_validation_results(helpers.MANIFEST_FILE_PATH, helpers.PROJECT1_NAME, PROJECT_LIST, CI_INDEX_PATH)
         assert len(result) == 3
         return mock_vm, result
 
     @staticmethod
     def _setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results):
         """Configure CiIndexXml with one active and one archived project and set collect-project mock to return PROJECT_RESULTS."""
-        TestEdkManifestValidation._make_mock_ci_index(mock_ci_index_cls, [PROJECT_A], [PROJECT_B])
+        TestEdkManifestValidation._make_mock_ci_index(mock_ci_index_cls, [helpers.PROJECT1_NAME], [helpers.PROJECT2_NAME])
         mock_collect_project_results.return_value = PROJECT_RESULTS
 
     @staticmethod
     def _call_print_errors(results):
-        """Build a single-entry validation dict keyed by MANIFEST_PATH and invoke print_manifest_errors."""
-        print_manifest_errors({MANIFEST_PATH: results})
+        """Build a single-entry validation dict keyed by MANIFEST_PATH and invoke emv.print_manifest_errors."""
+        emv.print_manifest_errors({helpers.MANIFEST_FILE_PATH: results})
 
     def test_collect_file_validation_results_parsing_succeeds_codename_included(self, mock_validate_manifest):
         """When parsing succeeds and _manifest_xmldata is populated, validate_codename is called and its result is appended."""
         xmldata = MagicMock()
-        xmldata.project_info.codename = PROJECT_A
+        xmldata.project_info.codename = helpers.PROJECT1_NAME
         mock_vm = self._setup_file_validator_mock(mock_validate_manifest, PARSE_PASS, xmldata)
         mock_vm.validate_codename.return_value = CODENAME_PASS
 
-        result = _collect_file_validation_results(MANIFEST_PATH)
+        result = emv._collect_file_validation_results(helpers.MANIFEST_FILE_PATH)
 
         assert result == [PARSE_PASS, CODENAME_PASS]
-        mock_vm.validate_codename.assert_called_once_with(PROJECT_A)
+        mock_vm.validate_codename.assert_called_once_with(helpers.PROJECT1_NAME)
 
     def test_collect_file_validation_results_parsing_fails_hardcoded_codename_error(self, mock_validate_manifest):
         """When parsing fails and _manifest_xmldata is None, a hardcoded CODENAME failure tuple is appended without calling validate_codename."""
         mock_vm = self._setup_file_validator_mock(mock_validate_manifest, PARSE_FAIL, None)
 
-        result = _collect_file_validation_results(MANIFEST_PATH)
+        result = emv._collect_file_validation_results(helpers.MANIFEST_FILE_PATH)
 
         assert result == [PARSE_FAIL, CODENAME_HARDCODED_FAIL]
         mock_vm.validate_codename.assert_not_called()
@@ -163,17 +149,17 @@ class TestEdkManifestValidation:
         mock_ci_index = MagicMock()
         mock_ci_index.get_project_xml.return_value = PROJECT_XML_RELATIVE
 
-        result = _resolve_project_manifest_path(mock_ci_index, MANIFEST_DIR, PROJECT_A)
+        result = emv._resolve_project_manifest_path(mock_ci_index, MANIFEST_DIR, helpers.PROJECT1_NAME)
 
         expected = os.path.join(MANIFEST_DIR, os.path.normpath(PROJECT_XML_RELATIVE))
         assert result == expected
-        mock_ci_index.get_project_xml.assert_called_once_with(PROJECT_A)
+        mock_ci_index.get_project_xml.assert_called_once_with(helpers.PROJECT1_NAME)
 
     def test_collect_project_validation_results_all_validations_pass(self, mock_validate_manifest):
         """When all three ValidateManifest methods return passing tuples, the result contains exactly three passing entries."""
         _, result = self._call_collect_project_results(mock_validate_manifest, PARSE_PASS)
 
-        assert result[2][0] == RESULT_DUPLICATE
+        assert result[2][0] == helpers.RESULT_DUPLICATE
         assert all(entry[1] is True for entry in result)
 
     def test_collect_project_validation_results_parsing_fails_three_results_returned(self, mock_validate_manifest):
@@ -181,81 +167,81 @@ class TestEdkManifestValidation:
         mock_vm, result = self._call_collect_project_results(mock_validate_manifest, PARSE_FAIL)
 
         assert result[0][1] is False
-        mock_vm.validate_codename.assert_called_once_with(PROJECT_A)
+        mock_vm.validate_codename.assert_called_once_with(helpers.PROJECT1_NAME)
         mock_vm.validate_case_insensitive_single_match.assert_called_once_with(
-            PROJECT_A, PROJECT_LIST, CI_INDEX_PATH
+            helpers.PROJECT1_NAME, PROJECT_LIST, CI_INDEX_PATH
         )
 
     def test_validate_manifestfiles_empty_list_returns_empty_dict(self):
         """When called with an empty list, returns an empty dictionary without invoking any helper."""
-        result = validate_manifestfiles([])
+        result = emv.validate_manifestfiles([])
         assert result == {}
 
     def test_validate_manifestfiles_single_manifest_calls_helper_once(self, mock_collect_file_results):
-        """When the list contains one path, _collect_file_validation_results is called once and the result is keyed by that path."""
+        """When the list contains one path, emv._collect_file_validation_results is called once and the result is keyed by that path."""
         mock_collect_file_results.return_value = FILE_RESULTS
 
-        result = validate_manifestfiles([MANIFEST_PATH])
+        result = emv.validate_manifestfiles([helpers.MANIFEST_FILE_PATH])
 
-        mock_collect_file_results.assert_called_once_with(MANIFEST_PATH)
-        assert result == {MANIFEST_PATH: FILE_RESULTS}
+        mock_collect_file_results.assert_called_once_with(helpers.MANIFEST_FILE_PATH)
+        assert result == {helpers.MANIFEST_FILE_PATH: FILE_RESULTS}
 
     def test_validate_manifestfiles_multiple_manifests_calls_helper_for_each(self, mock_collect_file_results):
-        """When the list contains two paths, _collect_file_validation_results is called once per path and both results are mapped correctly."""
+        """When the list contains two paths, emv._collect_file_validation_results is called once per path and both results are mapped correctly."""
         results_a = FILE_RESULTS
         results_b = [PARSE_FAIL, CODENAME_HARDCODED_FAIL]
         mock_collect_file_results.side_effect = [results_a, results_b]
 
-        result = validate_manifestfiles([MANIFEST_PATH, MANIFEST_PATH_2])
+        result = emv.validate_manifestfiles([helpers.MANIFEST_FILE_PATH, MANIFEST_PATH_2])
 
         assert mock_collect_file_results.call_count == 2
-        mock_collect_file_results.assert_any_call(MANIFEST_PATH)
+        mock_collect_file_results.assert_any_call(helpers.MANIFEST_FILE_PATH)
         mock_collect_file_results.assert_any_call(MANIFEST_PATH_2)
-        assert result == {MANIFEST_PATH: results_a, MANIFEST_PATH_2: results_b}
+        assert result == {helpers.MANIFEST_FILE_PATH: results_a, MANIFEST_PATH_2: results_b}
 
     def test_validate_manifestrepo_without_archived_only_active_projects_processed(
             self, mock_ci_index_cls, mock_resolve_path, mock_collect_project_results):
         """When verify_archived=False, only active projects are iterated and the dict contains exactly one entry."""
         self._setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results)
-        mock_resolve_path.return_value = MANIFEST_PATH
+        mock_resolve_path.return_value = helpers.MANIFEST_FILE_PATH
 
-        result = validate_manifestrepo(MANIFEST_DIR, verify_archived=False)
+        result = emv.validate_manifestrepo(MANIFEST_DIR, verify_archived=False)
 
         mock_collect_project_results.assert_called_once()
-        assert list(result.keys()) == [MANIFEST_PATH]
+        assert list(result.keys()) == [helpers.MANIFEST_FILE_PATH]
 
     def test_validate_manifestrepo_with_archived_active_and_archived_processed(
             self, mock_ci_index_cls, mock_resolve_path, mock_collect_project_results):
         """When verify_archived=True, both active and archived projects are iterated and the dict contains two entries."""
         self._setup_manifestrepo_mocks(mock_ci_index_cls, mock_collect_project_results)
-        mock_resolve_path.side_effect = [MANIFEST_PATH, MANIFEST_PATH_2]
+        mock_resolve_path.side_effect = [helpers.MANIFEST_FILE_PATH, MANIFEST_PATH_2]
 
-        result = validate_manifestrepo(MANIFEST_DIR, verify_archived=True)
+        result = emv.validate_manifestrepo(MANIFEST_DIR, verify_archived=True)
 
         assert mock_collect_project_results.call_count == 2
-        assert set(result.keys()) == {MANIFEST_PATH, MANIFEST_PATH_2}
+        assert set(result.keys()) == {helpers.MANIFEST_FILE_PATH, MANIFEST_PATH_2}
 
     @pytest.mark.parametrize(VALIDATION_STATUS_FIELDS, [
-        pytest.param({MANIFEST_PATH: FILE_RESULTS},    False, id=ID_ALL_PASS),
-        pytest.param({MANIFEST_PATH: FAILURE_RESULTS}, True,  id=ID_ONE_FAIL),
-        pytest.param({},                               False, id=ID_EMPTY_DICT),
+        pytest.param({helpers.MANIFEST_FILE_PATH: FILE_RESULTS}, False, id=ID_ALL_PASS),
+        pytest.param({helpers.MANIFEST_FILE_PATH: FAILURE_RESULTS}, True, id=ID_ONE_FAIL),
+        pytest.param({}, False, id=ID_EMPTY_DICT),
     ])
     def test_get_manifest_validation_status(self, data, expected):
         """Verify all manifests in the dict; parametrized over all-pass, one-fail, and empty-dict scenarios."""
-        assert get_manifest_validation_status(data) is expected
+        assert emv.get_manifest_validation_status(data) is expected
 
     def test_print_manifest_errors_prints_header_and_details_for_failures(self, mock_print):
         """When the dict contains a failing result, VERIFY_ERROR_HEADER and the file/type/message lines are all printed."""
         self._call_print_errors(FAILURE_RESULTS)
 
-        mock_print.assert_any_call(VERIFY_ERROR_HEADER)
-        mock_print.assert_any_call(FILE_NAME_FMT.format(MANIFEST_PATH))
-        mock_print.assert_any_call(ERROR_TYPE_FMT.format(RESULT_PARSING))
-        mock_print.assert_any_call(ERROR_MSG_FMT.format(BAD_XML_MSG))
+        mock_print.assert_any_call(humble.VERIFY_ERROR_HEADER)
+        mock_print.assert_any_call(FILE_NAME_FMT.format(helpers.MANIFEST_FILE_PATH))
+        mock_print.assert_any_call(ERROR_TYPE_FMT.format(helpers.RESULT_PARSING))
+        mock_print.assert_any_call(ERROR_MSG_FMT.format(helpers.BAD_XML_MSG))
         assert mock_print.call_count == 4
 
     def test_print_manifest_errors_all_passing_only_header_printed(self, mock_print):
         """When all results are passing, only VERIFY_ERROR_HEADER is printed and no error detail lines follow."""
         self._call_print_errors(FILE_RESULTS)
 
-        mock_print.assert_called_once_with(VERIFY_ERROR_HEADER)
+        mock_print.assert_called_once_with(humble.VERIFY_ERROR_HEADER)

--- a/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping.py
+++ b/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping.py
@@ -12,33 +12,16 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_iter,
-    make_empty_element,
-    REMOTE_NAME,
-    PROJECT1_NAME,
-    PROJECT2_NAME,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _FolderToFolderMapping,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_PROJECT1             = 'project1'
-ATTRIB_PROJECT2             = 'project2'
-ATTRIB_REMOTE               = 'remote'
-TAG_EXCLUDE                 = 'Exclude'
-TAG_FOLDER                  = 'Folder'
-TAG_FILE                    = 'File'
-FIELD_REMOTE_NAME           = 'remote_name'
-PROJECT1_FOLDER             = 'project1/path'
-PROJECT2_FOLDER             = 'project2/path'
-PARAM_OPTIONAL_ATTRIB       = 'attrib_key, attrib_value, field_name'
-ID_PROJECT1_PRESENT         = 'project1_present'
-ID_PROJECT2_PRESENT         = 'project2_present'
-ID_REMOTE_NAME_PRESENT      = 'remote_name_present'
-PARAM_CHILD_SLOT            = 'folder_children_count, file_children_count'
-ID_FOLDER_CHILD             = 'folder_child'
-ID_FILE_CHILD               = 'file_child'
+TAG_FOLDER = 'Folder'
+TAG_FILE = 'File'
+ID_PROJECT1_PRESENT = 'project1_present'
+ID_PROJECT2_PRESENT = 'project2_present'
+PARAM_CHILD_SLOT = 'folder_children_count, file_children_count'
+ID_FOLDER_CHILD = 'folder_child'
+ID_FILE_CHILD = 'file_child'
 
 
 class TestFolderToFolderMapping:
@@ -48,38 +31,38 @@ class TestFolderToFolderMapping:
         """Build a mock element suitable for use as a Folder/File child with optional project attribs and no Exclude children."""
         attrib = {}
         if project1 is not None:
-            attrib[ATTRIB_PROJECT1] = project1
+            attrib[helpers.ATTRIB_PROJECT1] = project1
         if project2 is not None:
-            attrib[ATTRIB_PROJECT2] = project2
-        return make_mock_element_with_iter(attrib, {TAG_EXCLUDE: []})
+            attrib[helpers.ATTRIB_PROJECT2] = project2
+        return helpers.make_mock_element_with_iter(attrib, {helpers.TAG_EXCLUDE: []})
 
     @staticmethod
     def _build_mapping_from_children(folder_children, file_children):
         """Build a _FolderToFolderMapping from explicit Folder and File child lists."""
-        element = make_mock_element_with_iter(
+        element = helpers.make_mock_element_with_iter(
             {},
             {TAG_FOLDER: folder_children, TAG_FILE: file_children},
         )
-        return _FolderToFolderMapping(element)
+        return edk_manifest._FolderToFolderMapping(element)
 
     def test_all_fields_default_when_absent(self):
         """When all optional attributes and child elements are absent, __init__ must apply all defaults."""
-        mapping = _FolderToFolderMapping(make_empty_element())
+        mapping = edk_manifest._FolderToFolderMapping(helpers.make_empty_element())
 
         assert mapping.project1 is None
         assert mapping.project2 is None
         assert mapping.remote_name is None
         assert mapping.folders == []
 
-    @pytest.mark.parametrize(PARAM_OPTIONAL_ATTRIB, [
-        pytest.param(ATTRIB_PROJECT1, PROJECT1_NAME, ATTRIB_PROJECT1, id=ID_PROJECT1_PRESENT),
-        pytest.param(ATTRIB_PROJECT2, PROJECT2_NAME, ATTRIB_PROJECT2, id=ID_PROJECT2_PRESENT),
-        pytest.param(ATTRIB_REMOTE,   REMOTE_NAME,   FIELD_REMOTE_NAME, id=ID_REMOTE_NAME_PRESENT),
+    @pytest.mark.parametrize(helpers.PARAM_ATTRIB_VALUE_FIELD, [
+        pytest.param(helpers.ATTRIB_PROJECT1, helpers.PROJECT1_NAME, helpers.ATTRIB_PROJECT1, id=ID_PROJECT1_PRESENT),
+        pytest.param(helpers.ATTRIB_PROJECT2, helpers.PROJECT2_NAME, helpers.ATTRIB_PROJECT2, id=ID_PROJECT2_PRESENT),
+        pytest.param(helpers.ATTRIB_REMOTE, helpers.REMOTE_NAME, helpers.FIELD_REMOTE_NAME, id=helpers.ID_REMOTE_NAME_PRESENT),
     ])
     def test_init_sets_optional_attrib_when_present(self, attrib_key, attrib_value, field_name):
         """When an optional attribute is present, __init__ must set the corresponding field to its value."""
-        element = make_mock_element_with_iter({attrib_key: attrib_value})
-        mapping = _FolderToFolderMapping(element)
+        element = helpers.make_mock_element_with_iter({attrib_key: attrib_value})
+        mapping = edk_manifest._FolderToFolderMapping(element)
         assert getattr(mapping, field_name) == attrib_value
 
     @pytest.mark.parametrize(PARAM_CHILD_SLOT, [
@@ -88,35 +71,34 @@ class TestFolderToFolderMapping:
     ])
     def test_init_populates_folders_from_single_child_tag(self, folder_children_count, file_children_count):
         """When one child element is present under either the Folder or File tag, __init__ must add one _FolderToFolderMappingFolder with the correct project folder values."""
-        child = self._make_folder_child_element(PROJECT1_FOLDER, PROJECT2_FOLDER)
+        child = self._make_folder_child_element(helpers.PROJECT1_FOLDER, helpers.PROJECT2_FOLDER)
         mapping = self._build_mapping_from_children(
             [child] * folder_children_count,
             [child] * file_children_count,
         )
 
         assert len(mapping.folders) == 1
-        assert mapping.folders[0].project1_folder == PROJECT1_FOLDER
-        assert mapping.folders[0].project2_folder == PROJECT2_FOLDER
+        assert mapping.folders[0].project1_folder == helpers.PROJECT1_FOLDER
+        assert mapping.folders[0].project2_folder == helpers.PROJECT2_FOLDER
 
     def test_init_combines_folder_and_file_children(self):
         """When both Folder and File children are present, __init__ must create entries for all of them."""
-        folder_child = self._make_folder_child_element(PROJECT1_FOLDER)
-        file_child = self._make_folder_child_element(PROJECT2_FOLDER)
+        folder_child = self._make_folder_child_element(helpers.PROJECT1_FOLDER)
+        file_child = self._make_folder_child_element(helpers.PROJECT2_FOLDER)
         mapping = self._build_mapping_from_children([folder_child], [file_child])
 
         assert len(mapping.folders) == 2
 
     def test_tuple_returns_correct_folder_to_folder_mapping_namedtuple(self):
         """The tuple property must return a FolderToFolderMapping namedtuple with all field values correct."""
-        folder_child = self._make_folder_child_element(PROJECT1_FOLDER, PROJECT2_FOLDER)
-        element = make_mock_element_with_iter(
-            {ATTRIB_PROJECT1: PROJECT1_NAME, ATTRIB_PROJECT2: PROJECT2_NAME, ATTRIB_REMOTE: REMOTE_NAME},
+        folder_child = self._make_folder_child_element(helpers.PROJECT1_FOLDER, helpers.PROJECT2_FOLDER)
+        element = helpers.make_mock_element_with_iter(
+            {helpers.ATTRIB_PROJECT1: helpers.PROJECT1_NAME, helpers.ATTRIB_PROJECT2: helpers.PROJECT2_NAME, helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME},
             {TAG_FOLDER: [folder_child], TAG_FILE: []},
         )
-        result = _FolderToFolderMapping(element).tuple
+        result = edk_manifest._FolderToFolderMapping(element).tuple
 
-        assert result.project1 == PROJECT1_NAME
-        assert result.project2 == PROJECT2_NAME
-        assert result.remote_name == REMOTE_NAME
+        assert result.project1 == helpers.PROJECT1_NAME
+        assert result.project2 == helpers.PROJECT2_NAME
+        assert result.remote_name == helpers.REMOTE_NAME
         assert len(result.folders) == 1
-

--- a/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder.py
+++ b/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder.py
@@ -12,71 +12,57 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_iter,
-    make_empty_element,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _FolderToFolderMappingFolder,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_PATH                 = 'path'
-ATTRIB_PROJECT1             = 'project1'
-ATTRIB_PROJECT2             = 'project2'
-TAG_EXCLUDE                 = 'Exclude'
-FIELD_PROJECT1_FOLDER       = 'project1_folder'
-FIELD_PROJECT2_FOLDER       = 'project2_folder'
-PROJECT1_FOLDER             = 'project1/path'
-PROJECT2_FOLDER             = 'project2/path'
-EXCLUDE_PATH                = 'exclude/some/path'
-PARAM_PROJECT_FOLDER        = 'attrib_key, attrib_value, field_name'
-ID_PROJECT1_FOLDER_PRESENT  = 'project1_folder_present'
-ID_PROJECT2_FOLDER_PRESENT  = 'project2_folder_present'
+FIELD_PROJECT1_FOLDER = 'project1_folder'
+FIELD_PROJECT2_FOLDER = 'project2_folder'
+ID_PROJECT1_FOLDER_PRESENT = 'project1_folder_present'
+ID_PROJECT2_FOLDER_PRESENT = 'project2_folder_present'
 
 
 class TestFolderToFolderMappingFolder:
 
     def test_all_fields_default_when_absent(self):
         """When all optional attributes and child elements are absent, __init__ must apply all defaults."""
-        folder = _FolderToFolderMappingFolder(make_empty_element())
+        folder = edk_manifest._FolderToFolderMappingFolder(helpers.make_empty_element())
 
         assert folder.project1_folder is None
         assert folder.project2_folder is None
         assert folder.excludes == []
 
-    @pytest.mark.parametrize(PARAM_PROJECT_FOLDER, [
-        pytest.param(ATTRIB_PROJECT1, PROJECT1_FOLDER, FIELD_PROJECT1_FOLDER, id=ID_PROJECT1_FOLDER_PRESENT),
-        pytest.param(ATTRIB_PROJECT2, PROJECT2_FOLDER, FIELD_PROJECT2_FOLDER, id=ID_PROJECT2_FOLDER_PRESENT),
+    @pytest.mark.parametrize(helpers.PARAM_ATTRIB_VALUE_FIELD, [
+        pytest.param(helpers.ATTRIB_PROJECT1, helpers.PROJECT1_FOLDER, FIELD_PROJECT1_FOLDER, id=ID_PROJECT1_FOLDER_PRESENT),
+        pytest.param(helpers.ATTRIB_PROJECT2, helpers.PROJECT2_FOLDER, FIELD_PROJECT2_FOLDER, id=ID_PROJECT2_FOLDER_PRESENT),
     ])
     def test_init_sets_project_folder_when_present(self, attrib_key, attrib_value, field_name):
         """When a project folder attribute is present, __init__ must set the corresponding field to its value."""
-        element = make_mock_element_with_iter(
+        element = helpers.make_mock_element_with_iter(
             {attrib_key: attrib_value},
-            {TAG_EXCLUDE: []},
+            {helpers.TAG_EXCLUDE: []},
         )
-        folder = _FolderToFolderMappingFolder(element)
+        folder = edk_manifest._FolderToFolderMappingFolder(element)
         assert getattr(folder, field_name) == attrib_value
 
     def test_init_populates_excludes_from_exclude_children(self):
         """When Exclude children are present, __init__ must create a _FolderToFolderMappingFolderExclude for each."""
-        exclude_elem = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
-        element = make_mock_element_with_iter({}, {TAG_EXCLUDE: [exclude_elem]})
-        folder = _FolderToFolderMappingFolder(element)
+        exclude_elem = helpers.make_mock_element_with_iter({helpers.ATTRIB_PATH: helpers.EXCLUDE_PATH})
+        element = helpers.make_mock_element_with_iter({}, {helpers.TAG_EXCLUDE: [exclude_elem]})
+        folder = edk_manifest._FolderToFolderMappingFolder(element)
 
         assert len(folder.excludes) == 1
-        assert folder.excludes[0].path == EXCLUDE_PATH
+        assert folder.excludes[0].path == helpers.EXCLUDE_PATH
 
     def test_tuple_returns_correct_folder_to_folder_mapping_folder_namedtuple(self):
         """The tuple property must return a FolderToFolderMappingFolder namedtuple with all field values correct."""
-        exclude_elem = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
-        element = make_mock_element_with_iter(
-            {ATTRIB_PROJECT1: PROJECT1_FOLDER, ATTRIB_PROJECT2: PROJECT2_FOLDER},
-            {TAG_EXCLUDE: [exclude_elem]},
+        exclude_elem = helpers.make_mock_element_with_iter({helpers.ATTRIB_PATH: helpers.EXCLUDE_PATH})
+        element = helpers.make_mock_element_with_iter(
+            {helpers.ATTRIB_PROJECT1: helpers.PROJECT1_FOLDER, helpers.ATTRIB_PROJECT2: helpers.PROJECT2_FOLDER},
+            {helpers.TAG_EXCLUDE: [exclude_elem]},
         )
-        result = _FolderToFolderMappingFolder(element).tuple
+        result = edk_manifest._FolderToFolderMappingFolder(element).tuple
 
-        assert result.project1_folder == PROJECT1_FOLDER
-        assert result.project2_folder == PROJECT2_FOLDER
+        assert result.project1_folder == helpers.PROJECT1_FOLDER
+        assert result.project2_folder == helpers.PROJECT2_FOLDER
         assert len(result.excludes) == 1
-        assert result.excludes[0].path == EXCLUDE_PATH
-
+        assert result.excludes[0].path == helpers.EXCLUDE_PATH

--- a/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder_exclude.py
+++ b/edkrepo_manifest_parser/unit_tests/test_folder_to_folder_mapping_folder_exclude.py
@@ -12,17 +12,8 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_iter,
-    make_empty_element,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _FolderToFolderMappingFolderExclude,
-    FolderToFolderMappingFolderExclude,
-)
-
-ATTRIB_PATH  = 'path'
-EXCLUDE_PATH = 'exclude/some/path'
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
 
 class TestFolderToFolderMappingFolderExclude:
@@ -30,20 +21,19 @@ class TestFolderToFolderMappingFolderExclude:
     @pytest.fixture
     def full_folder_exclude(self):
         """Return a _FolderToFolderMappingFolderExclude built from an element with EXCLUDE_PATH set."""
-        element = make_mock_element_with_iter({ATTRIB_PATH: EXCLUDE_PATH})
-        return _FolderToFolderMappingFolderExclude(element)
+        element = helpers.make_mock_element_with_iter({helpers.ATTRIB_PATH: helpers.EXCLUDE_PATH})
+        return edk_manifest._FolderToFolderMappingFolderExclude(element)
 
     def test_path_defaults_to_none_when_absent(self):
         """When the path attribute is absent, __init__ must set self.path to None."""
-        exc = _FolderToFolderMappingFolderExclude(make_empty_element())
+        exc = edk_manifest._FolderToFolderMappingFolderExclude(helpers.make_empty_element())
 
         assert exc.path is None
 
     def test_path_when_present(self, full_folder_exclude):
         """When the path attribute is present, __init__ must set self.path to its value."""
-        assert full_folder_exclude.path == EXCLUDE_PATH
+        assert full_folder_exclude.path == helpers.EXCLUDE_PATH
 
     def test_tuple_returns_correct_folder_to_folder_mapping_folder_exclude_namedtuple(self, full_folder_exclude):
         """The tuple property must return a FolderToFolderMappingFolderExclude namedtuple with the correct path."""
-        assert full_folder_exclude.tuple == FolderToFolderMappingFolderExclude(path=EXCLUDE_PATH)
-
+        assert full_folder_exclude.tuple == edk_manifest.FolderToFolderMappingFolderExclude(path=helpers.EXCLUDE_PATH)

--- a/edkrepo_manifest_parser/unit_tests/test_general_config.py
+++ b/edkrepo_manifest_parser/unit_tests/test_general_config.py
@@ -10,34 +10,26 @@
 import sys
 import os
 import pytest
-from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_text_element,
-    make_attrib_element,
-)
-from edkrepo_manifest_parser.edk_manifest import _GeneralConfig, GeneralConfig
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-CHILD_PIN_PATH              = 'PinPath'
-CHILD_DEFAULT_COMBO         = 'DefaultCombo'
-CHILD_CURR_COMBO            = 'CurrentClonedCombo'
-CHILD_SOURCE_MANIFEST_REPO  = 'SourceManifestRepository'
-ATTRIB_COMBINATION          = 'combination'
-ATTRIB_MANIFEST_REPO        = 'manifest_repo'
-PIN_PATH                    = '/fake/pin.xml'
-DEFAULT_COMBO               = 'main'
-CURR_COMBO                  = 'dev'
-SOURCE_MANIFEST_REPO        = 'edk2-manifest'
-FIELD_PIN_PATH              = 'pin_path'
-FIELD_DEFAULT_COMBO         = 'default_combo'
-FIELD_CURR_COMBO            = 'curr_combo'
-FIELD_SOURCE_MANIFEST_REPO  = 'source_manifest_repo'
-PARAM_FIELD_NAME            = 'field_name'
-ID_PIN_PATH_ABSENT          = 'pin_path_absent'
-ID_DEFAULT_COMBO_ABSENT     = 'default_combo_absent'
-ID_CURR_COMBO_ABSENT        = 'curr_combo_absent'
-ID_SOURCE_REPO_ABSENT       = 'source_manifest_repo_absent'
+CHILD_PIN_PATH = 'PinPath'
+CHILD_DEFAULT_COMBO = 'DefaultCombo'
+CHILD_CURR_COMBO = 'CurrentClonedCombo'
+CHILD_SOURCE_MANIFEST_REPO = 'SourceManifestRepository'
+ATTRIB_MANIFEST_REPO = 'manifest_repo'
+PIN_PATH = '/fake/pin.xml'
+SOURCE_MANIFEST_REPO = 'edk2-manifest'
+FIELD_PIN_PATH = 'pin_path'
+FIELD_DEFAULT_COMBO = 'default_combo'
+FIELD_CURR_COMBO = 'curr_combo'
+FIELD_SOURCE_MANIFEST_REPO = 'source_manifest_repo'
+ID_PIN_PATH_ABSENT = 'pin_path_absent'
+ID_DEFAULT_COMBO_ABSENT = 'default_combo_absent'
+ID_CURR_COMBO_ABSENT = 'curr_combo_absent'
+ID_SOURCE_REPO_ABSENT = 'source_manifest_repo_absent'
 
 
 class TestGeneralConfig:
@@ -45,26 +37,23 @@ class TestGeneralConfig:
     @staticmethod
     def _make_mock_element(find_map=None):
         """Build a mock XML element whose find() returns values from find_map, or None for absent keys."""
-        elem = MagicMock()
-        fm = find_map if find_map is not None else {}
-        elem.find.side_effect = lambda tag: fm.get(tag)
-        return elem
+        return helpers.make_find_map_element(find_map)
 
     @staticmethod
     def _assert_field_present(find_map, field_name, expected):
-        """Build a _GeneralConfig from an element containing find_map and assert field_name equals expected."""
-        config = _GeneralConfig(TestGeneralConfig._make_mock_element(find_map))
+        """Build a edk_manifest._GeneralConfig from an element containing find_map and assert field_name equals expected."""
+        config = edk_manifest._GeneralConfig(TestGeneralConfig._make_mock_element(find_map))
         assert getattr(config, field_name) == expected
 
     @pytest.fixture
     def empty_config(self):
-        """Return a _GeneralConfig built from an element with no children so all fields default to None."""
-        return _GeneralConfig(self._make_mock_element({}))
+        """Return a edk_manifest._GeneralConfig built from an element with no children so all fields default to None."""
+        return edk_manifest._GeneralConfig(self._make_mock_element({}))
 
     def test_init_sets_pin_path_when_present(self):
         """When the PinPath child element is present, __init__ must set self.pin_path to its text value."""
         self._assert_field_present(
-            {CHILD_PIN_PATH: make_text_element(PIN_PATH)},
+            {CHILD_PIN_PATH: helpers.make_text_element(PIN_PATH)},
             FIELD_PIN_PATH,
             PIN_PATH,
         )
@@ -72,31 +61,31 @@ class TestGeneralConfig:
     def test_init_sets_default_combo_when_present(self):
         """When the DefaultCombo child element is present, __init__ must set self.default_combo to its combination attribute."""
         self._assert_field_present(
-            {CHILD_DEFAULT_COMBO: make_attrib_element({ATTRIB_COMBINATION: DEFAULT_COMBO})},
+            {CHILD_DEFAULT_COMBO: helpers.make_attrib_element({helpers.ATTRIB_COMBINATION: helpers.BRANCH})},
             FIELD_DEFAULT_COMBO,
-            DEFAULT_COMBO,
+            helpers.BRANCH,
         )
 
     def test_init_sets_curr_combo_when_present(self):
         """When the CurrentClonedCombo child element is present, __init__ must set self.curr_combo to its combination attribute."""
         self._assert_field_present(
-            {CHILD_CURR_COMBO: make_attrib_element({ATTRIB_COMBINATION: CURR_COMBO})},
+            {CHILD_CURR_COMBO: helpers.make_attrib_element({helpers.ATTRIB_COMBINATION: helpers.DEV})},
             FIELD_CURR_COMBO,
-            CURR_COMBO,
+            helpers.DEV,
         )
 
     def test_init_sets_source_manifest_repo_when_present(self):
         """When the SourceManifestRepository child element is present, __init__ must set self.source_manifest_repo to its manifest_repo attribute."""
         self._assert_field_present(
-            {CHILD_SOURCE_MANIFEST_REPO: make_attrib_element({ATTRIB_MANIFEST_REPO: SOURCE_MANIFEST_REPO})},
+            {CHILD_SOURCE_MANIFEST_REPO: helpers.make_attrib_element({ATTRIB_MANIFEST_REPO: SOURCE_MANIFEST_REPO})},
             FIELD_SOURCE_MANIFEST_REPO,
             SOURCE_MANIFEST_REPO,
         )
 
-    @pytest.mark.parametrize(PARAM_FIELD_NAME, [
-        pytest.param(FIELD_PIN_PATH,             id=ID_PIN_PATH_ABSENT),
-        pytest.param(FIELD_DEFAULT_COMBO,        id=ID_DEFAULT_COMBO_ABSENT),
-        pytest.param(FIELD_CURR_COMBO,           id=ID_CURR_COMBO_ABSENT),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_NAME, [
+        pytest.param(FIELD_PIN_PATH, id=ID_PIN_PATH_ABSENT),
+        pytest.param(FIELD_DEFAULT_COMBO, id=ID_DEFAULT_COMBO_ABSENT),
+        pytest.param(FIELD_CURR_COMBO, id=ID_CURR_COMBO_ABSENT),
         pytest.param(FIELD_SOURCE_MANIFEST_REPO, id=ID_SOURCE_REPO_ABSENT),
     ])
     def test_init_field_defaults_to_none_when_absent(self, empty_config, field_name):
@@ -104,19 +93,18 @@ class TestGeneralConfig:
         assert getattr(empty_config, field_name) is None
 
     def test_tuple_returns_correct_general_config_namedtuple(self):
-        """The tuple property must return a GeneralConfig namedtuple with the correct field values."""
+        """The tuple property must return a edk_manifest.GeneralConfig namedtuple with the correct field values."""
         find_map = {
-            CHILD_PIN_PATH: make_text_element(PIN_PATH),
-            CHILD_DEFAULT_COMBO: make_attrib_element({ATTRIB_COMBINATION: DEFAULT_COMBO}),
-            CHILD_CURR_COMBO: make_attrib_element({ATTRIB_COMBINATION: CURR_COMBO}),
-            CHILD_SOURCE_MANIFEST_REPO: make_attrib_element({ATTRIB_MANIFEST_REPO: SOURCE_MANIFEST_REPO}),
+            CHILD_PIN_PATH: helpers.make_text_element(PIN_PATH),
+            CHILD_DEFAULT_COMBO: helpers.make_attrib_element({helpers.ATTRIB_COMBINATION: helpers.BRANCH}),
+            CHILD_CURR_COMBO: helpers.make_attrib_element({helpers.ATTRIB_COMBINATION: helpers.DEV}),
+            CHILD_SOURCE_MANIFEST_REPO: helpers.make_attrib_element({ATTRIB_MANIFEST_REPO: SOURCE_MANIFEST_REPO}),
         }
-        result = _GeneralConfig(self._make_mock_element(find_map)).tuple
+        result = edk_manifest._GeneralConfig(self._make_mock_element(find_map)).tuple
 
-        assert result == GeneralConfig(
-            default_combo=DEFAULT_COMBO,
-            current_combo=CURR_COMBO,
+        assert result == edk_manifest.GeneralConfig(
+            default_combo=helpers.BRANCH,
+            current_combo=helpers.DEV,
             pin_path=PIN_PATH,
             source_manifest_repo=SOURCE_MANIFEST_REPO,
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_manifestxml.py
+++ b/edkrepo_manifest_parser/unit_tests/test_manifestxml.py
@@ -13,48 +13,27 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.edk_manifest import (
-    ManifestXml,
-    _validate_repo_local_root_or_raise,
-    PatchSet,
-    INVALID_REPO_PATH_ERROR,
-    NO_PARENT_REPO_ERROR,
-    COMBO_INVALIDINPUT_ERROR,
-    NO_PATCHSET_IN_COMBO,
-    PATCHSET_UNKNOWN_ERROR,
-    PATCHSET_PARENT_CIRCULAR_DEPENDENCY,
-)
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    MANIFEST_PATH,
-    REMOTE_NAME,
-    REMOTE_URL,
-)
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
 
-ATTRIB_NAME               = 'name'
-ELEMENT_TAG_MANIFEST      = 'Manifest'
-ELEMENT_TAG_PIN           = 'Pin'
-PARAM_IS_PIN_FILE         = 'xml_type, expected'
-ID_XML_TYPE_PIN           = 'xml_type_pin'
-ID_XML_TYPE_MANIFEST      = 'xml_type_manifest'
-PARAM_SUBMODULE_ALTS      = 'alt_remote, query_remote, expect_match'
-ID_ALT_MATCHING           = 'matching_remote'
-ID_ALT_NO_MATCH           = 'no_match'
-PARAM_NESTED_REPO_RAISES  = 'sources, path, expected_error'
-ID_NON_NESTED_PATH        = 'non_nested_path'
-ID_NO_PARENT_FOUND        = 'no_parent_found'
-PARAM_COMBO_ARG           = 'combo_arg'
-ID_COMBO_NONE             = 'combo_none'
-ID_COMBO_SPECIFIED        = 'combo_specified'
-COMBO_NAME           = 'default'
-CHILD_DEFAULT_COMBO  = 'main'
-PIN_PREFIX_COMBO     = 'Pin:main'
-UNKNOWN_COMBO        = 'unknown_combo'
-UNKNOWN_REMOTE       = 'upstream'
-PATCHSET_NAME        = 'ps_name'
-UNKNOWN_PATCHSET     = 'unknown_ps'
-PARENT_REPO          = 'parent'
-NESTED_REPO          = 'parent/child'
-INVALID_REPO_PATH    = 'singlecomponent'
+PARAM_IS_PIN_FILE = 'xml_type, expected'
+ID_XML_TYPE_PIN = 'xml_type_pin'
+ID_XML_TYPE_MANIFEST = 'xml_type_manifest'
+PARAM_SUBMODULE_ALTS = 'alt_remote, query_remote, expect_match'
+ID_ALT_MATCHING = 'matching_remote'
+PARAM_NESTED_REPO_RAISES = 'sources, path, expected_error'
+ID_NON_NESTED_PATH = 'non_nested_path'
+ID_NO_PARENT_FOUND = 'no_parent_found'
+PARAM_COMBO_ARG = 'combo_arg'
+ID_COMBO_NONE = 'combo_none'
+ID_COMBO_SPECIFIED = 'combo_specified'
+COMBO_NAME = 'default'
+PIN_PREFIX_COMBO = 'Pin:main'
+UNKNOWN_COMBO = 'unknown_combo'
+UNKNOWN_PATCHSET = 'unknown_ps'
+PARENT_REPO = 'parent'
+NESTED_REPO = 'parent/child'
+INVALID_REPO_PATH = 'singlecomponent'
 
 
 class TestManifestXml:
@@ -65,14 +44,14 @@ class TestManifestXml:
         with patch('edkrepo_manifest_parser.edk_manifest.ET.ElementTree') as mock_et_cls:
             mock_tree = MagicMock()
             mock_et_cls.return_value = mock_tree
-            mock_tree.getroot.return_value.tag = ELEMENT_TAG_MANIFEST
+            mock_tree.getroot.return_value.tag = helpers.TAG_MANIFEST
             mock_tree.iter.return_value = []
             yield mock_et_cls
 
     @pytest.fixture
     def manifest_instance(self, mock_et):
         """Return a ManifestXml with cleared internal collections ready for per-test configuration."""
-        instance = ManifestXml(MANIFEST_PATH)
+        instance = edk_manifest.ManifestXml(helpers.MANIFEST_PATH)
         instance._combo_sources = {}
         instance._combinations = {}
         instance._remotes = {}
@@ -80,7 +59,7 @@ class TestManifestXml:
         instance._patch_set_operations = {}
         instance._submodule_init_list = []
         instance._submodule_alternate_remotes = []
-        instance._xml_type = ELEMENT_TAG_MANIFEST
+        instance._xml_type = helpers.TAG_MANIFEST
         return instance
 
     @staticmethod
@@ -88,7 +67,7 @@ class TestManifestXml:
         """Build and return a mock RepoSource-like object with configurable patch_set and remote_name."""
         src = MagicMock()
         src.patch_set = patch_set
-        src.remote_name = remote_name if remote_name is not None else REMOTE_NAME
+        src.remote_name = remote_name if remote_name is not None else helpers.REMOTE_NAME
         return src
 
     @staticmethod
@@ -102,7 +81,7 @@ class TestManifestXml:
     @staticmethod
     def _make_patchset_tuple(name, remote, parent_sha='orphan', fetch_branch='main'):
         """Build and return a PatchSet namedtuple with the given fields."""
-        return PatchSet(remote=remote, name=name, parent_sha=parent_sha, fetch_branch=fetch_branch)
+        return edk_manifest.PatchSet(remote=remote, name=name, parent_sha=parent_sha, fetch_branch=fetch_branch)
 
     @staticmethod
     def _make_mock_remote(name=None, url=None):
@@ -132,41 +111,41 @@ class TestManifestXml:
     def _setup_combo_with_patchset(manifest_instance):
         """Populate manifest_instance with one combo and one patchset; return the PatchSet tuple."""
         ps = TestManifestXml._make_patchset_tuple(
-            PATCHSET_NAME, REMOTE_NAME
+            helpers.PATCHSET_NAME, helpers.REMOTE_NAME
         )
         mock_src = TestManifestXml._make_mock_source(
-            patch_set=PATCHSET_NAME,
-            remote_name=REMOTE_NAME,
+            patch_set=helpers.PATCHSET_NAME,
+            remote_name=helpers.REMOTE_NAME,
         )
         manifest_instance._combo_sources = {COMBO_NAME: [mock_src]}
-        manifest_instance._patch_sets = {(PATCHSET_NAME, REMOTE_NAME): ps}
+        manifest_instance._patch_sets = {(helpers.PATCHSET_NAME, helpers.REMOTE_NAME): ps}
         return ps
 
     @staticmethod
     def _setup_patchset_with_ops(manifest_instance, operations):
         """Populate manifest_instance with one patchset and given operations; return the PatchSet tuple."""
         ps = TestManifestXml._make_patchset_tuple(
-            PATCHSET_NAME, REMOTE_NAME
+            helpers.PATCHSET_NAME, helpers.REMOTE_NAME
         )
-        manifest_instance._patch_sets = {(PATCHSET_NAME, REMOTE_NAME): ps}
+        manifest_instance._patch_sets = {(helpers.PATCHSET_NAME, helpers.REMOTE_NAME): ps}
         manifest_instance._patch_set_operations = {
-            (PATCHSET_NAME, REMOTE_NAME): operations
+            (helpers.PATCHSET_NAME, helpers.REMOTE_NAME): operations
         }
         return ps
 
     def test_validate_repo_local_root_raises_for_single_component_path(self):
         """When repo_local_root has only one path component, must raise ValueError."""
         with pytest.raises(ValueError) as exc_info:
-            _validate_repo_local_root_or_raise(INVALID_REPO_PATH)
-        assert str(exc_info.value) == INVALID_REPO_PATH_ERROR.format(INVALID_REPO_PATH)
+            edk_manifest._validate_repo_local_root_or_raise(INVALID_REPO_PATH)
+        assert str(exc_info.value) == edk_manifest.INVALID_REPO_PATH_ERROR.format(INVALID_REPO_PATH)
 
     def test_validate_repo_local_root_does_not_raise_for_multi_component_path(self):
         """When repo_local_root has multiple path components, must not raise."""
-        _validate_repo_local_root_or_raise(NESTED_REPO)
+        edk_manifest._validate_repo_local_root_or_raise(NESTED_REPO)
 
     @pytest.mark.parametrize(PARAM_IS_PIN_FILE, [
-        pytest.param(ELEMENT_TAG_PIN,      True,  id=ID_XML_TYPE_PIN),
-        pytest.param(ELEMENT_TAG_MANIFEST, False, id=ID_XML_TYPE_MANIFEST),
+        pytest.param(helpers.TAG_PIN, True, id=ID_XML_TYPE_PIN),
+        pytest.param(helpers.TAG_MANIFEST, False, id=ID_XML_TYPE_MANIFEST),
     ])
     def test_is_pin_file(self, manifest_instance, xml_type, expected):
         """When _xml_type is set to the given value, is_pin_file must return the expected boolean."""
@@ -176,19 +155,19 @@ class TestManifestXml:
     def test_get_remote_returns_remote_object_when_found(self, manifest_instance):
         """When remote_name exists in _remotes, must return the corresponding remote object."""
         mock_remote = self._make_mock_remote()
-        manifest_instance._remotes = {REMOTE_NAME: mock_remote}
-        assert manifest_instance.get_remote(REMOTE_NAME) is mock_remote
+        manifest_instance._remotes = {helpers.REMOTE_NAME: mock_remote}
+        assert manifest_instance.get_remote(helpers.REMOTE_NAME) is mock_remote
 
     def test_get_remote_returns_none_when_not_found(self, manifest_instance):
         """When remote_name is not in _remotes, must return None."""
-        assert manifest_instance.get_remote(UNKNOWN_REMOTE) is None
+        assert manifest_instance.get_remote(helpers.UPSTREAM) is None
 
     def test_get_remotes_dict_returns_name_to_url_mapping(self, manifest_instance):
         """Must return a dict mapping each remote name to its URL."""
-        mock_remote = self._make_mock_remote(name=REMOTE_NAME, url=REMOTE_URL)
-        manifest_instance._remotes = {REMOTE_NAME: mock_remote}
+        mock_remote = self._make_mock_remote(name=helpers.REMOTE_NAME, url=helpers.REMOTE_URL)
+        manifest_instance._remotes = {helpers.REMOTE_NAME: mock_remote}
         result = manifest_instance.get_remotes_dict()
-        assert result == {REMOTE_NAME: REMOTE_URL}
+        assert result == {helpers.REMOTE_NAME: helpers.REMOTE_URL}
 
     def test_get_repo_sources_returns_tuple_list_when_combo_found(self, manifest_instance):
         """When combo_name is in _combo_sources, must return tuples of that combo's sources."""
@@ -200,9 +179,9 @@ class TestManifestXml:
     def test_get_repo_sources_returns_default_combo_sources_for_pin_prefix(self, manifest_instance):
         """When combo_name starts with 'Pin:', must return sources of the default combo."""
         mock_src = self._make_mock_source()
-        manifest_instance._combo_sources = {CHILD_DEFAULT_COMBO: [mock_src]}
+        manifest_instance._combo_sources = {helpers.BRANCH: [mock_src]}
         manifest_instance._general_config = MagicMock()
-        manifest_instance._general_config.tuple.default_combo = CHILD_DEFAULT_COMBO
+        manifest_instance._general_config.tuple.default_combo = helpers.BRANCH
         result = manifest_instance.get_repo_sources(PIN_PREFIX_COMBO)
         assert result == [mock_src.tuple]
 
@@ -210,11 +189,11 @@ class TestManifestXml:
         """When combo_name is not in _combo_sources and not a Pin prefix, must raise ValueError."""
         with pytest.raises(ValueError) as exc_info:
             manifest_instance.get_repo_sources(UNKNOWN_COMBO)
-        assert str(exc_info.value) == COMBO_INVALIDINPUT_ERROR.format(UNKNOWN_COMBO)
+        assert str(exc_info.value) == edk_manifest.COMBO_INVALIDINPUT_ERROR.format(UNKNOWN_COMBO)
 
     @pytest.mark.parametrize(PARAM_NESTED_REPO_RAISES, [
-        pytest.param([], INVALID_REPO_PATH, INVALID_REPO_PATH_ERROR.format(INVALID_REPO_PATH), id=ID_NON_NESTED_PATH),
-        pytest.param([], NESTED_REPO,       NO_PARENT_REPO_ERROR.format(NESTED_REPO),          id=ID_NO_PARENT_FOUND),
+        pytest.param([], INVALID_REPO_PATH, edk_manifest.INVALID_REPO_PATH_ERROR.format(INVALID_REPO_PATH), id=ID_NON_NESTED_PATH),
+        pytest.param([], NESTED_REPO, edk_manifest.NO_PARENT_REPO_ERROR.format(NESTED_REPO), id=ID_NO_PARENT_FOUND),
     ])
     def test_get_parent_of_nested_repo_raises(self, manifest_instance, sources, path, expected_error):
         """When path is non-nested or no parent source is found, must raise ValueError with the expected message."""
@@ -232,7 +211,7 @@ class TestManifestXml:
     def test_get_combo_element_returns_deepcopy_when_found(self, manifest_instance, mock_et):
         """When a Combination with the given name exists in the tree, must return a deepcopy."""
         mock_elem = MagicMock()
-        mock_elem.attrib = {ATTRIB_NAME: COMBO_NAME}
+        mock_elem.attrib = {helpers.ATTRIB_NAME: COMBO_NAME}
         mock_et.return_value.find.return_value = self._make_combo_root([mock_elem])
         with patch('edkrepo_manifest_parser.edk_manifest.copy.deepcopy', return_value=mock_elem):
             result = manifest_instance.get_combo_element(COMBO_NAME)
@@ -246,8 +225,8 @@ class TestManifestXml:
         assert UNKNOWN_COMBO in str(exc_info.value)
 
     @pytest.mark.parametrize(PARAM_SUBMODULE_ALTS, [
-        pytest.param(REMOTE_NAME,    REMOTE_NAME, True,  id=ID_ALT_MATCHING),
-        pytest.param(UNKNOWN_REMOTE, REMOTE_NAME, False, id=ID_ALT_NO_MATCH),
+        pytest.param(helpers.REMOTE_NAME, helpers.REMOTE_NAME, True, id=ID_ALT_MATCHING),
+        pytest.param(helpers.UPSTREAM, helpers.REMOTE_NAME, False, id=helpers.ID_NO_MATCH),
     ])
     def test_get_submodule_alternates_for_remote(self, manifest_instance, alt_remote, query_remote, expect_match):
         """When an alternate's remote_name matches the query, its tuple is returned; otherwise an empty list."""
@@ -258,24 +237,24 @@ class TestManifestXml:
 
     def test_get_submodule_init_paths_returns_all_when_no_filters(self, manifest_instance):
         """When both remote_name and combo are None, must return tuples for all submodule entries."""
-        e1 = self._make_mock_submodule_entry(REMOTE_NAME)
+        e1 = self._make_mock_submodule_entry(helpers.REMOTE_NAME)
         manifest_instance._submodule_init_list = [e1]
         result = manifest_instance.get_submodule_init_paths()
         assert result == [e1.tuple]
 
     def test_get_submodule_init_paths_filters_by_remote_name(self, manifest_instance):
         """When only remote_name is given, must return tuples only for entries matching that remote."""
-        e1 = self._make_mock_submodule_entry(REMOTE_NAME)
-        e2 = self._make_mock_submodule_entry(UNKNOWN_REMOTE)
+        e1 = self._make_mock_submodule_entry(helpers.REMOTE_NAME)
+        e2 = self._make_mock_submodule_entry(helpers.UPSTREAM)
         manifest_instance._submodule_init_list = [e1, e2]
-        result = manifest_instance.get_submodule_init_paths(remote_name=REMOTE_NAME)
+        result = manifest_instance.get_submodule_init_paths(remote_name=helpers.REMOTE_NAME)
         assert result == [e1.tuple]
 
     def test_get_submodule_init_paths_filters_by_combo(self, manifest_instance):
         """When only combo is given, must return tuples for entries matching that combo or with no combo."""
-        e_match = self._make_mock_submodule_entry(REMOTE_NAME, combo=COMBO_NAME)
-        e_no_combo = self._make_mock_submodule_entry(REMOTE_NAME, combo=None)
-        e_other = self._make_mock_submodule_entry(REMOTE_NAME, combo=UNKNOWN_COMBO)
+        e_match = self._make_mock_submodule_entry(helpers.REMOTE_NAME, combo=COMBO_NAME)
+        e_no_combo = self._make_mock_submodule_entry(helpers.REMOTE_NAME, combo=None)
+        e_other = self._make_mock_submodule_entry(helpers.REMOTE_NAME, combo=UNKNOWN_COMBO)
         manifest_instance._submodule_init_list = [e_match, e_no_combo, e_other]
         result = manifest_instance.get_submodule_init_paths(combo=COMBO_NAME)
         assert e_match.tuple in result
@@ -284,29 +263,29 @@ class TestManifestXml:
 
     def test_get_submodule_init_paths_filters_by_remote_and_combo(self, manifest_instance):
         """When both remote_name and combo are given, must return entries matching both filters."""
-        e_match = self._make_mock_submodule_entry(REMOTE_NAME, combo=COMBO_NAME)
-        e_wrong_remote = self._make_mock_submodule_entry(UNKNOWN_REMOTE, combo=COMBO_NAME)
+        e_match = self._make_mock_submodule_entry(helpers.REMOTE_NAME, combo=COMBO_NAME)
+        e_wrong_remote = self._make_mock_submodule_entry(helpers.UPSTREAM, combo=COMBO_NAME)
         manifest_instance._submodule_init_list = [e_match, e_wrong_remote]
         result = manifest_instance.get_submodule_init_paths(
-            remote_name=REMOTE_NAME, combo=COMBO_NAME
+            remote_name=helpers.REMOTE_NAME, combo=COMBO_NAME
         )
         assert result == [e_match.tuple]
 
     def test_get_patchset_returns_patchset_when_found(self, manifest_instance):
         """When (name, remote) exists in _patch_sets, must return the corresponding PatchSet."""
-        ps = self._make_patchset_tuple(PATCHSET_NAME, REMOTE_NAME)
-        manifest_instance._patch_sets = {(PATCHSET_NAME, REMOTE_NAME): ps}
-        result = manifest_instance.get_patchset(PATCHSET_NAME, REMOTE_NAME)
+        ps = self._make_patchset_tuple(helpers.PATCHSET_NAME, helpers.REMOTE_NAME)
+        manifest_instance._patch_sets = {(helpers.PATCHSET_NAME, helpers.REMOTE_NAME): ps}
+        result = manifest_instance.get_patchset(helpers.PATCHSET_NAME, helpers.REMOTE_NAME)
         assert result == ps
 
     def test_get_patchset_raises_key_error_when_not_found(self, manifest_instance):
         """When (name, remote) does not exist in _patch_sets, must raise KeyError."""
         with pytest.raises(KeyError) as exc_info:
-            manifest_instance.get_patchset(UNKNOWN_PATCHSET, REMOTE_NAME)
+            manifest_instance.get_patchset(UNKNOWN_PATCHSET, helpers.REMOTE_NAME)
         assert UNKNOWN_PATCHSET in str(exc_info.value)
 
     @pytest.mark.parametrize(PARAM_COMBO_ARG, [
-        pytest.param(None,       id=ID_COMBO_NONE),
+        pytest.param(None, id=ID_COMBO_NONE),
         pytest.param(COMBO_NAME, id=ID_COMBO_SPECIFIED),
     ])
     def test_get_patchsets_for_combo_returns_patchset(self, manifest_instance, combo_arg):
@@ -321,13 +300,13 @@ class TestManifestXml:
         manifest_instance._combo_sources = {COMBO_NAME: [mock_src]}
         with pytest.raises(KeyError) as exc_info:
             manifest_instance.get_patchsets_for_combo(combo=COMBO_NAME)
-        assert NO_PATCHSET_IN_COMBO.format(COMBO_NAME) in str(exc_info.value)
+        assert edk_manifest.NO_PATCHSET_IN_COMBO.format(COMBO_NAME) in str(exc_info.value)
 
     def test_get_patchset_operations_returns_list_when_patchset_found(self, manifest_instance):
         """When (name, remote) is in _patch_sets and there is no circular parent, must return a list containing the operations."""
         mock_ops = [MagicMock()]
         self._setup_patchset_with_ops(manifest_instance, mock_ops)
-        result = manifest_instance.get_patchset_operations(PATCHSET_NAME, REMOTE_NAME)
+        result = manifest_instance.get_patchset_operations(helpers.PATCHSET_NAME, helpers.REMOTE_NAME)
         assert mock_ops in result
 
     def test_get_patchset_operations_raises_on_circular_dependency(self, manifest_instance):
@@ -335,11 +314,11 @@ class TestManifestXml:
         self._setup_patchset_with_ops(manifest_instance, [])
         manifest_instance.get_parent_patchset_operations = MagicMock(side_effect=RecursionError)
         with pytest.raises(ValueError) as exc_info:
-            manifest_instance.get_patchset_operations(PATCHSET_NAME, REMOTE_NAME)
-        assert str(exc_info.value) == PATCHSET_PARENT_CIRCULAR_DEPENDENCY
+            manifest_instance.get_patchset_operations(helpers.PATCHSET_NAME, helpers.REMOTE_NAME)
+        assert str(exc_info.value) == edk_manifest.PATCHSET_PARENT_CIRCULAR_DEPENDENCY
 
     def test_get_patchset_operations_raises_value_error_when_not_found(self, manifest_instance):
         """When (name, remote) is not in _patch_sets, must raise ValueError with the patchset name."""
         with pytest.raises(ValueError) as exc_info:
-            manifest_instance.get_patchset_operations(UNKNOWN_PATCHSET, REMOTE_NAME)
-        assert str(exc_info.value) == PATCHSET_UNKNOWN_ERROR.format(UNKNOWN_PATCHSET, MANIFEST_PATH)
+            manifest_instance.get_patchset_operations(UNKNOWN_PATCHSET, helpers.REMOTE_NAME)
+        assert str(exc_info.value) == edk_manifest.PATCHSET_UNKNOWN_ERROR.format(UNKNOWN_PATCHSET, helpers.MANIFEST_PATH)

--- a/edkrepo_manifest_parser/unit_tests/test_patchset.py
+++ b/edkrepo_manifest_parser/unit_tests/test_patchset.py
@@ -12,33 +12,16 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-    REMOTE_NAME,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _PatchSet,
-    _parse_patchset_required_attribs,
-    PatchSet,
-    REQUIRED_ATTRIB_ERROR_MSG,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_NAME          = 'name'
-ATTRIB_REMOTE        = 'remote'
-ATTRIB_PARENT_SHA    = 'parentSha'
-ATTRIB_FETCH_BRANCH  = 'fetchBranch'
-ELEMENT_TAG_PATCHSET = 'PatchSet'
-PATCHSET_NAME        = 'ps_name'
-OTHER_PATCHSET_NAME  = 'other_ps'
-COMMIT               = 'abc123'
-BRANCH               = 'main'
-
-PARAM_MISSING_ATTRIB      = 'missing_attrib'
-ID_REMOTE_MISSING         = 'remote_missing'
-ID_NAME_MISSING           = 'name_missing'
-ID_PARENT_SHA_MISSING     = 'parent_sha_missing'
-ID_FETCH_BRANCH_MISSING   = 'fetch_branch_missing'
+ATTRIB_PARENT_SHA = 'parentSha'
+ATTRIB_FETCH_BRANCH = 'fetchBranch'
+ELEMENT_TAG_PATCHSET = 'edk_manifest.PatchSet'
+OTHER_PATCHSET_NAME = 'other_ps'
+ID_NAME_MISSING = 'name_missing'
+ID_PARENT_SHA_MISSING = 'parent_sha_missing'
+ID_FETCH_BRANCH_MISSING = 'fetch_branch_missing'
 
 
 class TestPatchSet:
@@ -46,89 +29,89 @@ class TestPatchSet:
     @staticmethod
     def _make_full_element():
         """Build a mock element with all four required patchset attributes."""
-        return make_mock_element({
-            ATTRIB_REMOTE:       REMOTE_NAME,
-            ATTRIB_NAME:         PATCHSET_NAME,
-            ATTRIB_PARENT_SHA:   COMMIT,
-            ATTRIB_FETCH_BRANCH: BRANCH,
+        return helpers.make_mock_element({
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
+            helpers.ATTRIB_NAME: helpers.PATCHSET_NAME,
+            ATTRIB_PARENT_SHA: helpers.COMMIT,
+            ATTRIB_FETCH_BRANCH: helpers.BRANCH,
         }, tag=ELEMENT_TAG_PATCHSET)
 
     def test_parse_required_attribs_returns_all_four_when_all_present(self):
         """When all four required attributes are present, must return the four values."""
         element = self._make_full_element()
 
-        remote, name, parent_sha, fetch_branch = _parse_patchset_required_attribs(element)
+        remote, name, parent_sha, fetch_branch = edk_manifest._parse_patchset_required_attribs(element)
 
-        assert remote == REMOTE_NAME
-        assert name == PATCHSET_NAME
-        assert parent_sha == COMMIT
-        assert fetch_branch == BRANCH
+        assert remote == helpers.REMOTE_NAME
+        assert name == helpers.PATCHSET_NAME
+        assert parent_sha == helpers.COMMIT
+        assert fetch_branch == helpers.BRANCH
 
-    @pytest.mark.parametrize(PARAM_MISSING_ATTRIB, [
-        pytest.param(ATTRIB_REMOTE,       id=ID_REMOTE_MISSING),
-        pytest.param(ATTRIB_NAME,         id=ID_NAME_MISSING),
-        pytest.param(ATTRIB_PARENT_SHA,   id=ID_PARENT_SHA_MISSING),
+    @pytest.mark.parametrize(helpers.PARAM_MISSING_ATTRIB, [
+        pytest.param(helpers.ATTRIB_REMOTE, id=helpers.ID_REMOTE_MISSING),
+        pytest.param(helpers.ATTRIB_NAME, id=ID_NAME_MISSING),
+        pytest.param(ATTRIB_PARENT_SHA, id=ID_PARENT_SHA_MISSING),
         pytest.param(ATTRIB_FETCH_BRANCH, id=ID_FETCH_BRANCH_MISSING),
     ])
     def test_parse_required_attribs_raises_key_error_when_missing(self, missing_attrib):
         """When any required attribute is absent, must raise KeyError with the required-attrib message."""
         full = {
-            ATTRIB_REMOTE:       REMOTE_NAME,
-            ATTRIB_NAME:         PATCHSET_NAME,
-            ATTRIB_PARENT_SHA:   COMMIT,
-            ATTRIB_FETCH_BRANCH: BRANCH,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
+            helpers.ATTRIB_NAME: helpers.PATCHSET_NAME,
+            ATTRIB_PARENT_SHA: helpers.COMMIT,
+            ATTRIB_FETCH_BRANCH: helpers.BRANCH,
         }
         del full[missing_attrib]
-        element = make_mock_element(full, tag=ELEMENT_TAG_PATCHSET)
+        element = helpers.make_mock_element(full, tag=ELEMENT_TAG_PATCHSET)
         with pytest.raises(KeyError) as exc_info:
-            _parse_patchset_required_attribs(element)
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+            edk_manifest._parse_patchset_required_attribs(element)
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_all_fields_from_required_attribs(self):
         """When all required attributes are present, __init__ must set all four fields correctly."""
         element = self._make_full_element()
 
-        ps = _PatchSet(element)
+        ps = edk_manifest._PatchSet(element)
 
-        assert ps.remote == REMOTE_NAME
-        assert ps.name == PATCHSET_NAME
-        assert ps.parentSha == COMMIT
-        assert ps.fetchBranch == BRANCH
+        assert ps.remote == helpers.REMOTE_NAME
+        assert ps.name == helpers.PATCHSET_NAME
+        assert ps.parentSha == helpers.COMMIT
+        assert ps.fetchBranch == helpers.BRANCH
 
     def test_eq_returns_true_for_equal_patchsets(self):
-        """Two _PatchSet instances with identical attributes must compare as equal."""
-        ps1 = _PatchSet(self._make_full_element())
-        ps2 = _PatchSet(self._make_full_element())
+        """Two edk_manifest._PatchSet instances with identical attributes must compare as equal."""
+        ps1 = edk_manifest._PatchSet(self._make_full_element())
+        ps2 = edk_manifest._PatchSet(self._make_full_element())
 
         assert ps1 == ps2
 
     def test_eq_returns_false_for_different_patchsets(self):
-        """Two _PatchSet instances with different attributes must not compare as equal."""
-        ps1 = _PatchSet(self._make_full_element())
-        ps2 = _PatchSet(make_mock_element({
-            ATTRIB_REMOTE:       REMOTE_NAME,
-            ATTRIB_NAME:         OTHER_PATCHSET_NAME,
-            ATTRIB_PARENT_SHA:   COMMIT,
-            ATTRIB_FETCH_BRANCH: BRANCH,
+        """Two edk_manifest._PatchSet instances with different attributes must not compare as equal."""
+        ps1 = edk_manifest._PatchSet(self._make_full_element())
+        ps2 = edk_manifest._PatchSet(helpers.make_mock_element({
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
+            helpers.ATTRIB_NAME: OTHER_PATCHSET_NAME,
+            ATTRIB_PARENT_SHA: helpers.COMMIT,
+            ATTRIB_FETCH_BRANCH: helpers.BRANCH,
         }, tag=ELEMENT_TAG_PATCHSET))
 
         assert ps1 != ps2
 
     def test_eq_returns_false_for_non_patchset_type(self):
-        """Comparing a _PatchSet to a non-_PatchSet object must return False."""
-        ps = _PatchSet(self._make_full_element())
+        """Comparing a edk_manifest._PatchSet to a non-edk_manifest._PatchSet object must return False."""
+        ps = edk_manifest._PatchSet(self._make_full_element())
 
         assert ps.__eq__(object()) is False
 
     def test_tuple_returns_correct_patchset_namedtuple(self):
-        """The tuple property must return a PatchSet namedtuple with the correct field values."""
-        ps = _PatchSet(self._make_full_element())
+        """The tuple property must return a edk_manifest.PatchSet namedtuple with the correct field values."""
+        ps = edk_manifest._PatchSet(self._make_full_element())
 
         result = ps.tuple
 
-        assert result == PatchSet(
-            remote=REMOTE_NAME,
-            name=PATCHSET_NAME,
-            parent_sha=COMMIT,
-            fetch_branch=BRANCH,
+        assert result == edk_manifest.PatchSet(
+            remote=helpers.REMOTE_NAME,
+            name=helpers.PATCHSET_NAME,
+            parent_sha=helpers.COMMIT,
+            fetch_branch=helpers.BRANCH,
         )

--- a/edkrepo_manifest_parser/unit_tests/test_patchset_operations.py
+++ b/edkrepo_manifest_parser/unit_tests/test_patchset_operations.py
@@ -12,26 +12,20 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-)
-from edkrepo_manifest_parser.edk_manifest import _PatchSetOperations, PatchOperation
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ELEMENT_TAG_CHERRY_PICK  = 'CherryPick'
-ATTRIB_FILE              = 'file'
-ATTRIB_SHA               = 'sha'
-ATTRIB_SOURCE_REMOTE     = 'sourceRemote'
-ATTRIB_SOURCE_BRANCH     = 'sourceBranch'
-ATTRIB_MERGE_STRATEGY    = 'mergeStrategy'
-OPS_FILE                 = 'some_file.patch'
-OPS_SHA                  = 'aabbcc'
-OPS_SOURCE_REMOTE        = 'upstream'
-OPS_SOURCE_BRANCH        = 'dev'
-OPS_MERGE_STRATEGY       = 'ours'
-FIELD_SOURCE_REMOTE      = 'source_remote'
-FIELD_SOURCE_BRANCH      = 'source_branch'
-FIELD_MERGE_STRATEGY     = 'merge_strategy'
-PARAM_FIELD_NAME         = 'field_name'
+ELEMENT_TAG_CHERRY_PICK = 'CherryPick'
+ATTRIB_SHA = 'sha'
+ATTRIB_SOURCE_REMOTE = 'sourceRemote'
+ATTRIB_SOURCE_BRANCH = 'sourceBranch'
+ATTRIB_MERGE_STRATEGY = 'mergeStrategy'
+OPS_FILE = 'some_file.patch'
+OPS_SHA = 'aabbcc'
+OPS_MERGE_STRATEGY = 'ours'
+FIELD_SOURCE_REMOTE = 'source_remote'
+FIELD_SOURCE_BRANCH = 'source_branch'
+FIELD_MERGE_STRATEGY = 'merge_strategy'
 
 
 class TestPatchSetOperations:
@@ -39,19 +33,19 @@ class TestPatchSetOperations:
     @pytest.fixture
     def full_ops(self):
         """Return a _PatchSetOperations instance with all optional attributes present."""
-        return _PatchSetOperations(make_mock_element({
-            ATTRIB_FILE: OPS_FILE,
+        return edk_manifest._PatchSetOperations(helpers.make_mock_element({
+            helpers.ATTRIB_FILE: OPS_FILE,
             ATTRIB_SHA: OPS_SHA,
-            ATTRIB_SOURCE_REMOTE: OPS_SOURCE_REMOTE,
-            ATTRIB_SOURCE_BRANCH: OPS_SOURCE_BRANCH,
+            ATTRIB_SOURCE_REMOTE: helpers.UPSTREAM,
+            ATTRIB_SOURCE_BRANCH: helpers.DEV,
             ATTRIB_MERGE_STRATEGY: OPS_MERGE_STRATEGY,
         }, tag=ELEMENT_TAG_CHERRY_PICK))
 
     def test_init_sets_type_from_element_tag(self):
         """__init__ must set self.type to element.tag."""
-        element = make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK)
+        element = helpers.make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK)
 
-        ops = _PatchSetOperations(element)
+        ops = edk_manifest._PatchSetOperations(element)
 
         assert ops.type == ELEMENT_TAG_CHERRY_PICK
 
@@ -59,29 +53,29 @@ class TestPatchSetOperations:
         """When all optional attributes are present, __init__ must set each field to its value."""
         assert full_ops.file == OPS_FILE
         assert full_ops.sha == OPS_SHA
-        assert full_ops.source_remote == OPS_SOURCE_REMOTE
-        assert full_ops.source_branch == OPS_SOURCE_BRANCH
+        assert full_ops.source_remote == helpers.UPSTREAM
+        assert full_ops.source_branch == helpers.DEV
         assert full_ops.merge_strategy == OPS_MERGE_STRATEGY
 
-    @pytest.mark.parametrize(PARAM_FIELD_NAME, [
-        pytest.param(ATTRIB_FILE,          id=ATTRIB_FILE),
-        pytest.param(ATTRIB_SHA,           id=ATTRIB_SHA),
-        pytest.param(FIELD_SOURCE_REMOTE,  id=FIELD_SOURCE_REMOTE),
-        pytest.param(FIELD_SOURCE_BRANCH,  id=FIELD_SOURCE_BRANCH),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_NAME, [
+        pytest.param(helpers.ATTRIB_FILE, id=helpers.ATTRIB_FILE),
+        pytest.param(ATTRIB_SHA, id=ATTRIB_SHA),
+        pytest.param(FIELD_SOURCE_REMOTE, id=FIELD_SOURCE_REMOTE),
+        pytest.param(FIELD_SOURCE_BRANCH, id=FIELD_SOURCE_BRANCH),
         pytest.param(FIELD_MERGE_STRATEGY, id=FIELD_MERGE_STRATEGY),
     ])
     def test_init_optional_attrib_defaults_to_none_when_missing(self, field_name):
         """When any optional attribute is absent, __init__ must set the corresponding field to None."""
-        ops = _PatchSetOperations(make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK))
+        ops = edk_manifest._PatchSetOperations(helpers.make_mock_element({}, tag=ELEMENT_TAG_CHERRY_PICK))
         assert getattr(ops, field_name) is None
 
     def test_tuple_returns_correct_patch_operation_namedtuple(self, full_ops):
         """The tuple property must return a PatchOperation namedtuple with the correct field values."""
-        assert full_ops.tuple == PatchOperation(
+        assert full_ops.tuple == edk_manifest.PatchOperation(
             type=ELEMENT_TAG_CHERRY_PICK,
             file=OPS_FILE,
             sha=OPS_SHA,
-            source_remote=OPS_SOURCE_REMOTE,
-            source_branch=OPS_SOURCE_BRANCH,
+            source_remote=helpers.UPSTREAM,
+            source_branch=helpers.DEV,
             merge_strategy=OPS_MERGE_STRATEGY,
         )

--- a/edkrepo_manifest_parser/unit_tests/test_project.py
+++ b/edkrepo_manifest_parser/unit_tests/test_project.py
@@ -12,26 +12,17 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import _Project, _parse_project_required_attribs, REQUIRED_ATTRIB_ERROR_MSG
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_NAME                  = 'name'
-ATTRIB_XML_PATH              = 'xmlPath'
-ATTRIB_ARCHIVED              = 'archived'
-ATTRIB_BOOL_TRUE             = 'true'
-ATTRIB_BOOL_FALSE            = 'false'
-ARCHIVED_TRUE_UPPER          = 'TRUE'
-ELEMENT_TAG_PROJECT          = 'Project'
-TEST_PROJECT_NAME            = 'MyProject'
-PROJECT_XML_PATH             = 'MyProject/MyProject.xml'
+ATTRIB_XML_PATH = 'xmlPath'
+ELEMENT_TAG_PROJECT = 'Project'
+TEST_PROJECT_NAME = 'MyProject'
+PROJECT_XML_PATH = 'MyProject/MyProject.xml'
 PROJECT_ARCHIVED_FLAG_FIELDS = 'archived_value,expected'
-ID_TRUE_LOWER                = 'true_lower'
-ID_FALSE_LOWER               = 'false_lower'
-ID_MISSING                   = 'missing'
-ID_TRUE_UPPER                = 'true_upper'
+ID_TRUE_LOWER = 'true_lower'
+ID_FALSE_LOWER = 'false_lower'
+ID_TRUE_UPPER = 'true_upper'
 
 
 class TestProject:
@@ -39,26 +30,26 @@ class TestProject:
     def _make_full_element(archived=None):
         """Build a mock element with name, xmlPath and an optional archived value."""
         attrib = {
-            ATTRIB_NAME: TEST_PROJECT_NAME,
+            helpers.ATTRIB_NAME: TEST_PROJECT_NAME,
             ATTRIB_XML_PATH: PROJECT_XML_PATH,
         }
         if archived is not None:
-            attrib[ATTRIB_ARCHIVED] = archived
-        return make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
+            attrib[helpers.ATTRIB_ARCHIVED] = archived
+        return helpers.make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
 
     @staticmethod
     def _assert_required_attrib_key_error(attrib):
-        """Call _parse_project_required_attribs with attrib and assert KeyError with the required-attrib message prefix."""
-        element = make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
+        """Call edk_manifest._parse_project_required_attribs with attrib and assert KeyError with the required-attrib message prefix."""
+        element = helpers.make_mock_element(attrib, tag=ELEMENT_TAG_PROJECT)
         with pytest.raises(KeyError) as exc_info:
-            _parse_project_required_attribs(element)
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+            edk_manifest._parse_project_required_attribs(element)
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_parse_required_attribs_returns_name_and_xml_path_when_both_present(self):
         """When name and xmlPath are present, must return (name, xmlPath) without raising."""
         element = self._make_full_element()
 
-        name, xml_path = _parse_project_required_attribs(element)
+        name, xml_path = edk_manifest._parse_project_required_attribs(element)
 
         assert name == TEST_PROJECT_NAME
         assert xml_path == PROJECT_XML_PATH
@@ -69,25 +60,25 @@ class TestProject:
 
     def test_parse_required_attribs_raises_key_error_when_xml_path_missing(self):
         """When xmlPath is absent from the element, must raise KeyError with the required-attrib message."""
-        self._assert_required_attrib_key_error({ATTRIB_NAME: TEST_PROJECT_NAME})
+        self._assert_required_attrib_key_error({helpers.ATTRIB_NAME: TEST_PROJECT_NAME})
 
     def test_init_sets_name_and_xml_path_from_required_attribs(self):
         """When all required attributes are present, __init__ must set name and xmlPath correctly."""
         element = self._make_full_element()
 
-        proj = _Project(element)
+        proj = edk_manifest._Project(element)
 
         assert proj.name == TEST_PROJECT_NAME
         assert proj.xmlPath == PROJECT_XML_PATH
 
     @pytest.mark.parametrize(PROJECT_ARCHIVED_FLAG_FIELDS, [
-        pytest.param(ATTRIB_BOOL_TRUE,    True,  id=ID_TRUE_LOWER),
-        pytest.param(ATTRIB_BOOL_FALSE,   False, id=ID_FALSE_LOWER),
-        pytest.param(None,                False, id=ID_MISSING),
-        pytest.param(ARCHIVED_TRUE_UPPER, True,  id=ID_TRUE_UPPER),
+        pytest.param(helpers.ATTRIB_BOOL_TRUE, True, id=ID_TRUE_LOWER),
+        pytest.param(helpers.ATTRIB_BOOL_FALSE, False, id=ID_FALSE_LOWER),
+        pytest.param(None, False, id=helpers.ID_MISSING),
+        pytest.param(helpers.ARCHIVED_TRUE_UPPER, True, id=ID_TRUE_UPPER),
     ])
     def test_init_archived_flag(self, archived_value, expected):
         """Each archived_value must produce the expected boolean on self.archived."""
         element = self._make_full_element(archived=archived_value)
-        proj = _Project(element)
+        proj = edk_manifest._Project(element)
         assert proj.archived is expected

--- a/edkrepo_manifest_parser/unit_tests/test_project_info.py
+++ b/edkrepo_manifest_parser/unit_tests/test_project_info.py
@@ -13,90 +13,73 @@ import pytest
 from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_text_element,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _ProjectInfo,
-    _parse_project_info_required_fields,
-    ProjectInfo,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ELEMENT_TAG_PROJECT_INFO = 'ProjectInfo'
-CHILD_CODE_NAME          = 'CodeName'
-CHILD_DESCRIPT           = 'Description'
-CHILD_ORG                = 'Org'
-CHILD_SHORT_NAME         = 'ShortName'
-CHILD_LEAD_REVIEWERS     = 'LeadReviewers'
-TEST_PROJECT_NAME        = 'TestProject'
-DESCRIPT                 = 'A test project.'
-LEAD                     = 'lead@example.com'
-ORG                      = 'Intel'
-SHORT_NAME               = 'TP'
-REVIEWER                 = 'reviewer@example.com'
-PARAM_REQUIRED_ABSENT    = 'missing_child'
-ID_CODE_NAME_ABSENT      = 'code_name_absent'
-ID_DESCRIPT_ABSENT       = 'descript_absent'
-ATTR_ORG                 = 'org'
-ATTR_SHORT_NAME          = 'short_name'
-PARAM_OPTIONAL_PRESENT   = 'child_key, value, attr'
-PARAM_OPTIONAL_ABSENT    = 'attr'
-ID_ORG_PRESENT           = 'org_present'
-ID_SHORT_NAME_PRESENT    = 'short_name_present'
-ID_ORG_ABSENT            = 'org_absent'
-ID_SHORT_NAME_ABSENT     = 'short_name_absent'
+ELEMENT_TAG_PROJECT_INFO = 'edk_manifest.ProjectInfo'
+CHILD_CODE_NAME = 'CodeName'
+CHILD_DESCRIPT = 'Description'
+CHILD_ORG = 'Org'
+CHILD_SHORT_NAME = 'ShortName'
+CHILD_LEAD_REVIEWERS = 'LeadReviewers'
+TEST_PROJECT_NAME = 'TestProject'
+DESCRIPT = 'A test project.'
+LEAD = 'lead@example.com'
+ORG = 'Intel'
+SHORT_NAME = 'TP'
+REVIEWER = 'reviewer@example.com'
+PARAM_REQUIRED_ABSENT = 'missing_child'
+ID_CODE_NAME_ABSENT = 'code_name_absent'
+ID_DESCRIPT_ABSENT = 'descript_absent'
+ATTR_ORG = 'org'
+ATTR_SHORT_NAME = 'short_name'
+PARAM_OPTIONAL_PRESENT = 'child_key, value, attr'
+PARAM_OPTIONAL_ABSENT = 'attr'
+ID_ORG_PRESENT = 'org_present'
+ID_SHORT_NAME_PRESENT = 'short_name_present'
+ID_ORG_ABSENT = 'org_absent'
+ID_SHORT_NAME_ABSENT = 'short_name_absent'
 
 
 class TestProjectInfo:
 
-    @staticmethod
-    def _make_mock_element(find_map=None, dev_leads=None):
-        """Build a mock XML element using find_map for find() calls and dev_leads for findall('DevLead')."""
-        elem = MagicMock()
-        elem.tag = ELEMENT_TAG_PROJECT_INFO
-        fm = find_map if find_map is not None else {}
-        elem.find.side_effect = lambda tag: fm.get(tag)
-        elem.findall.return_value = dev_leads if dev_leads is not None else []
-        return elem
-
-    @staticmethod
-    def _make_required_element():
-        """Build a mock element with only the required CodeName and Description children."""
-        find_map = {
-            CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-            CHILD_DESCRIPT: make_text_element(DESCRIPT),
-        }
-        return TestProjectInfo._make_mock_element(find_map=find_map)
+    @pytest.fixture
+    def required_element(self):
+        """Return a fresh mock element with only the required CodeName and Description children."""
+        return helpers.make_find_map_element(
+            find_map={
+                CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+                CHILD_DESCRIPT: helpers.make_text_element(DESCRIPT),
+            },
+            tag=ELEMENT_TAG_PROJECT_INFO,
+        )
 
     @pytest.fixture
-    def required_info(self):
-        """Build and return a _ProjectInfo instance with only the required CodeName and Description children."""
-        return _ProjectInfo(self._make_required_element())
+    def required_info(self, required_element):
+        """Return a edk_manifest._ProjectInfo instance built from an element with only the required CodeName and Description children."""
+        return edk_manifest._ProjectInfo(required_element)
 
-    def test_parse_required_fields_returns_codename_and_descript_when_both_present(self):
+    def test_parse_required_fields_returns_codename_and_descript_when_both_present(self, required_element):
         """When CodeName and Description children are present, must return (codename, descript)."""
-        element = self._make_required_element()
-
-        codename, descript = _parse_project_info_required_fields(element)
+        codename, descript = edk_manifest._parse_project_info_required_fields(required_element)
 
         assert codename == TEST_PROJECT_NAME
         assert descript == DESCRIPT
 
     @pytest.mark.parametrize(PARAM_REQUIRED_ABSENT, [
         pytest.param(CHILD_CODE_NAME, id=ID_CODE_NAME_ABSENT),
-        pytest.param(CHILD_DESCRIPT,  id=ID_DESCRIPT_ABSENT),
+        pytest.param(CHILD_DESCRIPT, id=ID_DESCRIPT_ABSENT),
     ])
     def test_parse_required_fields_raises_when_required_child_absent(self, missing_child):
         """When a required child element is absent, must raise AttributeError."""
         find_map = {
-            CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-            CHILD_DESCRIPT:  make_text_element(DESCRIPT),
+            CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+            CHILD_DESCRIPT:  helpers.make_text_element(DESCRIPT),
         }
         del find_map[missing_child]
-        element = self._make_mock_element(find_map=find_map)
-
+        element = helpers.make_find_map_element(find_map=find_map, tag=ELEMENT_TAG_PROJECT_INFO)
         with pytest.raises(AttributeError):
-            _parse_project_info_required_fields(element)
+            edk_manifest._parse_project_info_required_fields(element)
 
     def test_init_sets_codename_and_descript(self, required_info):
         """When required children are present, __init__ must set codename and descript correctly."""
@@ -105,16 +88,17 @@ class TestProjectInfo:
 
     def test_init_builds_lead_list_from_dev_lead_children(self):
         """When DevLead child elements are present, __init__ must populate lead_list with their text values."""
-        lead_mock = make_text_element(LEAD)
-        element = self._make_mock_element(
+        lead_mock = helpers.make_text_element(LEAD)
+        element = helpers.make_find_map_element(
             find_map={
-                CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-                CHILD_DESCRIPT: make_text_element(DESCRIPT),
+                CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+                CHILD_DESCRIPT: helpers.make_text_element(DESCRIPT),
             },
             dev_leads=[lead_mock],
+            tag=ELEMENT_TAG_PROJECT_INFO,
         )
 
-        info = _ProjectInfo(element)
+        info = edk_manifest._ProjectInfo(element)
 
         assert info.lead_list == [LEAD]
 
@@ -123,23 +107,23 @@ class TestProjectInfo:
         assert required_info.lead_list == []
 
     @pytest.mark.parametrize(PARAM_OPTIONAL_PRESENT, [
-        pytest.param(CHILD_ORG,        ORG,        ATTR_ORG,        id=ID_ORG_PRESENT),
+        pytest.param(CHILD_ORG, ORG, ATTR_ORG, id=ID_ORG_PRESENT),
         pytest.param(CHILD_SHORT_NAME, SHORT_NAME, ATTR_SHORT_NAME, id=ID_SHORT_NAME_PRESENT),
     ])
     def test_init_sets_optional_field_when_present(self, child_key, value, attr):
         """When an optional child element is present, __init__ must set the field to its text value."""
-        element = self._make_mock_element(find_map={
-            CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-            CHILD_DESCRIPT: make_text_element(DESCRIPT),
-            child_key: make_text_element(value),
-        })
+        element = helpers.make_find_map_element(find_map={
+            CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+            CHILD_DESCRIPT: helpers.make_text_element(DESCRIPT),
+            child_key: helpers.make_text_element(value),
+        }, tag=ELEMENT_TAG_PROJECT_INFO)
 
-        info = _ProjectInfo(element)
+        info = edk_manifest._ProjectInfo(element)
 
         assert getattr(info, attr) == value
 
     @pytest.mark.parametrize(PARAM_OPTIONAL_ABSENT, [
-        pytest.param(ATTR_ORG,        id=ID_ORG_ABSENT),
+        pytest.param(ATTR_ORG, id=ID_ORG_ABSENT),
         pytest.param(ATTR_SHORT_NAME, id=ID_SHORT_NAME_ABSENT),
     ])
     def test_init_sets_optional_field_to_none_when_absent(self, required_info, attr):
@@ -148,16 +132,16 @@ class TestProjectInfo:
 
     def test_init_sets_reviewer_list_from_lead_reviewers(self):
         """When LeadReviewers with Reviewer children is present, __init__ must populate reviewer_list."""
-        reviewer_mock = make_text_element(REVIEWER)
+        reviewer_mock = helpers.make_text_element(REVIEWER)
         lead_reviewers_mock = MagicMock()
         lead_reviewers_mock.iter.return_value = [reviewer_mock]
-        element = self._make_mock_element(find_map={
-            CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-            CHILD_DESCRIPT: make_text_element(DESCRIPT),
+        element = helpers.make_find_map_element(find_map={
+            CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+            CHILD_DESCRIPT: helpers.make_text_element(DESCRIPT),
             CHILD_LEAD_REVIEWERS: lead_reviewers_mock,
-        })
+        }, tag=ELEMENT_TAG_PROJECT_INFO)
 
-        info = _ProjectInfo(element)
+        info = edk_manifest._ProjectInfo(element)
 
         assert info.reviewer_list == [REVIEWER]
 
@@ -166,21 +150,21 @@ class TestProjectInfo:
         assert required_info.reviewer_list is None
 
     def test_tuple_returns_correct_project_info_namedtuple(self):
-        """The tuple property must return a ProjectInfo namedtuple with the correct field values."""
-        lead_mock = make_text_element(LEAD)
-        reviewer_mock = make_text_element(REVIEWER)
+        """The tuple property must return a edk_manifest.ProjectInfo namedtuple with the correct field values."""
+        lead_mock = helpers.make_text_element(LEAD)
+        reviewer_mock = helpers.make_text_element(REVIEWER)
         lead_reviewers_mock = MagicMock()
         lead_reviewers_mock.iter.return_value = [reviewer_mock]
         find_map = {
-            CHILD_CODE_NAME: make_text_element(TEST_PROJECT_NAME),
-            CHILD_DESCRIPT: make_text_element(DESCRIPT),
-            CHILD_ORG: make_text_element(ORG),
-            CHILD_SHORT_NAME: make_text_element(SHORT_NAME),
+            CHILD_CODE_NAME: helpers.make_text_element(TEST_PROJECT_NAME),
+            CHILD_DESCRIPT: helpers.make_text_element(DESCRIPT),
+            CHILD_ORG: helpers.make_text_element(ORG),
+            CHILD_SHORT_NAME: helpers.make_text_element(SHORT_NAME),
             CHILD_LEAD_REVIEWERS: lead_reviewers_mock,
         }
-        result = _ProjectInfo(self._make_mock_element(find_map=find_map, dev_leads=[lead_mock])).tuple
+        result = edk_manifest._ProjectInfo(helpers.make_find_map_element(find_map=find_map, dev_leads=[lead_mock], tag=ELEMENT_TAG_PROJECT_INFO)).tuple
 
-        assert result == ProjectInfo(
+        assert result == edk_manifest.ProjectInfo(
             codename=TEST_PROJECT_NAME,
             description=DESCRIPT,
             dev_leads=[LEAD],
@@ -188,4 +172,3 @@ class TestProjectInfo:
             org=ORG,
             short_name=SHORT_NAME,
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_remote_repo.py
+++ b/edkrepo_manifest_parser/unit_tests/test_remote_repo.py
@@ -12,98 +12,79 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_text,
-    REMOTE_NAME,
-    REMOTE_URL,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _RemoteRepo,
-    _parse_remote_repo_required_attribs,
-    RemoteRepo,
-    REQUIRED_ATTRIB_ERROR_MSG,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_NAME             = 'name'
-ATTRIB_OWNER            = 'owner'
-ATTRIB_REVIEW_TYPE      = 'reviewType'
-ATTRIB_PR_STRATEGY      = 'prStrategy'
-ELEMENT_TAG_REMOTE_REPO = 'RemoteRepo'
-OWNER                   = 'Jane Doe'
-REVIEW_TYPE             = 'gerrit'
-PR_STRATEGY             = 'squash'
-FIELD_OWNER             = 'owner'
-FIELD_REVIEW_TYPE       = 'review_type'
-FIELD_PR_STRATEGY       = 'pr_strategy'
-PARAM_FIELD_NAME          = 'field_name'
-PARAM_FIELD_AND_EXPECTED  = 'field_name, expected_value'
-ID_OWNER_ABSENT           = 'owner_absent'
-ID_REVIEW_TYPE_ABSENT     = 'review_type_absent'
-ID_PR_STRATEGY_ABSENT     = 'pr_strategy_absent'
-ID_OWNER_PRESENT          = 'owner_present'
-ID_REVIEW_TYPE_PRESENT    = 'review_type_present'
-ID_PR_STRATEGY_PRESENT    = 'pr_strategy_present'
+ATTRIB_OWNER = 'owner'
+ATTRIB_REVIEW_TYPE = 'reviewType'
+ATTRIB_PR_STRATEGY = 'prStrategy'
+ELEMENT_TAG_REMOTE_REPO = 'edk_manifest.RemoteRepo'
+OWNER = 'Jane Doe'
+REVIEW_TYPE = 'gerrit'
+PR_STRATEGY = 'squash'
+FIELD_REVIEW_TYPE = 'review_type'
+FIELD_PR_STRATEGY = 'pr_strategy'
+ID_OWNER_ABSENT = 'owner_absent'
+ID_REVIEW_TYPE_ABSENT = 'review_type_absent'
+ID_PR_STRATEGY_ABSENT = 'pr_strategy_absent'
+ID_OWNER_PRESENT = 'owner_present'
+ID_REVIEW_TYPE_PRESENT = 'review_type_present'
+ID_PR_STRATEGY_PRESENT = 'pr_strategy_present'
 
 
 class TestRemoteRepo:
 
-    @staticmethod
-    def _make_full_element():
-        """Build a mock element with all required and optional RemoteRepo attributes."""
-        return make_mock_element_with_text(
+    @pytest.fixture
+    def full_remote_repo(self):
+        """Return a edk_manifest._RemoteRepo built from a fully-populated element with all optional attributes set."""
+        return edk_manifest._RemoteRepo(helpers.make_mock_element_with_text(
             attrib={
-                ATTRIB_NAME: REMOTE_NAME,
+                helpers.ATTRIB_NAME: helpers.REMOTE_NAME,
                 ATTRIB_OWNER: OWNER,
                 ATTRIB_REVIEW_TYPE: REVIEW_TYPE,
                 ATTRIB_PR_STRATEGY: PR_STRATEGY,
             },
-            text=REMOTE_URL,
+            text=helpers.REMOTE_URL,
             tag=ELEMENT_TAG_REMOTE_REPO,
-        )
-
-    @pytest.fixture
-    def full_remote_repo(self):
-        """Return a _RemoteRepo instance with all optional attributes present."""
-        return _RemoteRepo(self._make_full_element())
+        ))
 
     def test_parse_required_attribs_returns_name_and_url_when_name_present(self):
-        """When name is present, _parse_remote_repo_required_attribs must return (name, url)."""
-        element = make_mock_element_with_text(
-            attrib={ATTRIB_NAME: REMOTE_NAME},
-            text=REMOTE_URL,
+        """When name is present, edk_manifest._parse_remote_repo_required_attribs must return (name, url)."""
+        element = helpers.make_mock_element_with_text(
+            attrib={helpers.ATTRIB_NAME: helpers.REMOTE_NAME},
+            text=helpers.REMOTE_URL,
             tag=ELEMENT_TAG_REMOTE_REPO,
         )
 
-        name, url = _parse_remote_repo_required_attribs(element)
+        name, url = edk_manifest._parse_remote_repo_required_attribs(element)
 
-        assert name == REMOTE_NAME
-        assert url == REMOTE_URL
+        assert name == helpers.REMOTE_NAME
+        assert url == helpers.REMOTE_URL
 
     def test_parse_required_attribs_raises_key_error_when_name_missing(self):
-        """When name is absent, _parse_remote_repo_required_attribs must raise KeyError with the required-attrib message."""
-        element = make_mock_element_with_text(attrib={}, text=REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO)
+        """When name is absent, edk_manifest._parse_remote_repo_required_attribs must raise KeyError with the required-attrib message."""
+        element = helpers.make_mock_element_with_text(attrib={}, text=helpers.REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO)
 
         with pytest.raises(KeyError) as exc_info:
-            _parse_remote_repo_required_attribs(element)
+            edk_manifest._parse_remote_repo_required_attribs(element)
 
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_name_and_url_from_required_attribs(self):
         """When name is present, __init__ must set self.name and self.url correctly."""
-        element = make_mock_element_with_text(
-            attrib={ATTRIB_NAME: REMOTE_NAME},
-            text=REMOTE_URL,
+        element = helpers.make_mock_element_with_text(
+            attrib={helpers.ATTRIB_NAME: helpers.REMOTE_NAME},
+            text=helpers.REMOTE_URL,
             tag=ELEMENT_TAG_REMOTE_REPO,
         )
 
-        repo = _RemoteRepo(element)
+        repo = edk_manifest._RemoteRepo(element)
 
-        assert repo.name == REMOTE_NAME
-        assert repo.url == REMOTE_URL
+        assert repo.name == helpers.REMOTE_NAME
+        assert repo.url == helpers.REMOTE_URL
 
-    @pytest.mark.parametrize(PARAM_FIELD_AND_EXPECTED, [
-        pytest.param(FIELD_OWNER, OWNER, id=ID_OWNER_PRESENT),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_AND_EXPECTED, [
+        pytest.param(ATTRIB_OWNER, OWNER, id=ID_OWNER_PRESENT),
         pytest.param(FIELD_REVIEW_TYPE, REVIEW_TYPE, id=ID_REVIEW_TYPE_PRESENT),
         pytest.param(FIELD_PR_STRATEGY, PR_STRATEGY, id=ID_PR_STRATEGY_PRESENT),
     ])
@@ -111,26 +92,26 @@ class TestRemoteRepo:
         """When any optional attribute is present, __init__ must set the corresponding field to its value."""
         assert getattr(full_remote_repo, field_name) == expected_value
 
-    @pytest.mark.parametrize(PARAM_FIELD_NAME, [
-        pytest.param(FIELD_OWNER, id=ID_OWNER_ABSENT),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_NAME, [
+        pytest.param(ATTRIB_OWNER, id=ID_OWNER_ABSENT),
         pytest.param(FIELD_REVIEW_TYPE, id=ID_REVIEW_TYPE_ABSENT),
         pytest.param(FIELD_PR_STRATEGY, id=ID_PR_STRATEGY_ABSENT),
     ])
     def test_init_optional_attrib_defaults_to_none_when_absent(self, field_name):
         """When any optional attribute is absent, __init__ must set the corresponding field to None."""
-        element = make_mock_element_with_text(
-            attrib={ATTRIB_NAME: REMOTE_NAME}, text=REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO,
+        element = helpers.make_mock_element_with_text(
+            attrib={helpers.ATTRIB_NAME: helpers.REMOTE_NAME}, text=helpers.REMOTE_URL, tag=ELEMENT_TAG_REMOTE_REPO,
         )
-        repo = _RemoteRepo(element)
+        repo = edk_manifest._RemoteRepo(element)
         assert getattr(repo, field_name) is None
 
     def test_tuple_returns_correct_remote_repo_namedtuple(self, full_remote_repo):
-        """The tuple property must return a RemoteRepo namedtuple with all field values correct."""
+        """The tuple property must return a edk_manifest.RemoteRepo namedtuple with all field values correct."""
         result = full_remote_repo.tuple
 
-        assert result == RemoteRepo(
-            name=REMOTE_NAME,
-            url=REMOTE_URL,
+        assert result == edk_manifest.RemoteRepo(
+            name=helpers.REMOTE_NAME,
+            url=helpers.REMOTE_URL,
             owner=OWNER,
             review_type=REVIEW_TYPE,
             pr_strategy=PR_STRATEGY,

--- a/edkrepo_manifest_parser/unit_tests/test_repo_hook.py
+++ b/edkrepo_manifest_parser/unit_tests/test_repo_hook.py
@@ -12,36 +12,21 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-    make_mock_remotes,
-    REMOTE_NAME,
-    REMOTE_URL,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _RepoHook,
-    _parse_repo_hook_required_attribs,
-    RepoHook,
-    REQUIRED_ATTRIB_ERROR_MSG,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_SOURCE               = 'source'
-ATTRIB_DESTINATION          = 'destination'
-ATTRIB_REMOTE               = 'remote'
-ATTRIB_DEST_FILE            = 'destination_file'
+ATTRIB_DESTINATION = 'destination'
+ATTRIB_DEST_FILE = 'destination_file'
 ELEMENT_TAG_CLIENT_GIT_HOOK = 'ClientGitHook'
-HOOK_SOURCE                 = '/scripts/pre-commit.sh'
-DEST_PATH                   = '.git/hooks'
-DEST_FILE                   = 'pre-commit'
-PARAM_MISSING_ATTRIB        = 'missing_attrib'
-PARAM_FIELD_AND_EXPECTED    = 'field_name, expected_value'
-FIELD_REMOTE_URL            = 'remote_url'
-FIELD_DEST_FILE             = 'dest_file'
-ID_SOURCE_ABSENT            = 'source_absent'
-ID_DESTINATION_ABSENT       = 'destination_absent'
-ID_REMOTE_URL_FOUND         = 'remote_url_found'
-ID_DEST_FILE_PRESENT        = 'dest_file_present'
+HOOK_SOURCE = '/scripts/pre-commit.sh'
+DEST_PATH = '.git/hooks'
+DEST_FILE = 'pre-commit'
+FIELD_REMOTE_URL = 'remote_url'
+FIELD_DEST_FILE = 'dest_file'
+ID_SOURCE_ABSENT = 'source_absent'
+ID_DESTINATION_ABSENT = 'destination_absent'
+ID_REMOTE_URL_FOUND = 'remote_url_found'
+ID_DEST_FILE_PRESENT = 'dest_file_present'
 
 
 class TestRepoHook:
@@ -49,54 +34,54 @@ class TestRepoHook:
     @pytest.fixture
     def default_remotes(self):
         """Return a remotes dict with a single entry using the class-level constants."""
-        return make_mock_remotes()
+        return helpers.make_mock_remotes()
 
     @pytest.fixture
     def full_hook(self, default_remotes):
-        """Return a _RepoHook built from a full-attribute element and the default remotes."""
-        element = make_mock_element({
-            ATTRIB_SOURCE: HOOK_SOURCE,
+        """Return a edk_manifest._RepoHook built from a full-attribute element and the default remotes."""
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_SOURCE: HOOK_SOURCE,
             ATTRIB_DESTINATION: DEST_PATH,
-            ATTRIB_REMOTE: REMOTE_NAME,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
             ATTRIB_DEST_FILE: DEST_FILE,
         }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
-        return _RepoHook(element, default_remotes)
+        return edk_manifest._RepoHook(element, default_remotes)
 
     def test_parse_required_attribs_returns_source_and_dest_when_both_present(self):
         """When source and destination are present, must return (source, dest_path) without raising."""
-        element = make_mock_element({
-            ATTRIB_SOURCE: HOOK_SOURCE,
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_SOURCE: HOOK_SOURCE,
             ATTRIB_DESTINATION: DEST_PATH,
         }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
 
-        source, dest_path = _parse_repo_hook_required_attribs(element)
+        source, dest_path = edk_manifest._parse_repo_hook_required_attribs(element)
 
         assert source == HOOK_SOURCE
         assert dest_path == DEST_PATH
 
-    @pytest.mark.parametrize(PARAM_MISSING_ATTRIB, [
-        pytest.param(ATTRIB_SOURCE, id=ID_SOURCE_ABSENT),
+    @pytest.mark.parametrize(helpers.PARAM_MISSING_ATTRIB, [
+        pytest.param(helpers.ATTRIB_SOURCE, id=ID_SOURCE_ABSENT),
         pytest.param(ATTRIB_DESTINATION, id=ID_DESTINATION_ABSENT),
     ])
     def test_parse_required_attribs_raises_key_error_when_missing(self, missing_attrib):
         """When any required attribute is absent, must raise KeyError with the required-attrib message."""
         full = {
-            ATTRIB_SOURCE: HOOK_SOURCE,
+            helpers.ATTRIB_SOURCE: HOOK_SOURCE,
             ATTRIB_DESTINATION: DEST_PATH,
         }
         del full[missing_attrib]
-        element = make_mock_element(full, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
+        element = helpers.make_mock_element(full, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
         with pytest.raises(KeyError) as exc_info:
-            _parse_repo_hook_required_attribs(element)
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+            edk_manifest._parse_repo_hook_required_attribs(element)
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_source_and_dest_path(self, full_hook):
         """When all required attributes are present, __init__ must set self.source and self.dest_path correctly."""
         assert full_hook.source == HOOK_SOURCE
         assert full_hook.dest_path == DEST_PATH
 
-    @pytest.mark.parametrize(PARAM_FIELD_AND_EXPECTED, [
-        pytest.param(FIELD_REMOTE_URL, REMOTE_URL, id=ID_REMOTE_URL_FOUND),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_AND_EXPECTED, [
+        pytest.param(FIELD_REMOTE_URL, helpers.REMOTE_URL, id=ID_REMOTE_URL_FOUND),
         pytest.param(FIELD_DEST_FILE, DEST_FILE, id=ID_DEST_FILE_PRESENT),
     ])
     def test_init_sets_optional_field_when_present(self, full_hook, field_name, expected_value):
@@ -105,32 +90,32 @@ class TestRepoHook:
 
     def test_init_sets_remote_url_to_none_when_remote_absent(self):
         """When the remote attribute is absent from the element, __init__ must set self.remote_url to None."""
-        element = make_mock_element({
-            ATTRIB_SOURCE: HOOK_SOURCE,
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_SOURCE: HOOK_SOURCE,
             ATTRIB_DESTINATION: DEST_PATH,
         }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
 
-        hook = _RepoHook(element, {})
+        hook = edk_manifest._RepoHook(element, {})
 
         assert hook.remote_url is None
 
     def test_init_sets_dest_file_to_none_when_absent(self, default_remotes):
         """When the destination_file attribute is absent, __init__ must set self.dest_file to None."""
-        element = make_mock_element({
-            ATTRIB_SOURCE: HOOK_SOURCE,
+        element = helpers.make_mock_element({
+            helpers.ATTRIB_SOURCE: HOOK_SOURCE,
             ATTRIB_DESTINATION: DEST_PATH,
-            ATTRIB_REMOTE: REMOTE_NAME,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
         }, tag=ELEMENT_TAG_CLIENT_GIT_HOOK)
 
-        hook = _RepoHook(element, default_remotes)
+        hook = edk_manifest._RepoHook(element, default_remotes)
 
         assert hook.dest_file is None
 
     def test_tuple_returns_correct_repo_hook_namedtuple(self, full_hook):
-        """The tuple property must return a RepoHook namedtuple with the correct field values."""
-        assert full_hook.tuple == RepoHook(
+        """The tuple property must return a edk_manifest.RepoHook namedtuple with the correct field values."""
+        assert full_hook.tuple == edk_manifest.RepoHook(
             source=HOOK_SOURCE,
             dest_path=DEST_PATH,
             dest_file=DEST_FILE,
-            remote_url=REMOTE_URL,
+            remote_url=helpers.REMOTE_URL,
         )

--- a/edkrepo_manifest_parser/unit_tests/test_repo_source.py
+++ b/edkrepo_manifest_parser/unit_tests/test_repo_source.py
@@ -12,91 +12,66 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element,
-    make_mock_remotes,
-    REMOTE_NAME,
-    REMOTE_URL,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _RepoSource,
-    _parse_repo_source_required_attribs,
-    RepoSource,
-    REQUIRED_ATTRIB_ERROR_MSG,
-    ATTRIBUTE_MISSING_ERROR,
-    INVALID_COMBO_DEFINITION_ERROR,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
 # XML attribute names
-ATTRIB_LOCAL_ROOT        = 'localRoot'
-ATTRIB_REMOTE            = 'remote'
-ATTRIB_BRANCH            = 'branch'
-ATTRIB_COMMIT            = 'commit'
-ATTRIB_TAG               = 'tag'
-ATTRIB_PATCH_SET         = 'patchSet'
-ATTRIB_SPARSE            = 'sparseCheckout'
-ATTRIB_ENABLE_SUB        = 'enableSubmodule'
+ATTRIB_LOCAL_ROOT = 'localRoot'
+ATTRIB_BRANCH = 'branch'
+ATTRIB_COMMIT = 'commit'
+ATTRIB_TAG = 'tag'
+ATTRIB_PATCH_SET = 'patchSet'
+ATTRIB_SPARSE = 'sparseCheckout'
+ATTRIB_ENABLE_SUB = 'enableSubmodule'
 ATTRIB_ENABLE_SUB_LEGACY = 'enable_submodule'
-ATTRIB_VENV_CFG          = 'venv_cfg'
-ATTRIB_BLOBLESS          = 'blobless'
-ATTRIB_TREELESS          = 'treeless'
-ATTRIB_BOOL_TRUE         = 'true'
-ATTRIB_BOOL_FALSE        = 'false'
+ATTRIB_VENV_CFG = 'venv_cfg'
+ATTRIB_BLOBLESS = 'blobless'
+ATTRIB_TREELESS = 'treeless'
 
 # Element tag
-ELEMENT_TAG_SOURCE       = 'Source'
+ELEMENT_TAG_SOURCE = 'Source'
 
 # Test data values
-LOCAL_ROOT               = 'MyRepo'
-NESTED_LOCAL_ROOT        = 'parent/MyRepo'
-BRANCH                   = 'main'
-COMMIT                   = 'abc123'
-TAG                      = 'v1.0.0'
-PATCH_SET                = 'ps-debug'
-VENV_CFG                 = 'venv.cfg'
-FIELD_SPARSE             = 'sparse'
-FIELD_ENABLE_SUB         = 'enableSub'
-FIELD_NESTED_REPO        = 'nested_repo'
-FIELD_COMMIT             = 'commit'
-FIELD_TAG                = 'tag'
-FIELD_PATCH_SET          = 'patch_set'
-FIELD_VENV_CFG           = 'venv_cfg'
-FIELD_BLOBLESS           = 'blobless'
-FIELD_TREELESS           = 'treeless'
-PARAM_BOOL_FIELD         = 'extra, field_name, expected'
-PARAM_PATCH_SET_COMBO    = 'ref_attrib_key, ref_attrib_val'
-PARAM_OPTIONAL_REF       = 'attrib_key, attrib_val, field_name, expected'
-PARAM_PARSE_RAISES       = 'attrib, remotes'
-PARAM_ABSENT_REF         = 'field_name'
-ID_SPARSE_MISSING        = 'sparse_missing'
-ID_SPARSE_TRUE           = 'sparse_true'
-ID_SPARSE_FALSE          = 'sparse_false'
-ID_ENABLE_SUB_MISSING    = 'enable_sub_missing'
-ID_ENABLE_SUB_TRUE       = 'enable_sub_true'
-ID_ENABLE_SUB_FALSE      = 'enable_sub_false'
-ID_BLOBLESS_MISSING      = 'blobless_missing'
-ID_BLOBLESS_TRUE         = 'blobless_true'
-ID_BLOBLESS_FALSE        = 'blobless_false'
-ID_TREELESS_MISSING      = 'treeless_missing'
-ID_TREELESS_TRUE         = 'treeless_true'
-ID_TREELESS_FALSE        = 'treeless_false'
-ID_NESTED_REPO_TRUE      = 'nested_repo_true'
-ID_NESTED_REPO_FALSE     = 'nested_repo_false'
+LOCAL_ROOT = 'MyRepo'
+NESTED_LOCAL_ROOT = 'parent/MyRepo'
+TAG = 'v1.0.0'
+PATCH_SET = 'ps-debug'
+VENV_CFG = 'venv.cfg'
+FIELD_SPARSE = 'sparse'
+FIELD_ENABLE_SUB = 'enableSub'
+FIELD_NESTED_REPO = 'nested_repo'
+FIELD_PATCH_SET = 'patch_set'
+PARAM_BOOL_FIELD = 'extra, field_name, expected'
+PARAM_PATCH_SET_COMBO = 'ref_attrib_key, ref_attrib_val'
+PARAM_PARSE_RAISES = 'attrib, remotes'
+ID_SPARSE_MISSING = 'sparse_missing'
+ID_SPARSE_TRUE = 'sparse_true'
+ID_SPARSE_FALSE = 'sparse_false'
+ID_ENABLE_SUB_MISSING = 'enable_sub_missing'
+ID_ENABLE_SUB_TRUE = 'enable_sub_true'
+ID_ENABLE_SUB_FALSE = 'enable_sub_false'
+ID_BLOBLESS_MISSING = 'blobless_missing'
+ID_BLOBLESS_TRUE = 'blobless_true'
+ID_BLOBLESS_FALSE = 'blobless_false'
+ID_TREELESS_MISSING = 'treeless_missing'
+ID_TREELESS_TRUE = 'treeless_true'
+ID_TREELESS_FALSE = 'treeless_false'
+ID_NESTED_REPO_TRUE = 'nested_repo_true'
+ID_NESTED_REPO_FALSE = 'nested_repo_false'
 ID_PATCH_SET_WITH_BRANCH = 'patch_set_with_branch'
 ID_PATCH_SET_WITH_COMMIT = 'patch_set_with_commit'
-ID_PATCH_SET_WITH_TAG    = 'patch_set_with_tag'
-ID_COMMIT_PRESENT        = 'commit_present'
-ID_TAG_PRESENT           = 'tag_present'
-ID_COMMIT_ABSENT         = 'commit_absent'
-ID_TAG_ABSENT            = 'tag_absent'
-ID_PATCH_SET_ABSENT      = 'patch_set_absent'
-ID_LOCAL_ROOT_MISSING        = 'local_root_missing'
-ID_REMOTE_ATTRIB_MISSING     = 'remote_attrib_missing'
-ID_REMOTE_NOT_IN_REMOTES     = 'remote_not_in_remotes'
-ID_ENABLE_SUB_LEGACY_COMPAT  = 'enable_sub_legacy_compat'
-ID_VENV_CFG_PRESENT          = 'venv_cfg_present'
-ID_VENV_CFG_ABSENT           = 'venv_cfg_absent'
+ID_PATCH_SET_WITH_TAG = 'patch_set_with_tag'
+ID_COMMIT_PRESENT = 'commit_present'
+ID_TAG_PRESENT = 'tag_present'
+ID_COMMIT_ABSENT = 'commit_absent'
+ID_TAG_ABSENT = 'tag_absent'
+ID_PATCH_SET_ABSENT = 'patch_set_absent'
+ID_LOCAL_ROOT_MISSING = 'local_root_missing'
+ID_REMOTE_ATTRIB_MISSING = 'remote_attrib_missing'
+ID_REMOTE_NOT_IN_REMOTES = 'remote_not_in_remotes'
+ID_ENABLE_SUB_LEGACY_COMPAT = 'enable_sub_legacy_compat'
+ID_VENV_CFG_PRESENT = 'venv_cfg_present'
+ID_VENV_CFG_ABSENT = 'venv_cfg_absent'
 
 
 class TestRepoSource:
@@ -104,9 +79,9 @@ class TestRepoSource:
     @staticmethod
     def _make_single_ref_element(ref_key, ref_val):
         """Build a mock element with only the required fields (localRoot, remote) and one ref attribute."""
-        return make_mock_element({
+        return helpers.make_mock_element({
             ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
-            ATTRIB_REMOTE: REMOTE_NAME,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
             ref_key: ref_val,
         }, tag=ELEMENT_TAG_SOURCE)
 
@@ -115,93 +90,88 @@ class TestRepoSource:
         """Return minimum valid attributes dict (mutable - tests can modify as needed)."""
         return {
             ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
-            ATTRIB_REMOTE: REMOTE_NAME,
-            ATTRIB_BRANCH: BRANCH,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
+            ATTRIB_BRANCH: helpers.BRANCH,
         }
 
     @pytest.fixture
     def default_remotes(self):
         """Return a remotes dict with a single entry."""
-        return make_mock_remotes()
+        return helpers.make_mock_remotes()
 
     @pytest.fixture
     def base_source(self, base_attrib, default_remotes):
-        """Return a _RepoSource built from minimum valid attributes."""
-        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
-        return _RepoSource(element, default_remotes)
+        """Return a edk_manifest._RepoSource built from minimum valid attributes."""
+        element = helpers.make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        return edk_manifest._RepoSource(element, default_remotes)
 
     def test_parse_required_attribs_returns_all_three_when_all_present(self, default_remotes):
         """When all required attributes and the remote key are present, must return (root, remote_name, remote_url)."""
-        element = make_mock_element({
+        element = helpers.make_mock_element({
             ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
-            ATTRIB_REMOTE: REMOTE_NAME,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
         }, tag=ELEMENT_TAG_SOURCE)
 
-        root, remote_name, remote_url = _parse_repo_source_required_attribs(element, default_remotes)
+        root, remote_name, remote_url = edk_manifest._parse_repo_source_required_attribs(element, default_remotes)
 
         assert root == LOCAL_ROOT
-        assert remote_name == REMOTE_NAME
-        assert remote_url == REMOTE_URL
+        assert remote_name == helpers.REMOTE_NAME
+        assert remote_url == helpers.REMOTE_URL
 
     @pytest.mark.parametrize(PARAM_PARSE_RAISES, [
         pytest.param(
-            {ATTRIB_REMOTE: REMOTE_NAME},
-            make_mock_remotes(),
+            {helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME}, helpers.make_mock_remotes(),
             id=ID_LOCAL_ROOT_MISSING,
         ),
         pytest.param(
-            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT},
-            make_mock_remotes(),
+            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT}, helpers.make_mock_remotes(),
             id=ID_REMOTE_ATTRIB_MISSING,
         ),
         pytest.param(
-            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT, ATTRIB_REMOTE: REMOTE_NAME},
-            {},
-            id=ID_REMOTE_NOT_IN_REMOTES,
-        ),
+            {ATTRIB_LOCAL_ROOT: LOCAL_ROOT, helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME}, {}, id=ID_REMOTE_NOT_IN_REMOTES, ),
     ])
     def test_parse_required_attribs_raises_key_error(self, attrib, remotes):
         """When any required attribute or remote lookup is missing, must raise KeyError with the required-attrib message."""
-        element = make_mock_element(attrib, tag=ELEMENT_TAG_SOURCE)
+        element = helpers.make_mock_element(attrib, tag=ELEMENT_TAG_SOURCE)
 
         with pytest.raises(KeyError) as exc_info:
-            _parse_repo_source_required_attribs(element, remotes)
+            edk_manifest._parse_repo_source_required_attribs(element, remotes)
 
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_all_required_fields(self, base_source):
         """When all required attributes are present, __init__ must set root, remote_name, and remote_url correctly."""
         assert base_source.root == LOCAL_ROOT
-        assert base_source.remote_name == REMOTE_NAME
-        assert base_source.remote_url == REMOTE_URL
+        assert base_source.remote_name == helpers.REMOTE_NAME
+        assert base_source.remote_url == helpers.REMOTE_URL
 
     def test_init_sets_branch_when_present(self, base_source):
         """When the branch attribute is present, __init__ must set self.branch to its value."""
-        assert base_source.branch == BRANCH
+        assert base_source.branch == helpers.BRANCH
 
     def test_init_sets_branch_to_none_when_absent(self):
         """When the branch attribute is absent, __init__ must set self.branch to None."""
-        element = self._make_single_ref_element(ATTRIB_COMMIT, COMMIT)
-        assert _RepoSource(element, make_mock_remotes()).branch is None
+        element = self._make_single_ref_element(ATTRIB_COMMIT, helpers.COMMIT)
+        assert edk_manifest._RepoSource(element, helpers.make_mock_remotes()).branch is None
 
-    @pytest.mark.parametrize(PARAM_OPTIONAL_REF, [
-        pytest.param(ATTRIB_COMMIT,            COMMIT,           FIELD_COMMIT,     COMMIT,   id=ID_COMMIT_PRESENT),
-        pytest.param(ATTRIB_TAG,               TAG,              FIELD_TAG,        TAG,      id=ID_TAG_PRESENT),
-        pytest.param(ATTRIB_ENABLE_SUB_LEGACY, ATTRIB_BOOL_TRUE, FIELD_ENABLE_SUB, True,     id=ID_ENABLE_SUB_LEGACY_COMPAT),
-        pytest.param(ATTRIB_VENV_CFG,          VENV_CFG,         FIELD_VENV_CFG,   VENV_CFG, id=ID_VENV_CFG_PRESENT),
+    @pytest.mark.parametrize(helpers.PARAM_ATTRIB_VAL_FIELD_EXPECTED, [
+        pytest.param(ATTRIB_COMMIT, helpers.COMMIT, ATTRIB_COMMIT, helpers.COMMIT, id=ID_COMMIT_PRESENT),
+        pytest.param(ATTRIB_TAG, TAG, ATTRIB_TAG, TAG, id=ID_TAG_PRESENT),
+        pytest.param(ATTRIB_ENABLE_SUB_LEGACY, helpers.ATTRIB_BOOL_TRUE, FIELD_ENABLE_SUB, True, id=ID_ENABLE_SUB_LEGACY_COMPAT),
+        pytest.param(ATTRIB_VENV_CFG, VENV_CFG, ATTRIB_VENV_CFG, VENV_CFG, id=ID_VENV_CFG_PRESENT),
     ])
     def test_init_sets_optional_field_when_present(self, base_attrib, default_remotes, attrib_key, attrib_val, field_name, expected):
         """When an optional attribute is present, __init__ must set the corresponding field to its value."""
         base_attrib[attrib_key] = attrib_val
-        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
-        rs = _RepoSource(element, default_remotes)
+        element = helpers.make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = edk_manifest._RepoSource(element, default_remotes)
         assert getattr(rs, field_name) == expected
 
-    @pytest.mark.parametrize(PARAM_ABSENT_REF, [
-        pytest.param(FIELD_COMMIT,    id=ID_COMMIT_ABSENT),
-        pytest.param(FIELD_TAG,       id=ID_TAG_ABSENT),
+    @pytest.mark.parametrize(helpers.PARAM_FIELD_NAME, [
+        pytest.param(ATTRIB_COMMIT, id=ID_COMMIT_ABSENT),
+        pytest.param(ATTRIB_TAG, id=ID_TAG_ABSENT),
         pytest.param(FIELD_PATCH_SET, id=ID_PATCH_SET_ABSENT),
-        pytest.param(FIELD_VENV_CFG,  id=ID_VENV_CFG_ABSENT),
+        pytest.param(ATTRIB_VENV_CFG, id=ID_VENV_CFG_ABSENT),
     ])
     def test_init_sets_optional_field_to_none_when_absent(self, base_source, field_name):
         """When any optional attribute is absent, __init__ must set the corresponding field to None."""
@@ -210,80 +180,80 @@ class TestRepoSource:
     def test_init_sets_patch_set_when_present(self):
         """When the patchSet attribute is present and no other ref is given, __init__ must set self.patch_set to its value."""
         element = self._make_single_ref_element(ATTRIB_PATCH_SET, PATCH_SET)
-        assert _RepoSource(element, make_mock_remotes()).patch_set == PATCH_SET
+        assert edk_manifest._RepoSource(element, helpers.make_mock_remotes()).patch_set == PATCH_SET
 
     @pytest.mark.parametrize(PARAM_BOOL_FIELD, [
-        pytest.param({},                                      FIELD_SPARSE,      False, id=ID_SPARSE_MISSING),
-        pytest.param({ATTRIB_SPARSE:      ATTRIB_BOOL_TRUE},  FIELD_SPARSE,      True,  id=ID_SPARSE_TRUE),
-        pytest.param({ATTRIB_SPARSE:      ATTRIB_BOOL_FALSE}, FIELD_SPARSE,      False, id=ID_SPARSE_FALSE),
-        pytest.param({},                                      FIELD_ENABLE_SUB,  False, id=ID_ENABLE_SUB_MISSING),
-        pytest.param({ATTRIB_ENABLE_SUB:  ATTRIB_BOOL_TRUE},  FIELD_ENABLE_SUB,  True,  id=ID_ENABLE_SUB_TRUE),
-        pytest.param({ATTRIB_ENABLE_SUB:  ATTRIB_BOOL_FALSE}, FIELD_ENABLE_SUB,  False, id=ID_ENABLE_SUB_FALSE),
-        pytest.param({},                                      FIELD_BLOBLESS,    False, id=ID_BLOBLESS_MISSING),
-        pytest.param({ATTRIB_BLOBLESS:    ATTRIB_BOOL_TRUE},  FIELD_BLOBLESS,    True,  id=ID_BLOBLESS_TRUE),
-        pytest.param({ATTRIB_BLOBLESS:    ATTRIB_BOOL_FALSE}, FIELD_BLOBLESS,    False, id=ID_BLOBLESS_FALSE),
-        pytest.param({},                                      FIELD_TREELESS,    False, id=ID_TREELESS_MISSING),
-        pytest.param({ATTRIB_TREELESS:    ATTRIB_BOOL_TRUE},  FIELD_TREELESS,    True,  id=ID_TREELESS_TRUE),
-        pytest.param({ATTRIB_TREELESS:    ATTRIB_BOOL_FALSE}, FIELD_TREELESS,    False, id=ID_TREELESS_FALSE),
-        pytest.param({ATTRIB_LOCAL_ROOT:  NESTED_LOCAL_ROOT}, FIELD_NESTED_REPO, True,  id=ID_NESTED_REPO_TRUE),
-        pytest.param({},                                      FIELD_NESTED_REPO, False, id=ID_NESTED_REPO_FALSE),
+        pytest.param({}, FIELD_SPARSE, False, id=ID_SPARSE_MISSING),
+        pytest.param({ATTRIB_SPARSE: helpers.ATTRIB_BOOL_TRUE}, FIELD_SPARSE, True, id=ID_SPARSE_TRUE),
+        pytest.param({ATTRIB_SPARSE: helpers.ATTRIB_BOOL_FALSE}, FIELD_SPARSE, False, id=ID_SPARSE_FALSE),
+        pytest.param({}, FIELD_ENABLE_SUB, False, id=ID_ENABLE_SUB_MISSING),
+        pytest.param({ATTRIB_ENABLE_SUB: helpers.ATTRIB_BOOL_TRUE}, FIELD_ENABLE_SUB, True, id=ID_ENABLE_SUB_TRUE),
+        pytest.param({ATTRIB_ENABLE_SUB: helpers.ATTRIB_BOOL_FALSE}, FIELD_ENABLE_SUB, False, id=ID_ENABLE_SUB_FALSE),
+        pytest.param({}, ATTRIB_BLOBLESS, False, id=ID_BLOBLESS_MISSING),
+        pytest.param({ATTRIB_BLOBLESS: helpers.ATTRIB_BOOL_TRUE}, ATTRIB_BLOBLESS, True, id=ID_BLOBLESS_TRUE),
+        pytest.param({ATTRIB_BLOBLESS: helpers.ATTRIB_BOOL_FALSE}, ATTRIB_BLOBLESS, False, id=ID_BLOBLESS_FALSE),
+        pytest.param({}, ATTRIB_TREELESS, False, id=ID_TREELESS_MISSING),
+        pytest.param({ATTRIB_TREELESS: helpers.ATTRIB_BOOL_TRUE}, ATTRIB_TREELESS, True, id=ID_TREELESS_TRUE),
+        pytest.param({ATTRIB_TREELESS: helpers.ATTRIB_BOOL_FALSE}, ATTRIB_TREELESS, False, id=ID_TREELESS_FALSE),
+        pytest.param({ATTRIB_LOCAL_ROOT: NESTED_LOCAL_ROOT}, FIELD_NESTED_REPO, True, id=ID_NESTED_REPO_TRUE),
+        pytest.param({}, FIELD_NESTED_REPO, False, id=ID_NESTED_REPO_FALSE),
     ])
     def test_init_sets_bool_field(self, base_attrib, extra, field_name, expected):
         """Each boolean attribute must default to False when absent and map 'true'/'false' to True/False correctly."""
         base_attrib.update(extra)
-        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
-        rs = _RepoSource(element, make_mock_remotes())
+        element = helpers.make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = edk_manifest._RepoSource(element, helpers.make_mock_remotes())
         assert getattr(rs, field_name) is expected
 
     def test_init_raises_key_error_when_no_ref_specified(self):
         """When none of branch, commit, tag, or patchSet is specified, __init__ must raise KeyError."""
-        element = make_mock_element({ATTRIB_LOCAL_ROOT: LOCAL_ROOT, ATTRIB_REMOTE: REMOTE_NAME}, tag=ELEMENT_TAG_SOURCE)
+        element = helpers.make_mock_element({ATTRIB_LOCAL_ROOT: LOCAL_ROOT, helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME}, tag=ELEMENT_TAG_SOURCE)
 
         with pytest.raises(KeyError) as exc_info:
-            _RepoSource(element, make_mock_remotes())
+            edk_manifest._RepoSource(element, helpers.make_mock_remotes())
 
-        assert exc_info.value.args[0] == ATTRIBUTE_MISSING_ERROR
+        assert exc_info.value.args[0] == edk_manifest.ATTRIBUTE_MISSING_ERROR
 
     @pytest.mark.parametrize(PARAM_PATCH_SET_COMBO, [
-        pytest.param(ATTRIB_BRANCH, BRANCH, id=ID_PATCH_SET_WITH_BRANCH),
-        pytest.param(ATTRIB_COMMIT, COMMIT, id=ID_PATCH_SET_WITH_COMMIT),
-        pytest.param(ATTRIB_TAG,    TAG,    id=ID_PATCH_SET_WITH_TAG),
+        pytest.param(ATTRIB_BRANCH, helpers.BRANCH, id=ID_PATCH_SET_WITH_BRANCH),
+        pytest.param(ATTRIB_COMMIT, helpers.COMMIT, id=ID_PATCH_SET_WITH_COMMIT),
+        pytest.param(ATTRIB_TAG, TAG, id=ID_PATCH_SET_WITH_TAG),
     ])
     def test_init_raises_value_error_when_patch_set_combined_with_ref(self, default_remotes, ref_attrib_key, ref_attrib_val):
         """When patchSet is specified alongside any other ref attribute, __init__ must raise ValueError."""
-        element = make_mock_element({
+        element = helpers.make_mock_element({
             ATTRIB_LOCAL_ROOT: LOCAL_ROOT,
-            ATTRIB_REMOTE: REMOTE_NAME,
+            helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME,
             ATTRIB_PATCH_SET: PATCH_SET,
             ref_attrib_key: ref_attrib_val,
         }, tag=ELEMENT_TAG_SOURCE)
 
         with pytest.raises(ValueError) as exc_info:
-            _RepoSource(element, default_remotes)
+            edk_manifest._RepoSource(element, default_remotes)
 
-        assert str(exc_info.value) == INVALID_COMBO_DEFINITION_ERROR
+        assert str(exc_info.value) == edk_manifest.INVALID_COMBO_DEFINITION_ERROR
 
     def test_tuple_returns_correct_repo_source_namedtuple(self, base_attrib, default_remotes):
-        """The tuple property must return a RepoSource namedtuple with all field values correct."""
+        """The tuple property must return a edk_manifest.RepoSource namedtuple with all field values correct."""
         base_attrib.update({
-            ATTRIB_COMMIT:     COMMIT,
-            ATTRIB_SPARSE:     ATTRIB_BOOL_TRUE,
-            ATTRIB_ENABLE_SUB: ATTRIB_BOOL_FALSE,
+            ATTRIB_COMMIT:     helpers.COMMIT,
+            ATTRIB_SPARSE:     helpers.ATTRIB_BOOL_TRUE,
+            ATTRIB_ENABLE_SUB: helpers.ATTRIB_BOOL_FALSE,
             ATTRIB_VENV_CFG:   VENV_CFG,
-            ATTRIB_BLOBLESS:   ATTRIB_BOOL_FALSE,
-            ATTRIB_TREELESS:   ATTRIB_BOOL_FALSE,
+            ATTRIB_BLOBLESS:   helpers.ATTRIB_BOOL_FALSE,
+            ATTRIB_TREELESS:   helpers.ATTRIB_BOOL_FALSE,
         })
-        element = make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
-        rs = _RepoSource(element, default_remotes)
+        element = helpers.make_mock_element(base_attrib, tag=ELEMENT_TAG_SOURCE)
+        rs = edk_manifest._RepoSource(element, default_remotes)
 
         result = rs.tuple
 
-        assert result == RepoSource(
+        assert result == edk_manifest.RepoSource(
             root=LOCAL_ROOT,
-            remote_name=REMOTE_NAME,
-            remote_url=REMOTE_URL,
-            branch=BRANCH,
-            commit=COMMIT,
+            remote_name=helpers.REMOTE_NAME,
+            remote_url=helpers.REMOTE_URL,
+            branch=helpers.BRANCH,
+            commit=helpers.COMMIT,
             sparse=True,
             enable_submodule=False,
             tag=None,
@@ -293,4 +263,3 @@ class TestRepoSource:
             treeless=False,
             nested_repo=False,
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_sparse_data.py
+++ b/edkrepo_manifest_parser/unit_tests/test_sparse_data.py
@@ -12,39 +12,23 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_iter,
-    make_text_element,
-    make_empty_element,
-    REMOTE_NAME,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _SparseData,
-    SparseData,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_COMBINATION          = 'combination'
-ATTRIB_REMOTE               = 'remote'
-TAG_ALWAYS_INCLUDE          = 'AlwaysInclude'
-TAG_ALWAYS_EXCLUDE          = 'AlwaysExclude'
-COMBINATION                 = 'mycombo'
-INCLUDE_VALUE               = 'path/to/include'
-EXCLUDE_VALUE               = 'path/to/exclude'
-INCLUDE_MULTI               = 'path/a|path/b'
-EXCLUDE_MULTI               = 'path/c|path/d'
-PIPE_SEPARATOR              = '|'
-FIELD_COMBINATION           = 'combination'
-FIELD_REMOTE_NAME           = 'remote_name'
-FIELD_ALWAYS_INCLUDE        = 'always_include'
-FIELD_ALWAYS_EXCLUDE        = 'always_exclude'
-PARAM_OPTIONAL_ATTRIB       = 'attrib_key, attrib_val, field_name, expected'
-PARAM_LIST_FIELD            = 'tag, text_value, field_name, expected'
-ID_COMBINATION_PRESENT      = 'combination_present'
-ID_REMOTE_NAME_PRESENT      = 'remote_name_present'
-ID_ALWAYS_INCLUDE           = 'always_include'
-ID_ALWAYS_EXCLUDE           = 'always_exclude'
-ID_ALWAYS_INCLUDE_SPLIT     = 'always_include_split'
-ID_ALWAYS_EXCLUDE_SPLIT     = 'always_exclude_split'
+TAG_ALWAYS_INCLUDE = 'AlwaysInclude'
+TAG_ALWAYS_EXCLUDE = 'AlwaysExclude'
+COMBINATION = 'mycombo'
+INCLUDE_VALUE = 'path/to/include'
+EXCLUDE_VALUE = 'path/to/exclude'
+INCLUDE_MULTI = 'path/a|path/b'
+EXCLUDE_MULTI = 'path/c|path/d'
+PIPE_SEPARATOR = '|'
+FIELD_ALWAYS_INCLUDE = 'always_include'
+FIELD_ALWAYS_EXCLUDE = 'always_exclude'
+PARAM_LIST_FIELD = 'tag, text_value, field_name, expected'
+ID_COMBINATION_PRESENT = 'combination_present'
+ID_ALWAYS_INCLUDE_SPLIT = 'always_include_split'
+ID_ALWAYS_EXCLUDE_SPLIT = 'always_exclude_split'
 
 
 class TestSparseData:
@@ -52,33 +36,33 @@ class TestSparseData:
     @staticmethod
     def _assert_child_list_field(tag, text_value, field_name, expected):
         """Build a _SparseData element with one child under tag and assert the named list field equals expected."""
-        child = make_text_element(text_value)
-        element = make_mock_element_with_iter({}, {tag: [child]})
-        sd = _SparseData(element)
+        child = helpers.make_text_element(text_value)
+        element = helpers.make_mock_element_with_iter({}, {tag: [child]})
+        sd = edk_manifest._SparseData(element)
         assert getattr(sd, field_name) == expected
 
     def test_all_fields_default_when_absent(self):
         """When all optional attributes and child elements are absent, __init__ must apply all defaults."""
-        sd = _SparseData(make_empty_element())
+        sd = edk_manifest._SparseData(helpers.make_empty_element())
 
         assert sd.combination is None
         assert sd.remote_name is None
         assert sd.always_include == []
         assert sd.always_exclude == []
 
-    @pytest.mark.parametrize(PARAM_OPTIONAL_ATTRIB, [
-        pytest.param(ATTRIB_COMBINATION, COMBINATION, FIELD_COMBINATION, COMBINATION, id=ID_COMBINATION_PRESENT),
-        pytest.param(ATTRIB_REMOTE,      REMOTE_NAME, FIELD_REMOTE_NAME, REMOTE_NAME, id=ID_REMOTE_NAME_PRESENT),
+    @pytest.mark.parametrize(helpers.PARAM_ATTRIB_VAL_FIELD_EXPECTED, [
+        pytest.param(helpers.ATTRIB_COMBINATION, COMBINATION, helpers.ATTRIB_COMBINATION, COMBINATION, id=ID_COMBINATION_PRESENT),
+        pytest.param(helpers.ATTRIB_REMOTE, helpers.REMOTE_NAME, helpers.FIELD_REMOTE_NAME, helpers.REMOTE_NAME, id=helpers.ID_REMOTE_NAME_PRESENT),
     ])
     def test_init_sets_optional_attrib_when_present(self, attrib_key, attrib_val, field_name, expected):
         """When an optional attribute is present, __init__ must set the corresponding field to its value."""
-        element = make_mock_element_with_iter({attrib_key: attrib_val})
-        sd = _SparseData(element)
+        element = helpers.make_mock_element_with_iter({attrib_key: attrib_val})
+        sd = edk_manifest._SparseData(element)
         assert getattr(sd, field_name) == expected
 
     @pytest.mark.parametrize(PARAM_LIST_FIELD, [
-        pytest.param(TAG_ALWAYS_INCLUDE, INCLUDE_VALUE, FIELD_ALWAYS_INCLUDE, [INCLUDE_VALUE], id=ID_ALWAYS_INCLUDE),
-        pytest.param(TAG_ALWAYS_EXCLUDE, EXCLUDE_VALUE, FIELD_ALWAYS_EXCLUDE, [EXCLUDE_VALUE], id=ID_ALWAYS_EXCLUDE),
+        pytest.param(TAG_ALWAYS_INCLUDE, INCLUDE_VALUE, FIELD_ALWAYS_INCLUDE, [INCLUDE_VALUE], id=FIELD_ALWAYS_INCLUDE),
+        pytest.param(TAG_ALWAYS_EXCLUDE, EXCLUDE_VALUE, FIELD_ALWAYS_EXCLUDE, [EXCLUDE_VALUE], id=FIELD_ALWAYS_EXCLUDE),
     ])
     def test_init_populates_list_field_from_single_child(self, tag, text_value, field_name, expected):
         """When one child element is present, __init__ must append its text to the corresponding list field."""
@@ -94,18 +78,17 @@ class TestSparseData:
 
     def test_tuple_returns_correct_sparse_data_namedtuple(self):
         """The tuple property must return a SparseData namedtuple with all field values correct."""
-        include_elem = make_text_element(INCLUDE_VALUE)
-        exclude_elem = make_text_element(EXCLUDE_VALUE)
-        element = make_mock_element_with_iter(
-            {ATTRIB_COMBINATION: COMBINATION, ATTRIB_REMOTE: REMOTE_NAME},
+        include_elem = helpers.make_text_element(INCLUDE_VALUE)
+        exclude_elem = helpers.make_text_element(EXCLUDE_VALUE)
+        element = helpers.make_mock_element_with_iter(
+            {helpers.ATTRIB_COMBINATION: COMBINATION, helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME},
             {TAG_ALWAYS_INCLUDE: [include_elem], TAG_ALWAYS_EXCLUDE: [exclude_elem]},
         )
-        result = _SparseData(element).tuple
+        result = edk_manifest._SparseData(element).tuple
 
-        assert result == SparseData(
+        assert result == edk_manifest.SparseData(
             combination=COMBINATION,
-            remote_name=REMOTE_NAME,
+            remote_name=helpers.REMOTE_NAME,
             always_include=[INCLUDE_VALUE],
             always_exclude=[EXCLUDE_VALUE],
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_sparse_settings.py
+++ b/edkrepo_manifest_parser/unit_tests/test_sparse_settings.py
@@ -12,38 +12,31 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_iter,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _SparseSettings,
-    SparseSettings,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_SPARSE_BY_DEFAULT        = 'sparseByDefault'
-ATTRIB_BOOL_TRUE                = 'true'
-ATTRIB_BOOL_FALSE               = 'false'
-PARAM_SPARSE_BY_DEFAULT         = 'attrib, expected'
-ID_SPARSE_BY_DEFAULT_ABSENT     = 'sparse_by_default_absent'
-ID_SPARSE_BY_DEFAULT_TRUE       = 'sparse_by_default_true'
-ID_SPARSE_BY_DEFAULT_FALSE      = 'sparse_by_default_false'
+ATTRIB_SPARSE_BY_DEFAULT = 'sparseByDefault'
+PARAM_SPARSE_BY_DEFAULT = 'attrib, expected'
+ID_SPARSE_BY_DEFAULT_ABSENT = 'sparse_by_default_absent'
+ID_SPARSE_BY_DEFAULT_TRUE = 'sparse_by_default_true'
+ID_SPARSE_BY_DEFAULT_FALSE = 'sparse_by_default_false'
 
 
 class TestSparseSettings:
 
     @pytest.mark.parametrize(PARAM_SPARSE_BY_DEFAULT, [
-        pytest.param({},                                              False, id=ID_SPARSE_BY_DEFAULT_ABSENT),
-        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_TRUE},  True,  id=ID_SPARSE_BY_DEFAULT_TRUE),
-        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_FALSE}, False, id=ID_SPARSE_BY_DEFAULT_FALSE),
+        pytest.param({}, False, id=ID_SPARSE_BY_DEFAULT_ABSENT),
+        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: helpers.ATTRIB_BOOL_TRUE}, True, id=ID_SPARSE_BY_DEFAULT_TRUE),
+        pytest.param({ATTRIB_SPARSE_BY_DEFAULT: helpers.ATTRIB_BOOL_FALSE}, False, id=ID_SPARSE_BY_DEFAULT_FALSE),
     ])
     def test_init_sets_sparse_by_default(self, attrib, expected):
         """When sparseByDefault is absent, 'true', or 'false', __init__ must set self.sparse_by_default correctly."""
-        element = make_mock_element_with_iter(attrib)
-        assert _SparseSettings(element).sparse_by_default is expected
+        element = helpers.make_mock_element_with_iter(attrib)
+        assert edk_manifest._SparseSettings(element).sparse_by_default is expected
 
     def test_tuple_returns_correct_sparse_settings_namedtuple(self):
         """The tuple property must return a SparseSettings namedtuple with the correct sparse_by_default value."""
-        element = make_mock_element_with_iter({ATTRIB_SPARSE_BY_DEFAULT: ATTRIB_BOOL_TRUE})
-        ss = _SparseSettings(element)
+        element = helpers.make_mock_element_with_iter({ATTRIB_SPARSE_BY_DEFAULT: helpers.ATTRIB_BOOL_TRUE})
+        ss = edk_manifest._SparseSettings(element)
 
-        assert ss.tuple == SparseSettings(sparse_by_default=True)
+        assert ss.tuple == edk_manifest.SparseSettings(sparse_by_default=True)

--- a/edkrepo_manifest_parser/unit_tests/test_submodule_alternate_remote.py
+++ b/edkrepo_manifest_parser/unit_tests/test_submodule_alternate_remote.py
@@ -12,32 +12,16 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_text,
-    make_mock_remotes,
-    REMOTE_NAME,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _SubmoduleAlternateRemote,
-    _parse_submodule_alternate_remote_attribs,
-    SubmoduleAlternateRemote,
-    REQUIRED_ATTRIB_ERROR_MSG,
-    NO_REMOTE_EXISTS_WITH_NAME,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_REMOTE               = 'remote'
-ATTRIB_ORIGINAL_URL         = 'originalUrl'
-ELEMENT_TAG_SUBMODULE_ALT   = 'SubmoduleAlternateRemote'
-ORIGINAL_URL                = 'https://original.example.com/repo.git'
-ALT_URL                     = 'https://alt.example.com/repo.git'
-FIELD_REMOTE_NAME           = 'remote_name'
-FIELD_ORIGINAL_URL          = 'originalUrl'
-FIELD_ALT_URL               = 'altUrl'
-NO_REMOTE_SPLIT_CHAR        = '{'
-PARAM_PARSE_RAISES          = 'attrib'
-ID_REMOTE_MISSING           = 'remote_missing'
-ID_ORIGINAL_URL_MISSING     = 'original_url_missing'
+ATTRIB_ORIGINAL_URL = 'originalUrl'
+ELEMENT_TAG_SUBMODULE_ALT = 'edk_manifest.SubmoduleAlternateRemote'
+ORIGINAL_URL = 'https://original.example.com/repo.git'
+ALT_URL = 'https://alt.example.com/repo.git'
+FIELD_ALT_URL = 'altUrl'
+NO_REMOTE_SPLIT_CHAR = '{'
+ID_ORIGINAL_URL_MISSING = 'original_url_missing'
 
 
 class TestSubmoduleAlternateRemote:
@@ -45,59 +29,58 @@ class TestSubmoduleAlternateRemote:
     @pytest.fixture
     def default_remotes(self):
         """Return a remotes dict with a single entry using REMOTE_NAME."""
-        return make_mock_remotes(REMOTE_NAME)
+        return helpers.make_mock_remotes(helpers.REMOTE_NAME)
 
     @pytest.fixture
     def full_element(self):
-        """Return a mock element with all required attributes set for a SubmoduleAlternateRemote."""
-        return make_mock_element_with_text(
-            {ATTRIB_REMOTE: REMOTE_NAME, ATTRIB_ORIGINAL_URL: ORIGINAL_URL},
+        """Return a mock element with all required attributes set for a edk_manifest.SubmoduleAlternateRemote."""
+        return helpers.make_mock_element_with_text(
+            {helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME, ATTRIB_ORIGINAL_URL: ORIGINAL_URL},
             text=ALT_URL,
             tag=ELEMENT_TAG_SUBMODULE_ALT,
         )
 
     @pytest.fixture
     def full_sar(self, full_element, default_remotes):
-        """Return a _SubmoduleAlternateRemote built from an element with all required attributes set."""
-        return _SubmoduleAlternateRemote(full_element, default_remotes)
+        """Return a edk_manifest._SubmoduleAlternateRemote built from an element with all required attributes set."""
+        return edk_manifest._SubmoduleAlternateRemote(full_element, default_remotes)
 
     def test_parse_returns_all_fields_when_all_present(self, full_element, default_remotes):
         """When all required attributes are present and the remote is in remotes, must return (remote_name, original_url, alt_url)."""
-        remote_name, original_url, alt_url = _parse_submodule_alternate_remote_attribs(full_element, default_remotes)
+        remote_name, original_url, alt_url = edk_manifest._parse_submodule_alternate_remote_attribs(full_element, default_remotes)
 
-        assert remote_name == REMOTE_NAME
+        assert remote_name == helpers.REMOTE_NAME
         assert original_url == ORIGINAL_URL
         assert alt_url == ALT_URL
 
-    @pytest.mark.parametrize(PARAM_PARSE_RAISES, [
-        pytest.param({ATTRIB_ORIGINAL_URL: ORIGINAL_URL}, id=ID_REMOTE_MISSING),
-        pytest.param({ATTRIB_REMOTE: REMOTE_NAME}, id=ID_ORIGINAL_URL_MISSING),
+    @pytest.mark.parametrize(helpers.FIELD_ATTRIB, [
+        pytest.param({ATTRIB_ORIGINAL_URL: ORIGINAL_URL}, id=helpers.ID_REMOTE_MISSING),
+        pytest.param({helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME}, id=ID_ORIGINAL_URL_MISSING),
     ])
     def test_parse_raises_when_required_attrib_missing(self, default_remotes, attrib):
         """When any required attribute is absent, must raise KeyError with the required-attrib message."""
-        element = make_mock_element_with_text(attrib, tag=ELEMENT_TAG_SUBMODULE_ALT)
+        element = helpers.make_mock_element_with_text(attrib, tag=ELEMENT_TAG_SUBMODULE_ALT)
         with pytest.raises(KeyError) as exc_info:
-            _parse_submodule_alternate_remote_attribs(element, default_remotes)
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+            edk_manifest._parse_submodule_alternate_remote_attribs(element, default_remotes)
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_parse_raises_when_remote_not_in_remotes(self, full_element):
         """When the remote attribute value is not a key in the remotes dict, must raise KeyError with the no-remote message."""
         with pytest.raises(KeyError) as exc_info:
-            _parse_submodule_alternate_remote_attribs(full_element, {})
+            edk_manifest._parse_submodule_alternate_remote_attribs(full_element, {})
 
-        assert NO_REMOTE_EXISTS_WITH_NAME.split(NO_REMOTE_SPLIT_CHAR)[0] in exc_info.value.args[0]
+        assert edk_manifest.NO_REMOTE_EXISTS_WITH_NAME.split(NO_REMOTE_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_all_fields(self, full_sar):
         """When all required attributes are valid, __init__ must correctly set remote_name, originalUrl, and altUrl."""
-        assert getattr(full_sar, FIELD_REMOTE_NAME) == REMOTE_NAME
-        assert getattr(full_sar, FIELD_ORIGINAL_URL) == ORIGINAL_URL
+        assert getattr(full_sar, helpers.FIELD_REMOTE_NAME) == helpers.REMOTE_NAME
+        assert getattr(full_sar, ATTRIB_ORIGINAL_URL) == ORIGINAL_URL
         assert getattr(full_sar, FIELD_ALT_URL) == ALT_URL
 
     def test_tuple_returns_correct_submodule_alternate_remote_namedtuple(self, full_sar):
-        """The tuple property must return a SubmoduleAlternateRemote namedtuple with all field values correct."""
-        assert full_sar.tuple == SubmoduleAlternateRemote(
-            remote_name=REMOTE_NAME,
+        """The tuple property must return a edk_manifest.SubmoduleAlternateRemote namedtuple with all field values correct."""
+        assert full_sar.tuple == edk_manifest.SubmoduleAlternateRemote(
+            remote_name=helpers.REMOTE_NAME,
             original_url=ORIGINAL_URL,
             alternate_url=ALT_URL,
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_submodule_init_entry.py
+++ b/edkrepo_manifest_parser/unit_tests/test_submodule_init_entry.py
@@ -12,31 +12,17 @@ import os
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    make_mock_element_with_text,
-    REMOTE_NAME,
-    REQUIRED_ATTRIB_SPLIT_CHAR,
-)
-from edkrepo_manifest_parser.edk_manifest import (
-    _SubmoduleInitEntry,
-    _parse_submodule_init_required_attribs,
-    SubmoduleInitPath,
-    REQUIRED_ATTRIB_ERROR_MSG,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest as edk_manifest
 
-ATTRIB_REMOTE               = 'remote'
-ATTRIB_COMBO                = 'combo'
-ATTRIB_RECURSIVE            = 'recursive'
-ATTRIB_BOOL_TRUE            = 'true'
-ATTRIB_BOOL_FALSE           = 'false'
-ELEMENT_TAG_SUBMODULE_INIT  = 'SubmoduleInitEntry'
-SUBMODULE_PATH_VALUE        = 'some/submodule/path'
-SUBMODULE_COMBO             = 'combo_a'
-FIELD_REMOTE_NAME           = 'remote_name'
-FIELD_PATH                  = 'path'
-PARAM_RECURSIVE_FLAG        = 'attrib_val, expected'
-ID_RECURSIVE_TRUE           = 'recursive_true'
-ID_RECURSIVE_FALSE          = 'recursive_false'
+ATTRIB_COMBO = 'combo'
+ATTRIB_RECURSIVE = 'recursive'
+ELEMENT_TAG_SUBMODULE_INIT = 'SubmoduleInitEntry'
+SUBMODULE_PATH_VALUE = 'some/submodule/path'
+SUBMODULE_COMBO = 'combo_a'
+PARAM_RECURSIVE_FLAG = 'attrib_val, expected'
+ID_RECURSIVE_TRUE = 'recursive_true'
+ID_RECURSIVE_FALSE = 'recursive_false'
 
 
 class TestSubmoduleInitEntry:
@@ -44,37 +30,37 @@ class TestSubmoduleInitEntry:
     @staticmethod
     def _make_required_element(**extra):
         """Build a mock element with the required remote attrib and SUBMODULE_PATH_VALUE text, plus any extra attribs."""
-        attrib = {ATTRIB_REMOTE: REMOTE_NAME}
+        attrib = {helpers.ATTRIB_REMOTE: helpers.REMOTE_NAME}
         attrib.update(extra)
-        return make_mock_element_with_text(attrib, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
+        return helpers.make_mock_element_with_text(attrib, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
 
     @pytest.fixture
     def full_sie(self):
-        """Return a _SubmoduleInitEntry built from an element with required fields only and no optional fields."""
-        return _SubmoduleInitEntry(self._make_required_element())
+        """Return a edk_manifest._SubmoduleInitEntry built from an element with required fields only and no optional fields."""
+        return edk_manifest._SubmoduleInitEntry(self._make_required_element())
 
     def test_parse_returns_all_fields_when_all_present(self):
         """When the required remote attribute is present, must return (remote_name, path) with the correct values."""
         element = self._make_required_element()
 
-        remote_name, path = _parse_submodule_init_required_attribs(element)
+        remote_name, path = edk_manifest._parse_submodule_init_required_attribs(element)
 
-        assert remote_name == REMOTE_NAME
+        assert remote_name == helpers.REMOTE_NAME
         assert path == SUBMODULE_PATH_VALUE
 
     def test_parse_raises_when_remote_missing(self):
         """When the remote attribute is absent, must raise KeyError with the required-attrib message."""
-        element = make_mock_element_with_text({}, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
+        element = helpers.make_mock_element_with_text({}, text=SUBMODULE_PATH_VALUE, tag=ELEMENT_TAG_SUBMODULE_INIT)
 
         with pytest.raises(KeyError) as exc_info:
-            _parse_submodule_init_required_attribs(element)
+            edk_manifest._parse_submodule_init_required_attribs(element)
 
-        assert REQUIRED_ATTRIB_ERROR_MSG.split(REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
+        assert edk_manifest.REQUIRED_ATTRIB_ERROR_MSG.split(helpers.REQUIRED_ATTRIB_SPLIT_CHAR)[0] in exc_info.value.args[0]
 
     def test_init_sets_all_required_fields(self, full_sie):
         """When all required attributes are present, __init__ must correctly set remote_name and path."""
-        assert getattr(full_sie, FIELD_REMOTE_NAME) == REMOTE_NAME
-        assert getattr(full_sie, FIELD_PATH) == SUBMODULE_PATH_VALUE
+        assert getattr(full_sie, helpers.FIELD_REMOTE_NAME) == helpers.REMOTE_NAME
+        assert getattr(full_sie, helpers.ATTRIB_PATH) == SUBMODULE_PATH_VALUE
 
     def test_all_optional_fields_default_when_absent(self, full_sie):
         """When all optional attributes are absent, __init__ must set combo to None and recursive to False."""
@@ -84,25 +70,24 @@ class TestSubmoduleInitEntry:
     def test_combo_when_present(self):
         """When the combo attribute is present, __init__ must set self.combo to its value."""
         element = self._make_required_element(**{ATTRIB_COMBO: SUBMODULE_COMBO})
-        sie = _SubmoduleInitEntry(element)
+        sie = edk_manifest._SubmoduleInitEntry(element)
         assert sie.combo == SUBMODULE_COMBO
 
     @pytest.mark.parametrize(PARAM_RECURSIVE_FLAG, [
-        pytest.param(ATTRIB_BOOL_TRUE,  True,  id=ID_RECURSIVE_TRUE),
-        pytest.param(ATTRIB_BOOL_FALSE, False, id=ID_RECURSIVE_FALSE),
+        pytest.param(helpers.ATTRIB_BOOL_TRUE, True, id=ID_RECURSIVE_TRUE),
+        pytest.param(helpers.ATTRIB_BOOL_FALSE, False, id=ID_RECURSIVE_FALSE),
     ])
     def test_init_sets_recursive_flag(self, attrib_val, expected):
         """When recursive is 'true' or 'false', __init__ must set self.recursive to the expected boolean."""
         element = self._make_required_element(**{ATTRIB_RECURSIVE: attrib_val})
-        sie = _SubmoduleInitEntry(element)
+        sie = edk_manifest._SubmoduleInitEntry(element)
         assert sie.recursive is expected
 
     def test_tuple_returns_correct_submodule_init_path_namedtuple(self, full_sie):
-        """The tuple property must return a SubmoduleInitPath namedtuple with all field values correct."""
-        assert full_sie.tuple == SubmoduleInitPath(
-            remote_name=REMOTE_NAME,
+        """The tuple property must return a edk_manifest.SubmoduleInitPath namedtuple with all field values correct."""
+        assert full_sie.tuple == edk_manifest.SubmoduleInitPath(
+            remote_name=helpers.REMOTE_NAME,
             combo=None,
             recursive=False,
             path=SUBMODULE_PATH_VALUE,
         )
-

--- a/edkrepo_manifest_parser/unit_tests/test_validatemanifest.py
+++ b/edkrepo_manifest_parser/unit_tests/test_validatemanifest.py
@@ -13,35 +13,21 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
-from edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers import (
-    MANIFEST_PATH,
-    CI_INDEX_PATH,
-    PROJECT1_NAME,
-    PROJECT2_NAME,
-)
-from edkrepo_manifest_parser.edk_manifest_validation import (
-    ValidateManifest,
-    _try_parse_manifest_xml,
-)
+import edkrepo_manifest_parser.manifest_parser_unit_test_helpers.helpers as helpers
+import edkrepo_manifest_parser.edk_manifest_validation as emv
 
-PROJECT1_NAME_LOWER      = PROJECT1_NAME.lower()
-MISSING_PROJECT          = 'Missing'
-ACTUAL_CODENAME          = 'ActualCodename'
-HELLO_LOWER              = 'hello'
-HELLO_UPPER              = 'Hello'
-STR_FOO                  = 'foo'
-STR_BAR                  = 'bar'
-BAD_XML_MSG              = 'bad xml'
-RESULT_PARSING           = 'PARSING'
-RESULT_CODENAME          = 'CODENAME'
-RESULT_DUPLICATE         = 'DUPLICATE'
-CASE_EQUAL_FIELDS        = 'str1,str2,expected'
-ID_SAME_CASE             = 'same_case'
-ID_DIFF_CASE             = 'different_case'
-ID_UNEQUAL               = 'unequal'
+PROJECT1_NAME_LOWER = helpers.PROJECT1_NAME.lower()
+MISSING_PROJECT = 'Missing'
+ACTUAL_CODENAME = 'ActualCodename'
+HELLO_UPPER = 'Hello'
+STR_FOO = 'foo'
+STR_BAR = 'bar'
+CASE_EQUAL_FIELDS = 'str1,str2,expected'
+ID_SAME_CASE = 'same_case'
+ID_DIFF_CASE = 'different_case'
+ID_UNEQUAL = 'unequal'
 SINGLE_MATCH_FAIL_FIELDS = 'project,project_list,expected_msg'
-ID_NO_MATCH              = 'no_match'
-ID_MULTIPLE_MATCHES      = 'multiple_matches'
+ID_MULTIPLE_MATCHES = 'multiple_matches'
 
 
 class TestValidateManifest:
@@ -57,13 +43,13 @@ class TestValidateManifest:
 
     @pytest.fixture
     def vm(self):
-        """Return a ValidateManifest instance initialized with MANIFEST_PATH."""
-        return ValidateManifest(MANIFEST_PATH)
+        """Return a emv.ValidateManifest instance initialized with MANIFEST_PATH."""
+        return emv.ValidateManifest(helpers.MANIFEST_PATH)
 
     @staticmethod
     def _make_obj_with_codename(codename):
-        """Build a ValidateManifest instance whose _manifest_xmldata reports the given codename."""
-        obj = ValidateManifest(MANIFEST_PATH)
+        """Build a emv.ValidateManifest instance whose _manifest_xmldata reports the given codename."""
+        obj = emv.ValidateManifest(helpers.MANIFEST_PATH)
         mock_data = MagicMock()
         mock_data.project_info.codename = codename
         obj._manifest_xmldata = mock_data
@@ -71,13 +57,13 @@ class TestValidateManifest:
 
     @staticmethod
     def _call_validate_codename(codename, project):
-        """Build a ValidateManifest with the given codename and return the result of validate_codename."""
+        """Build a emv.ValidateManifest with the given codename and return the result of validate_codename."""
         return TestValidateManifest._make_obj_with_codename(codename).validate_codename(project)
 
     @staticmethod
     def _call_single_match(vm, project, project_list):
         """Call validate_case_insensitive_single_match with CI_INDEX_PATH as the index filename."""
-        return vm.validate_case_insensitive_single_match(project, project_list, CI_INDEX_PATH)
+        return vm.validate_case_insensitive_single_match(project, project_list, helpers.CI_INDEX_PATH)
 
     @staticmethod
     def _assert_parsing_result(vm, expected_result, expected_xmldata):
@@ -88,8 +74,8 @@ class TestValidateManifest:
 
     @staticmethod
     def _assert_try_parse_result(expected_xmldata, expected_error):
-        """Call _try_parse_manifest_xml and assert both returned values."""
-        xmldata, error = _try_parse_manifest_xml(MANIFEST_PATH)
+        """Call emv._try_parse_manifest_xml and assert both returned values."""
+        xmldata, error = emv._try_parse_manifest_xml(helpers.MANIFEST_PATH)
         assert xmldata is expected_xmldata
         assert error is expected_error
 
@@ -99,82 +85,82 @@ class TestValidateManifest:
 
     def test_try_parse_manifest_xml_returns_none_and_exception_on_failure(self, mock_manifest_xml):
         """When ManifestXml raises, must return (None, exception) with the original exception."""
-        exc = TypeError(BAD_XML_MSG)
+        exc = TypeError(helpers.BAD_XML_MSG)
         mock_manifest_xml.side_effect = exc
         self._assert_try_parse_result(None, exc)
 
     def test_validate_parsing_success(self, vm, mock_manifest_xml):
         """When ManifestXml succeeds, must return ("PARSING", True, None) and set _manifest_xmldata."""
-        self._assert_parsing_result(vm, (RESULT_PARSING, True, None), mock_manifest_xml.instance)
+        self._assert_parsing_result(vm, (helpers.RESULT_PARSING, True, None), mock_manifest_xml.instance)
 
     def test_validate_parsing_failure(self, vm, mock_manifest_xml):
         """When ManifestXml raises, must return ("PARSING", False, error) and set _manifest_xmldata to None."""
-        exc = TypeError(BAD_XML_MSG)
+        exc = TypeError(helpers.BAD_XML_MSG)
         mock_manifest_xml.side_effect = exc
-        self._assert_parsing_result(vm, (RESULT_PARSING, False, exc), None)
+        self._assert_parsing_result(vm, (helpers.RESULT_PARSING, False, exc), None)
 
     def test_validate_codename_fails_when_no_manifest_data(self, vm):
         """When _manifest_xmldata is None, must return ('CODENAME', False, message containing the project name)."""
         vm._manifest_xmldata = None
 
-        result = vm.validate_codename(PROJECT1_NAME)
+        result = vm.validate_codename(helpers.PROJECT1_NAME)
 
-        assert result[0] == RESULT_CODENAME
+        assert result[0] == helpers.RESULT_CODENAME
         assert result[1] is False
-        assert PROJECT1_NAME in str(result[2])
+        assert helpers.PROJECT1_NAME in str(result[2])
 
     def test_validate_codename_succeeds_when_codename_matches(self):
         """When _manifest_xmldata.project_info.codename equals the project, must return ('CODENAME', True, None)."""
-        result = self._call_validate_codename(PROJECT1_NAME, PROJECT1_NAME)
+        result = self._call_validate_codename(helpers.PROJECT1_NAME, helpers.PROJECT1_NAME)
 
-        assert result == (RESULT_CODENAME, True, None)
+        assert result == (helpers.RESULT_CODENAME, True, None)
 
     def test_validate_codename_fails_when_codename_mismatches(self):
         """When _manifest_xmldata.project_info.codename differs from the project, must return ('CODENAME', False, message)."""
-        result = self._call_validate_codename(ACTUAL_CODENAME, PROJECT1_NAME)
+        result = self._call_validate_codename(ACTUAL_CODENAME, helpers.PROJECT1_NAME)
 
-        assert result[0] == RESULT_CODENAME
+        assert result[0] == helpers.RESULT_CODENAME
         assert result[1] is False
         assert result[2] is not None
 
     def test_validate_case_insensitive_single_match_exactly_one_match(self, vm):
         """When exactly one case-insensitive match is found, must return ('DUPLICATE', True, None)."""
-        result = self._call_single_match(vm, PROJECT1_NAME, [PROJECT1_NAME, PROJECT2_NAME])
+        result = self._call_single_match(vm, helpers.PROJECT1_NAME, [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME])
 
-        assert result == (RESULT_DUPLICATE, True, None)
+        assert result == (helpers.RESULT_DUPLICATE, True, None)
 
     @pytest.mark.parametrize(SINGLE_MATCH_FAIL_FIELDS, [
-        pytest.param(MISSING_PROJECT, [PROJECT1_NAME, PROJECT2_NAME],       MISSING_PROJECT, id=ID_NO_MATCH),
-        pytest.param(PROJECT1_NAME,   [PROJECT1_NAME, PROJECT1_NAME_LOWER], PROJECT1_NAME,   id=ID_MULTIPLE_MATCHES),
+        pytest.param(MISSING_PROJECT, [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME], MISSING_PROJECT, id=helpers.ID_NO_MATCH),
+        pytest.param(helpers.PROJECT1_NAME, [helpers.PROJECT1_NAME, PROJECT1_NAME_LOWER], helpers.PROJECT1_NAME, id=ID_MULTIPLE_MATCHES),
     ])
     def test_validate_case_insensitive_single_match_fails(self, vm, project, project_list, expected_msg):
         """Must return ('DUPLICATE', False, message) when no match or multiple matches are found."""
         result = self._call_single_match(vm, project, project_list)
 
-        assert result[0] == RESULT_DUPLICATE
+        assert result[0] == helpers.RESULT_DUPLICATE
         assert result[1] is False
         assert expected_msg in str(result[2])
 
     def test_list_entries_returns_matching_entries(self, vm):
         """When the project list contains case-insensitive matches, must return all of them."""
-        project_list = [PROJECT1_NAME, PROJECT1_NAME_LOWER, PROJECT2_NAME]
+        project_list = [helpers.PROJECT1_NAME, PROJECT1_NAME_LOWER, helpers.PROJECT2_NAME]
 
         result = vm.list_entries(PROJECT1_NAME_LOWER, project_list)
 
-        assert PROJECT1_NAME in result
+        assert helpers.PROJECT1_NAME in result
         assert PROJECT1_NAME_LOWER in result
-        assert PROJECT2_NAME not in result
+        assert helpers.PROJECT2_NAME not in result
 
     def test_list_entries_returns_empty_when_no_matches(self, vm):
         """When no entries match the project name, must return an empty list."""
-        result = vm.list_entries(MISSING_PROJECT, [PROJECT1_NAME, PROJECT2_NAME])
+        result = vm.list_entries(MISSING_PROJECT, [helpers.PROJECT1_NAME, helpers.PROJECT2_NAME])
 
         assert result == []
 
     @pytest.mark.parametrize(CASE_EQUAL_FIELDS, [
-        pytest.param(HELLO_LOWER, HELLO_LOWER, True,  id=ID_SAME_CASE),
-        pytest.param(HELLO_UPPER, HELLO_LOWER, True,  id=ID_DIFF_CASE),
-        pytest.param(STR_FOO,     STR_BAR,     False, id=ID_UNEQUAL),
+        pytest.param(helpers.HELLO, helpers.HELLO, True, id=ID_SAME_CASE),
+        pytest.param(HELLO_UPPER, helpers.HELLO, True, id=ID_DIFF_CASE),
+        pytest.param(STR_FOO, STR_BAR, False, id=ID_UNEQUAL),
     ])
     def test_case_insensitive_equal(self, vm, str1, str2, expected):
         """Must return True when str1 and str2 are case-insensitively equal, False otherwise."""


### PR DESCRIPTION
…suite

Changes:
- Consolidated duplicated constants from multiple unit test modules into helpers.py
- Grouped constants by XML attributes, test values, parametrize fields, and IDs
- Updated test modules to import shared constants from helpers
- Added make_find_map_element into helpers.py
- Added all unit test modules references to docs/doc_index.md
- Updated structure of some markdown files to be reset numeration for each test, so it's more maintainable and easier to read

Fixes: #416