### PR TITLE
EdkRepo: Provide and Option to Expose the Absolute Path of Manifest R…

### DIFF
--- a/edkrepo/commands/arguments/edkrepo_cmd_args.py
+++ b/edkrepo/commands/arguments/edkrepo_cmd_args.py
@@ -18,3 +18,4 @@ SUBMODULE_SKIP_HELP = 'Skip the pull or sync of any submodules.'
 COLOR_HELP = 'Force color output (useful with \'less -r\')'
 SOURCE_MANIFEST_REPO_HELP = "The name of the workspace's source global manifest repository"
 PERFORMANCE_HELP = 'Displays performance timing data for successful commands'
+FORMAT_HELP = 'Choose between text or json output format. Default is text.'

--- a/edkrepo/commands/arguments/list_repos_args.py
+++ b/edkrepo/commands/arguments/list_repos_args.py
@@ -14,4 +14,3 @@ list-repos command meta data.
 COMMAND_DESCRIPTION = 'Lists the git repos used by available projects and the branches that are used.'
 ARCHIVED_HELP = 'Include a listing of archived projects.'
 REPOS_HELP = 'Only show the given subset of repos instead of all repos. The name of a repo is determined by the name given by the most manifest files.'
-FORMAT_HELP = 'Choose between text or json output format. Default is text.'

--- a/edkrepo/commands/edkrepo_command.py
+++ b/edkrepo/commands/edkrepo_command.py
@@ -59,3 +59,10 @@ PerformanceArgument = {'name': 'performance',
                        'positional': False,
                        'required': False,
                        'help-text': arguments.PERFORMANCE_HELP}
+
+FormatArgument = {'name': 'format',
+                  'positional': False,
+                  'required': False,
+                  'action': 'store',
+                  'nargs': 1,
+                  'help-text': arguments.FORMAT_HELP}

--- a/edkrepo/commands/humble/common_humble.py
+++ b/edkrepo/commands/humble/common_humble.py
@@ -19,3 +19,4 @@ MANIFEST_REPO = '{}Manifest Directory:{} {{}}'.format(Style.BRIGHT, Style.RESET_
 MANIFEST_REPO_PATH = '{}Manifest Directory Path:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
 MANIFEST_REPO_URL = '{}Manifest Repository URL:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
 MANIFEST_REPO_BRANCH = '{}Manifest Repository Branch:{} {{}}'.format(Style.BRIGHT, Style.RESET_ALL)
+FORMAT_TYPE_INVALID = 'format must be text or json'

--- a/edkrepo/commands/humble/list_repos_humble.py
+++ b/edkrepo/commands/humble/list_repos_humble.py
@@ -24,4 +24,3 @@ REPOSITORIES = 'Repositories:'
 REPO_NAME_AND_URL = '{}{}{{}}{} - [ {}{}{{}}{} ]'.format(Fore.MAGENTA, Style.BRIGHT, Style.RESET_ALL, Fore.RED, Style.BRIGHT, Style.RESET_ALL)
 REPO_NAME_NOT_FOUND = 'repo_name not found'
 REPO_NOT_FOUND_IN_MANIFEST = 'Repo(s) {} not found in any manifest file'
-FORMAT_TYPE_INVALID = 'format must be text or json'

--- a/edkrepo/commands/humble/manifest_repos_humble.py
+++ b/edkrepo/commands/humble/manifest_repos_humble.py
@@ -3,7 +3,7 @@
 ## @file
 # manifest_repos_humble.py
 #
-# Copyright (c) 2020, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2020-2026, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -12,7 +12,9 @@ Contains user visible strings printed by the manifest_repos command.
 '''
 
 CFG_LIST_ENTRY = 'Config File: edkrepo.cfg Manifest Repository Name: {}'
+CFG_LIST_ENTRY_VERBOSE = 'Config File: edkrepo.cfg Manifest Repository Name: {} Manifest Repository Path: {}'
 USER_CFG_LIST_ENTRY = 'Config File: edkrepo_user.cfg Manifest Repository Name: {}'
+USER_CFG_LIST_ENTRY_VERBOSE = 'Config File: edkrepo_user.cfg Manifest Repository Name: {} Manifest Repository Path: {}'
 NAME_REQUIRED = 'The "name" argument is required to add/remove a manifest repository'
 ADD_REQUIRED = 'The "name", "url", "branch" and "path" arguments are required to add a manifest repository'
 CANNOT_REMOVE_CFG = 'Manifest repositories cannot be removed from the edkrepo.cfg file.'

--- a/edkrepo/commands/list_repos_command.py
+++ b/edkrepo/commands/list_repos_command.py
@@ -13,16 +13,17 @@ import json
 import os
 import sys
 
-from edkrepo.commands.edkrepo_command import EdkrepoCommand
+import edkrepo.commands.edkrepo_command as edkrepo_command
 import edkrepo.commands.arguments.list_repos_args as arguments
 import edkrepo.commands.humble.list_repos_humble as humble
+import edkrepo.commands.humble.common_humble as common_humble
 from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoManifestInvalidException
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import pull_all_manifest_repos
 from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
 from edkrepo.config.tool_config import CI_INDEX_FILE_NAME
 from edkrepo_manifest_parser.edk_manifest import CiIndexXml, ManifestXml
 
-class ListReposCommand(EdkrepoCommand):
+class ListReposCommand(edkrepo_command.EdkrepoCommand):
     def __init__(self):
         super().__init__()
         self.repo_names = None
@@ -44,19 +45,14 @@ class ListReposCommand(EdkrepoCommand):
                      'positional': False,
                      'required': False,
                      'help-text': arguments.ARCHIVED_HELP})
-        args.append({'name': 'format',
-                     'positional': False,
-                     'required': False,
-                     'action': 'store',
-                     'nargs': 1,
-                     'help-text': arguments.FORMAT_HELP})
+        args.append(edkrepo_command.FormatArgument)
         return metadata
 
     def run_command(self, args, config):
         json_output = False
         if args.format is not None:
             if args.format[0] not in ['text', 'json']:
-                raise EdkrepoInvalidParametersException(humble.FORMAT_TYPE_INVALID)
+                raise EdkrepoInvalidParametersException(common_humble.FORMAT_TYPE_INVALID)
             if args.format[0] == 'json':
                 json_output = True
         stdout_backup = None

--- a/edkrepo/commands/manifest_repos_command.py
+++ b/edkrepo/commands/manifest_repos_command.py
@@ -8,19 +8,23 @@
 #
 
 import configparser
+import json
+import os
+import sys
 
-from edkrepo.commands.edkrepo_command import EdkrepoCommand
+import edkrepo.commands.edkrepo_command as edkrepo_command
 import edkrepo.commands.arguments.manifest_repo_args as arguments
 import edkrepo.commands.humble.manifest_repos_humble as humble
-from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException
-from edkrepo.common.workspace_maintenance.manifest_repos_maintenance import list_available_manifest_repos
+import edkrepo.commands.humble.common_humble as common_humble
+import edkrepo.common.edkrepo_exception as edkrepo_exception
+import edkrepo.common.workspace_maintenance.manifest_repos_maintenance as manifest_repos_maintenance
 import edkrepo.common.ui_functions as ui_functions
 
 
 
 
 
-class ManifestRepos(EdkrepoCommand):
+class ManifestRepos(edkrepo_command.EdkrepoCommand):
     def __init__(self):
         super().__init__()
 
@@ -69,32 +73,55 @@ class ManifestRepos(EdkrepoCommand):
                      'position': 4,
                      'nargs' : 1,
                      'help-text': arguments.LOCAL_PATH_HELP})
+        args.append(edkrepo_command.FormatArgument)
         return metadata
 
     def run_command(self, args, config):
-        cfg_repos, user_cfg_repos, conflicts = list_available_manifest_repos(config['cfg_file'], config['user_cfg_file'])
+        cfg_repos, user_cfg_repos, _ = manifest_repos_maintenance.list_available_manifest_repos(config['cfg_file'], config['user_cfg_file'])
 
         if args.action == 'list':
-            for repo in cfg_repos:
-                ui_functions.print_info_msg(humble.CFG_LIST_ENTRY.format(repo), header = False)
-            for repo in user_cfg_repos:
-                ui_functions.print_info_msg(humble.USER_CFG_LIST_ENTRY.format(repo), header = False)
+            # Default to text output if JSON is not explicitly specified.
+            format_type = 'text'
+            if args.format is not None:
+                format_type = args.format[0].lower()
+                if format_type not in ['text', 'json']:
+                    raise edkrepo_exception.EdkrepoInvalidParametersException(common_humble.FORMAT_TYPE_INVALID)
 
+            # If the user selected json output, suppress all debug messages
+            # so that the output from edkrepo will be a machine parseable json string
+            stdout_backup = None
+            if format_type == 'json':
+                devnull = open(os.devnull, 'w')
+                sys.stdout.flush()
+                stdout_backup = sys.stdout
+                sys.stdout = devnull
 
-        elif (args.action == ('add' or 'remove')) and not args.name:
-            raise EdkrepoInvalidParametersException(humble.NAME_REQUIRED)
+            try:
+                if format_type == 'json':
+                    json_output = self._list_manifest_repos_json(cfg_repos, user_cfg_repos, config)
+                else:
+                    self._list_manifest_repos(cfg_repos, user_cfg_repos, config, args.verbose)
+            finally:
+                if stdout_backup is not None:
+                    sys.stdout = stdout_backup
+                    devnull.close()
+            if format_type == 'json':
+                print(json_output)
+
+        elif args.action in ('add', 'remove') and not args.name:
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.NAME_REQUIRED)
         elif args.action == 'add' and (not args.branch or not args.url or not args.path):
-            raise EdkrepoInvalidParametersException(humble.ADD_REQUIRED)
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.ADD_REQUIRED)
         elif args.action == 'remove' and args.name and args.name in cfg_repos:
-            raise EdkrepoInvalidParametersException(humble.CANNOT_REMOVE_CFG)
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.CANNOT_REMOVE_CFG)
         elif args.action =='remove' and args.name not in config['user_cfg_file'].manifest_repo_list:
-            raise EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
         elif args.action == 'add' and (args.name in cfg_repos or args.name in user_cfg_repos):
-            raise EdkrepoInvalidParametersException(humble.ALREADY_EXISTS.format(args.name))
+            raise edkrepo_exception.EdkrepoInvalidParametersException(humble.ALREADY_EXISTS.format(args.name))
 
         user_cfg_file_path = config['user_cfg_file'].cfg_filename
 
-        if args.action == 'add' or 'remove':
+        if args.action in ('add', 'remove'):
             user_cfg_file = configparser.ConfigParser(allow_no_value=True)
             user_cfg_file.read(user_cfg_file_path)
             if args.action == 'add':
@@ -110,12 +137,59 @@ class ManifestRepos(EdkrepoCommand):
                     if user_cfg_file.has_option('manifest-repos', args.name):
                         user_cfg_file.remove_option('manifest-repos', args.name)
                     else:
-                        raise EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
+                        raise edkrepo_exception.EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
                 else:
-                    raise EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
+                    raise edkrepo_exception.EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
                 if user_cfg_file.has_section(args.name):
                     user_cfg_file.remove_section(args.name)
                 else:
-                    raise EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
+                    raise edkrepo_exception.EdkrepoInvalidParametersException(humble.REMOVE_NOT_EXIST)
             with open(user_cfg_file_path, 'w') as cfg_stream:
                 user_cfg_file.write(cfg_stream)
+
+    def _list_manifest_repos(self, cfg_repos, user_cfg_repos, config, verbose):
+        for repo in cfg_repos:
+            if verbose:
+                ui_functions.print_info_msg(humble.CFG_LIST_ENTRY_VERBOSE.format(repo, os.path.normpath(manifest_repos_maintenance.get_manifest_repo_path(repo, config))), header = False)
+            else:
+                ui_functions.print_info_msg(humble.CFG_LIST_ENTRY.format(repo), header = False)
+        for repo in user_cfg_repos:
+            if verbose:
+                ui_functions.print_info_msg(humble.USER_CFG_LIST_ENTRY_VERBOSE.format(repo, os.path.normpath(manifest_repos_maintenance.get_manifest_repo_path(repo, config))), header = False)
+            else:
+                ui_functions.print_info_msg(humble.USER_CFG_LIST_ENTRY.format(repo), header = False)
+
+    def _list_manifest_repos_json(self, cfg_repos, user_cfg_repos, config):
+        """Generate JSON output of manifest repositories.
+
+        Args:
+            cfg_repos: List of global config manifest repositories
+            user_cfg_repos: List of user config manifest repositories
+            config: Configuration object
+        """
+        output = {
+            "edkrepo_cfg": {
+                "manifest_repositories": []
+            },
+            "edkrepo_user_cfg": {
+                "manifest_repositories": []
+            }
+        }
+
+        # Add global config repositories
+        for repo in cfg_repos:
+            repo_path = os.path.normpath(manifest_repos_maintenance.get_manifest_repo_path(repo, config))
+            output["edkrepo_cfg"]["manifest_repositories"].append({
+                "name": repo,
+                "path": repo_path
+            })
+
+        # Add user config repositories
+        for repo in user_cfg_repos:
+            repo_path = os.path.normpath(manifest_repos_maintenance.get_manifest_repo_path(repo, config))
+            output["edkrepo_user_cfg"]["manifest_repositories"].append({
+                "name": repo,
+                "path": repo_path
+            })
+
+        return json.dumps(output, indent=2)

--- a/edkrepo/commands/unit_tests/ManifestReposCommand_TestCases.md
+++ b/edkrepo/commands/unit_tests/ManifestReposCommand_TestCases.md
@@ -1,0 +1,155 @@
+# Test Cases for `manifest_repos_command` Module
+
+## Test Structure
+
+Both test classes (`TestListManifestRepos` and `TestListManifestReposJson`) use pytest parameterization to consolidate multiple test scenarios into single test methods. Each parameterized test executes multiple test cases with different inputs, making the tests more maintainable and reducing code duplication.
+
+## Test Cases
+
+### TestListManifestRepos
+Tests the `_list_manifest_repos` method of the ManifestRepos class which displays manifest repository information in text format, with optional verbose output showing repository paths.
+
+**Implementation**: Single parameterized test method (`test_list_manifest_repos`) with 6 test scenarios.
+
+#### 1. Non-Verbose Output with CFG Repos Only
+- **Test ID**: `non_verbose_cfg_only`
+- **Description**: Display only global configuration repositories without verbose details.
+- **Test Data**: `cfg_repos=['repo1', 'repo2']`, `user_cfg_repos=[]`, `verbose=False`
+- **Verification**: 
+  - Verifies `print_info_msg` is called with correct message format for each cfg repo
+  - Verifies repository paths are NOT retrieved (performance optimization)
+  - Verifies correct message strings from `humble.CFG_LIST_ENTRY` are used
+
+#### 2. Non-Verbose Output with User CFG Repos Only
+- **Test ID**: `non_verbose_user_cfg_only`
+- **Description**: Display only user configuration repositories without verbose details.
+- **Test Data**: `cfg_repos=[]`, `user_cfg_repos=['user_repo1', 'user_repo2']`, `verbose=False`
+- **Verification**: 
+  - Verifies `print_info_msg` is called with correct message format for each user cfg repo
+  - Verifies repository paths are NOT retrieved
+  - Verifies correct message strings from `humble.USER_CFG_LIST_ENTRY` are used
+
+#### 3. Empty Repository Lists
+- **Test ID**: `empty_lists`
+- **Description**: Handle the case where no repositories are configured.
+- **Test Data**: `cfg_repos=[]`, `user_cfg_repos=[]`, `verbose=False`
+- **Verification**: 
+  - Verifies no calls to `print_info_msg`
+  - Verifies no calls to path retrieval functions
+
+#### 4. Verbose Output with CFG Repos Only
+- **Test ID**: `verbose_cfg_only`
+- **Description**: Display global configuration repositories with verbose details showing paths.
+- **Test Data**: `cfg_repos=['repo1', 'repo2']`, `user_cfg_repos=[]`, `verbose=True`
+- **Verification**: 
+  - Verifies repository paths are retrieved for each repo
+  - Verifies normalized paths are displayed
+  - Verifies correct verbose message strings from `humble.CFG_LIST_ENTRY_VERBOSE` are used
+
+#### 5. Verbose Output with User CFG Repos Only
+- **Test ID**: `verbose_user_cfg_only`
+- **Description**: Display user configuration repositories with verbose details showing paths.
+- **Test Data**: `cfg_repos=[]`, `user_cfg_repos=['user_repo1', 'user_repo2']`, `verbose=True`
+- **Verification**: 
+  - Verifies repository paths are retrieved for each repo
+  - Verifies normalized paths are displayed
+  - Verifies correct verbose message strings from `humble.USER_CFG_LIST_ENTRY_VERBOSE` are used
+
+#### 6. Verbose Output with Both CFG and User CFG Repos
+- **Test ID**: `verbose_both`
+- **Description**: Display both global and user configuration repositories with verbose details.
+- **Test Data**: `cfg_repos=['repo1', 'repo2']`, `user_cfg_repos=['user_repo1']`, `verbose=True`
+- **Verification**: 
+  - Verifies repository paths are retrieved for all repos
+  - Verifies both cfg and user cfg repos are displayed with normalized paths
+  - Verifies correct message formats for both cfg and user cfg repos
+
+
+### TestListManifestReposJson
+Tests the `_list_manifest_repos_json` method of the ManifestRepos class which generates JSON-formatted output of manifest repository information.
+
+**Implementation**: Single parameterized test method (`test_list_manifest_repos_json`) with 4 test scenarios.
+
+#### 1. JSON Output with CFG Repos Only
+- **Test ID**: `cfg_only`
+- **Description**: Generate JSON output containing only global configuration repositories.
+- **Test Data**: `cfg_repos=['repo1', 'repo2']`, `user_cfg_repos=[]`
+- **Verification**: 
+  - Verifies exact JSON string output with `indent=2` formatting
+  - Verifies `edkrepo_cfg.manifest_repositories` contains 2 entries with correct names and normalized paths
+  - Verifies `edkrepo_user_cfg.manifest_repositories` is empty array
+  - Verifies output is valid JSON and matches expected structure
+
+#### 2. JSON Output with User CFG Repos Only
+- **Test ID**: `user_cfg_only`
+- **Description**: Generate JSON output containing only user configuration repositories.
+- **Test Data**: `cfg_repos=[]`, `user_cfg_repos=['user_repo1', 'user_repo2']`
+- **Verification**: 
+  - Verifies exact JSON string output with `indent=2` formatting
+  - Verifies `edkrepo_cfg.manifest_repositories` is empty array
+  - Verifies `edkrepo_user_cfg.manifest_repositories` contains 2 entries with correct names and normalized paths
+  - Verifies output is valid JSON and matches expected structure
+
+#### 3. JSON Output with Both CFG and User CFG Repos
+- **Test ID**: `both`
+- **Description**: Generate JSON output containing both global and user configuration repositories.
+- **Test Data**: `cfg_repos=['repo1', 'repo2']`, `user_cfg_repos=['user_repo1']`
+- **Verification**: 
+  - Verifies exact JSON string output with `indent=2` formatting
+  - Verifies both repository arrays are populated with their respective repositories
+  - Verifies all entries have correct names and normalized paths
+  - Verifies output is valid JSON and matches expected structure
+
+#### 4. JSON Output with Empty Repository Lists
+- **Test ID**: `empty_lists`
+- **Description**: Generate JSON output when no repositories are configured.
+- **Test Data**: `cfg_repos=[]`, `user_cfg_repos=[]`
+- **Verification**: 
+  - Verifies exact JSON string output with `indent=2` formatting
+  - Verifies both repository arrays are empty
+  - Verifies JSON structure is maintained
+  - Verifies output is valid JSON
+
+
+## Running the Tests
+
+1. **Required Dependencies**:
+   Ensure that the following third-party Python libraries are installed:
+   - `pytest`
+   - `edkrepo_manifest_parser`
+   - `colorama`
+   - `GitPython`
+   - To generate HTML report output, `pytest-html` must be installed.
+
+2. **Run All Tests**:
+   From the `edkrepo\commands\unit_tests\` directory, run:
+   ```bash
+   python3 -m pytest test_manifest_repos_command.py
+   ```
+   
+   To run with verbose output:
+   ```bash
+   python3 -m pytest test_manifest_repos_command.py -v
+   ```
+
+3. **Run Specific Test Classes**:
+   ```bash
+   python3 -m pytest test_manifest_repos_command.py::TestListManifestRepos
+   python3 -m pytest test_manifest_repos_command.py::TestListManifestReposJson
+   ```
+
+4. **Run Specific Parameterized Test Cases**:
+   You can run individual parameterized scenarios using their test IDs:
+   ```bash
+   # Run only non-verbose cfg tests
+   python3 -m pytest test_manifest_repos_command.py::TestListManifestRepos::test_list_manifest_repos[non_verbose_cfg_only]
+   
+   # Run only JSON output with both repos
+   python3 -m pytest test_manifest_repos_command.py::TestListManifestReposJson::test_list_manifest_repos_json[both]
+   ```
+
+5. **Additional pytest Options**:
+   - Show all test IDs: `pytest --collect-only test_manifest_repos_command.py`
+   - Run tests matching a pattern: `pytest -k "verbose" test_manifest_repos_command.py`
+   - See the official `pytest` documentation at: https://docs.pytest.org/en/latest/how-to/usage.html for more options.
+

--- a/edkrepo/commands/unit_tests/test_manifest_repos_command.py
+++ b/edkrepo/commands/unit_tests/test_manifest_repos_command.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_manifest_repos_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import sys
+import os
+import json
+from unittest.mock import MagicMock, patch, call
+import pytest
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.commands.manifest_repos_command import ManifestRepos
+from edkrepo.commands.humble import manifest_repos_humble as humble
+
+
+# Shared fixtures for all test classes
+@pytest.fixture
+def manifest_repos_cmd():
+    """Provide a ManifestRepos instance for testing"""
+    return ManifestRepos()
+
+
+@pytest.fixture
+def mock_config():
+    """Provide a mock config for testing"""
+    return {'cfg_file': MagicMock(), 'user_cfg_file': MagicMock()}
+
+
+class TestListManifestRepos:
+    """Unit tests for the ManifestRepos._list_manifest_repos method"""
+
+    @pytest.mark.parametrize("cfg_repos,user_cfg_repos,verbose,mock_paths", [
+        # Non-verbose tests
+        (['repo1', 'repo2'], [], False, []),
+        ([], ['user_repo1', 'user_repo2'], False, []),
+        ([], [], False, []),
+        # Verbose tests
+        (['repo1', 'repo2'], [], True, ['/path/to/repo1', '/path/to/repo2']),
+        ([], ['user_repo1', 'user_repo2'], True, ['/path/to/user_repo1', '/path/to/user_repo2']),
+        (['repo1', 'repo2'], ['user_repo1'], True, ['/path/to/repo1', '/path/to/repo2', '/path/to/user_repo1']),
+    ], ids=[
+        "non_verbose_cfg_only",
+        "non_verbose_user_cfg_only",
+        "empty_lists",
+        "verbose_cfg_only",
+        "verbose_user_cfg_only",
+        "verbose_both",
+    ])
+    @patch('edkrepo.commands.manifest_repos_command.ui_functions.print_info_msg')
+    @patch('edkrepo.commands.manifest_repos_command.manifest_repos_maintenance.get_manifest_repo_path')
+    def test_list_manifest_repos(self, mock_get_path, mock_print_info, manifest_repos_cmd, 
+                                 mock_config, cfg_repos, user_cfg_repos, verbose, mock_paths):
+        """Test _list_manifest_repos with various configurations"""
+        # Setup mock paths
+        if mock_paths:
+            mock_get_path.side_effect = mock_paths
+        
+        # Execute method
+        manifest_repos_cmd._list_manifest_repos(cfg_repos, user_cfg_repos, mock_config, verbose)
+        
+        # Verify print_info_msg calls
+        if not cfg_repos and not user_cfg_repos:
+            mock_print_info.assert_not_called()
+        else:
+            for repo in cfg_repos:
+                if verbose:
+                    path = mock_paths[cfg_repos.index(repo)] if mock_paths else None
+                    mock_print_info.assert_any_call(
+                        humble.CFG_LIST_ENTRY_VERBOSE.format(repo, os.path.normpath(path)), 
+                        header=False
+                    )
+                else:
+                    mock_print_info.assert_any_call(humble.CFG_LIST_ENTRY.format(repo), header=False)
+            
+            for repo in user_cfg_repos:
+                if verbose:
+                    path_index = len(cfg_repos) + user_cfg_repos.index(repo)
+                    path = mock_paths[path_index] if mock_paths else None
+                    mock_print_info.assert_any_call(
+                        humble.USER_CFG_LIST_ENTRY_VERBOSE.format(repo, os.path.normpath(path)), 
+                        header=False
+                    )
+                else:
+                    mock_print_info.assert_any_call(humble.USER_CFG_LIST_ENTRY.format(repo), header=False)
+        
+        # Verify get_manifest_repo_path calls
+        if verbose and (cfg_repos or user_cfg_repos):
+            for repo in cfg_repos:
+                mock_get_path.assert_any_call(repo, mock_config)
+            for repo in user_cfg_repos:
+                mock_get_path.assert_any_call(repo, mock_config)
+        else:
+            mock_get_path.assert_not_called()
+
+
+class TestListManifestReposJson:
+    """Unit tests for the ManifestRepos._list_manifest_repos_json method"""
+
+    @pytest.mark.parametrize("cfg_repos,user_cfg_repos,mock_paths", [
+        (['repo1', 'repo2'], [], ['/path/to/repo1', '/path/to/repo2']),
+        ([], ['user_repo1', 'user_repo2'], ['/path/to/user_repo1', '/path/to/user_repo2']),
+        (['repo1', 'repo2'], ['user_repo1'], ['/path/to/repo1', '/path/to/repo2', '/path/to/user_repo1']),
+        ([], [], []),
+    ], ids=[
+        "cfg_only",
+        "user_cfg_only",
+        "both",
+        "empty_lists",
+    ])
+    @patch('edkrepo.commands.manifest_repos_command.manifest_repos_maintenance.get_manifest_repo_path')
+    def test_list_manifest_repos_json(self, mock_get_path, manifest_repos_cmd,
+                                      mock_config, cfg_repos, user_cfg_repos, mock_paths):
+        """Test _list_manifest_repos_json with various configurations"""
+        # Setup mock paths
+        if mock_paths:
+            mock_get_path.side_effect = mock_paths
+        
+        # Execute method
+        result = manifest_repos_cmd._list_manifest_repos_json(cfg_repos, user_cfg_repos, mock_config)
+        
+        # Build expected JSON output
+        expected_output = {
+            "edkrepo_cfg": {
+                "manifest_repositories": []
+            },
+            "edkrepo_user_cfg": {
+                "manifest_repositories": []
+            }
+        }
+        
+        # Add cfg repos to expected output
+        for i, repo in enumerate(cfg_repos):
+            path = os.path.normpath(mock_paths[i])
+            expected_output["edkrepo_cfg"]["manifest_repositories"].append({
+                "name": repo,
+                "path": path
+            })
+        
+        # Add user cfg repos to expected output
+        for i, repo in enumerate(user_cfg_repos):
+            path_index = len(cfg_repos) + i
+            path = os.path.normpath(mock_paths[path_index])
+            expected_output["edkrepo_user_cfg"]["manifest_repositories"].append({
+                "name": repo,
+                "path": path
+            })
+        
+        # Verify the return value is valid JSON and matches expected structure
+        assert result == json.dumps(expected_output, indent=2)
+        output_data = json.loads(result)
+        assert output_data == expected_output
+


### PR DESCRIPTION
…epositories in Use

Add JSON output support for manifest-repos list command

Implement JSON output format for manifest-repos list command.

Changes:
- Extract _list_manifest_repos() method from run_command() for better code organization
- Add _list_manifest_repos_json() method that outputs structured JSON with edkrepo_cfg and edkrepo_user_cfg sections containing repository names and paths
- Add shared FormatArgument definition in edkrepo_command.py
- Move FORMAT_HELP to edkrepo_cmd_args.py for reuse across commands
- Add --format text|json option to manifest-repos list (default: text)
- Add unit tests in test_manifest_repos_command.py covering both text and JSON output modes
- Add ManifestReposCommand_TestCases.md test documentation

Fixes: #422