### PR TITLE
f2f-cherry-pick: Fix GIT_EDITOR on Linux to use sys.executable

### DIFF
--- a/edkrepo/commands/f2f_cherry_pick_command.py
+++ b/edkrepo/commands/f2f_cherry_pick_command.py
@@ -12,7 +12,7 @@ from difflib import SequenceMatcher
 import json
 import os
 import re
-from subprocess import check_call, Popen, PIPE, STDOUT
+from subprocess import run, Popen, PIPE, STDOUT
 import sys
 import time
 import uuid
@@ -474,7 +474,7 @@ def strip_commit_message(commit, repo, source_commit=None, append_sha=False):
     os.environ['GIT_EDITOR'] = '"{}" "{}"'.format(sys.executable, os.path.join(git_automation_dir, "commit_msg.py"))
     os.environ['COMMIT_MESSAGE'] = commit_message
     try:
-        check_call(['git', 'commit', '--amend'])
+        run(['git', 'commit', '--amend'], check=True)
     finally:
         del os.environ['GIT_EDITOR']
         del os.environ['COMMIT_MESSAGE']
@@ -595,9 +595,9 @@ def run_filter_branch(command, repo):
             if bash_path is None:
                 raise EdkrepoNotFoundException(humble.F2F_CHERRY_PICK_BASH_NOT_FOUND)
             command = command.replace('"', '""')
-            check_call('"{}" -c "{}"'.format(bash_path, command), shell=True)
+            run('"{}" -c "{}"'.format(bash_path, command), shell=True, check=True)
         else:
-            check_call(command, shell=True)
+            run(command, shell=True, check=True)
     finally:
         if reset_environ:
             del os.environ['FILTER_BRANCH_SQUELCH_WARNING']

--- a/edkrepo/commands/f2f_cherry_pick_command.py
+++ b/edkrepo/commands/f2f_cherry_pick_command.py
@@ -287,10 +287,7 @@ def _complete_cherry_pick(args, continue_operation, repo_info, commit_info, cher
                     git_automation_dir = os.path.join(git_automation_dir, 'edkrepo', 'git_automation')
                     if not os.path.isfile(os.path.join(git_automation_dir, "commit_msg.py")):
                         raise EdkrepoNotFoundException(humble.F2F_CHERRY_PICK_COMMIT_MSG_PY_NOT_FOUND)
-                if sys.platform == "win32":
-                    os.environ['GIT_EDITOR'] = 'py "{}"'.format(os.path.join(git_automation_dir, "commit_msg.py"))
-                else:
-                    os.environ['GIT_EDITOR'] = os.path.join(git_automation_dir, "commit_msg.py")
+                os.environ['GIT_EDITOR'] = '"{}" "{}"'.format(sys.executable, os.path.join(git_automation_dir, "commit_msg.py"))
                 os.environ['COMMIT_MESSAGE_NO_EDIT'] = '1'
                 try:
                     repo.git.commit('--allow-empty')
@@ -474,14 +471,13 @@ def strip_commit_message(commit, repo, source_commit=None, append_sha=False):
         git_automation_dir = os.path.join(git_automation_dir, 'edkrepo', 'git_automation')
         if not os.path.isfile(os.path.join(git_automation_dir, "commit_msg.py")):
             raise EdkrepoNotFoundException(humble.F2F_CHERRY_PICK_COMMIT_MSG_PY_NOT_FOUND)
-    if sys.platform == "win32":
-        os.environ['GIT_EDITOR'] = 'py "{}"'.format(os.path.join(git_automation_dir, "commit_msg.py"))
-    else:
-        os.environ['GIT_EDITOR'] = os.path.join(git_automation_dir, "commit_msg.py")
+    os.environ['GIT_EDITOR'] = '"{}" "{}"'.format(sys.executable, os.path.join(git_automation_dir, "commit_msg.py"))
     os.environ['COMMIT_MESSAGE'] = commit_message
-    check_call(['git', 'commit', '--amend'])
-    del os.environ['GIT_EDITOR']
-    del os.environ['COMMIT_MESSAGE']
+    try:
+        check_call(['git', 'commit', '--amend'])
+    finally:
+        del os.environ['GIT_EDITOR']
+        del os.environ['COMMIT_MESSAGE']
 
 def _perform_cherry_pick(commit, repo, verbose):
     merge_conflict = False

--- a/edkrepo/common/squash.py
+++ b/edkrepo/common/squash.py
@@ -9,7 +9,7 @@
 
 import os
 import sys
-from subprocess import check_call
+from subprocess import run
 
 from edkrepo.common.edkrepo_exception import EdkrepoInvalidParametersException, EdkrepoWorkspaceInvalidException
 from edkrepo.common.humble import COMMIT_NOT_FOUND, NOT_GIT_REPO, SQUASH_COMMON_ANCESTOR_REQUIRED
@@ -82,7 +82,7 @@ def squash_commits(start_commit, end_commit, branch_name, commit_message, repo, 
     os.environ['COMMIT_MESSAGE'] = commit_message
     try:
         #Do an interactive rebase back to the oldest commit, squashing all commits between then and now
-        check_call(['git', 'rebase', '-i', '{}'.format(start_commit)])
+        run(['git', 'rebase', '-i', '{}'.format(start_commit)], check=True)
         if reset_author:
             repo.git.commit('--amend', '--no-edit', '--reset-author', '--signoff')
     finally:

--- a/edkrepo/common/squash.py
+++ b/edkrepo/common/squash.py
@@ -77,17 +77,15 @@ def squash_commits(start_commit, end_commit, branch_name, commit_message, repo, 
     repo.heads[local_branch.name].checkout()
     #Set up environment variables for automating the interactive rebase
     git_automation_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'git_automation')
-    if sys.platform == "win32":
-        os.environ['GIT_SEQUENCE_EDITOR'] = 'py "{}"'.format(os.path.join(git_automation_dir, "rebase_squash.py"))
-        os.environ['GIT_EDITOR'] = 'py "{}"'.format(os.path.join(git_automation_dir, "commit_msg.py"))
-    else:
-        os.environ['GIT_SEQUENCE_EDITOR'] = os.path.join(git_automation_dir, "rebase_squash.py")
-        os.environ['GIT_EDITOR'] = os.path.join(git_automation_dir, "commit_msg.py")
+    os.environ['GIT_SEQUENCE_EDITOR'] = '"{}" "{}"'.format(sys.executable, os.path.join(git_automation_dir, "rebase_squash.py"))
+    os.environ['GIT_EDITOR'] = '"{}" "{}"'.format(sys.executable, os.path.join(git_automation_dir, "commit_msg.py"))
     os.environ['COMMIT_MESSAGE'] = commit_message
-    #Do an interactive rebase back to the oldest commit, squashing all commits between then and now
-    check_call(['git', 'rebase', '-i', '{}'.format(start_commit)])
-    if reset_author:
-        repo.git.commit('--amend', '--no-edit', '--reset-author', '--signoff')
-    del os.environ['GIT_SEQUENCE_EDITOR']
-    del os.environ['GIT_EDITOR']
-    del os.environ['COMMIT_MESSAGE']
+    try:
+        #Do an interactive rebase back to the oldest commit, squashing all commits between then and now
+        check_call(['git', 'rebase', '-i', '{}'.format(start_commit)])
+        if reset_author:
+            repo.git.commit('--amend', '--no-edit', '--reset-author', '--signoff')
+    finally:
+        del os.environ['GIT_SEQUENCE_EDITOR']
+        del os.environ['GIT_EDITOR']
+        del os.environ['COMMIT_MESSAGE']


### PR DESCRIPTION
On Linux, GIT_EDITOR was set to the bare path of commit_msg.py. Since .py files do not have the executable bit set, git failed to exec the editor with 'Permission denied'. This caused git commit to fail during --continue, leaving staged files from the cherry-pick that then prevented checkout back to the original branch.

Both uses of GIT_EDITOR are now fixed to use sys.executable to invoke commit_msg.py.