### PR TITLE
EdkRepo: Fix git hooks to use consistent Python interpreter

### DIFF
--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -9,6 +9,7 @@
 
 import json
 import os
+import re
 import shutil
 import sys
 import urllib.request
@@ -158,6 +159,61 @@ def write_conditional_include(workspace_path, repo_sources, included_configs):
                     gitglobalconfig.add_section(section)
                     gitglobalconfig.set(section, 'path', path)
 
+# Matches a shebang that generically resolves to "whatever python is on this
+# system", either via "env" or a hardcoded common system path. Does not match a
+# shebang that pins to a specific interpreter (Ex: '/usr/bin/python3.12'), which
+# is left alone since that's a deliberate choice by whoever wrote the hook.
+_GENERIC_PYTHON_SHEBANG_RE = re.compile(
+    r'^#!\s*(?:/usr/bin/env\s+|/usr/bin/|/usr/local/bin/|/bin/)python3?(\s.*)?$')
+
+def _edkrepo_hook_interpreter():
+    """
+    Returns the path that a repinned hook's shebang should point at.
+
+    Prefers the 'edkrepo_python' launcher created by the installer in
+    ~/.edkrepo, which is a small script that execs the interpreter EdkRepo is
+    currently installed on.
+
+    Falls back to sys.executable if the launcher is missing (Ex: an
+    installation from before this launcher existed).
+    """
+    shim_path = os.path.join(pathfix.expanduser('~/.edkrepo'), 'edkrepo_python')
+    if os.path.isfile(shim_path) and os.access(shim_path, os.X_OK):
+        return shim_path
+    return sys.executable
+
+def _repin_hook_shebang(hook_file_name):
+    """
+    Rewrites a generic Python shebang line in an installed git hook script to
+    instead point at the Python interpreter currently running EdkRepo.
+
+    A '/usr/bin/env python3' shebang resolves to whatever 'python3' happens to
+    be first on the invoking shell's PATH at the moment the hook runs. Pinning
+    the shebang removes that ambiguity and keeps the hook in sync with whichever
+    interpreter is currently in use.
+
+    Linux & macOS only. Windows has a different mechanism, see InstallWorker.cs.
+    """
+    if not (sys.platform.startswith('linux') or sys.platform == 'darwin'):
+        return
+    try:
+        with open(hook_file_name, 'r', errors='ignore') as handle:
+            lines = handle.readlines()
+    except (OSError, UnicodeError):
+        return
+    if not lines:
+        return
+    match = _GENERIC_PYTHON_SHEBANG_RE.match(lines[0])
+    if not match:
+        return
+    trailing_args = match.group(1) or ''
+    lines[0] = '#!{}{}\n'.format(_edkrepo_hook_interpreter(), trailing_args)
+    try:
+        with open(hook_file_name, 'w') as handle:
+            handle.writelines(lines)
+    except OSError:
+        pass
+
 def install_hooks(hooks, local_repo_path, repo_for_install, config, global_manifest_directory):
     # Determine the which hooks are for the repo in question and which are from a URL based source or are in a global
     # manifest repo relative path
@@ -183,6 +239,7 @@ def install_hooks(hooks, local_repo_path, repo_for_install, config, global_manif
         with urllib.request.urlopen(hook.source) as response, open(hook_file_name, 'wb') as out_file:
             data = response.read()
             out_file.write(data)
+        _repin_hook_shebang(hook_file_name)
 
     # Copy any global manifest repository relative path source based hooks
     for hook in hooks_path:
@@ -198,6 +255,7 @@ def install_hooks(hooks, local_repo_path, repo_for_install, config, global_manif
         if not os.path.exists(destination_path):
             os.makedirs(destination_path)
         shutil.copy(man_dir_rel_hook_path, hook_file_name)
+        _repin_hook_shebang(hook_file_name)
         if os.name == 'posix':
             # Need to make sure the script is executable or it will not run on Linux
             os.chmod(hook_file_name, os.stat(hook_file_name).st_mode | 0o111)

--- a/edkrepo/common/unit_tests/test_repin_hook_shebang.py
+++ b/edkrepo/common/unit_tests/test_repin_hook_shebang.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+## @file
+# test_repin_hook_shebang.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+import os
+import stat
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+from edkrepo.common.common_repo_functions import _repin_hook_shebang, _edkrepo_hook_interpreter
+
+HOOK_BODY = 'print("hello from hook")\n'
+
+def _write_hook(tmp_path, shebang, name='some-hook'):
+    hook_file = tmp_path / name
+    hook_file.write_text('{}\n{}'.format(shebang, HOOK_BODY))
+    return str(hook_file)
+
+def _read_first_line(hook_file_name):
+    with open(hook_file_name, 'r') as f:
+        return f.readline()
+
+@pytest.fixture
+def edkrepo_shim(tmp_path):
+    """Creates ~/.edkrepo/edkrepo_python as a non-executable file."""
+    edkrepo_dir = tmp_path / '.edkrepo'
+    edkrepo_dir.mkdir()
+    shim = edkrepo_dir / 'edkrepo_python'
+    shim.write_text('#!/bin/sh\nexec "/usr/bin/python3.13" "$@"\n')
+    return edkrepo_dir, shim
+
+class TestEdkrepoHookInterpreter:
+    def test_uses_launcher_when_present_and_executable(self, edkrepo_shim):
+        edkrepo_dir, shim = edkrepo_shim
+        os.chmod(str(shim), os.stat(str(shim)).st_mode | stat.S_IEXEC)
+        with patch('edkrepo.common.common_repo_functions.pathfix.expanduser', return_value=str(edkrepo_dir)):
+            assert _edkrepo_hook_interpreter() == str(shim)
+
+    def test_falls_back_to_sys_executable_when_launcher_missing(self, tmp_path):
+        edkrepo_dir = tmp_path / '.edkrepo'  # deliberately not created
+        with patch('edkrepo.common.common_repo_functions.pathfix.expanduser', return_value=str(edkrepo_dir)):
+            assert _edkrepo_hook_interpreter() == sys.executable
+
+    def test_falls_back_to_sys_executable_when_launcher_not_executable(self, edkrepo_shim):
+        edkrepo_dir, shim = edkrepo_shim
+        # no chmod -- deliberately left non-executable
+        with patch('edkrepo.common.common_repo_functions.pathfix.expanduser', return_value=str(edkrepo_dir)):
+            assert _edkrepo_hook_interpreter() == sys.executable
+
+class TestRepinHookShebangPlatformGuard:
+    @pytest.mark.parametrize('platform,expected', [
+        ('win32',  '#!/usr/bin/env python3\n'),
+        ('linux',  '#!/opt/edkrepo_python\n'),
+        ('darwin', '#!/opt/edkrepo_python\n'),
+    ])
+    def test_platform_guard(self, tmp_path, platform, expected):
+        hook_file = _write_hook(tmp_path, '#!/usr/bin/env python3')
+        with patch('edkrepo.common.common_repo_functions.sys.platform', platform), \
+             patch('edkrepo.common.common_repo_functions._edkrepo_hook_interpreter',
+                   return_value='/opt/edkrepo_python'):
+            _repin_hook_shebang(hook_file)
+        assert _read_first_line(hook_file) == expected
+
+class TestRepinHookShebangGenericMatching:
+    @pytest.mark.parametrize('shebang,expected', [
+        ('#!/usr/bin/env python3',    '#!/opt/edkrepo_python\n'),   # generic env form  -> rewritten
+        ('#!/usr/bin/python3',        '#!/opt/edkrepo_python\n'),   # bare /usr/bin form -> rewritten
+        ('#!/usr/bin/env python3 -u', '#!/opt/edkrepo_python -u\n'), # generic form with trailing args -> rewritten, args preserved
+        ('#!/usr/bin/python3.12',     '#!/usr/bin/python3.12\n'),   # version-pinned     -> left alone
+        ('#!/opt/bin/python3.12.3',   '#!/opt/bin/python3.12.3\n'), # custom-pinned      -> left alone
+        ('#!/bin/sh',                 '#!/bin/sh\n'),               # non-python         -> left alone
+    ])
+    def test_shebang_matching(self, tmp_path, shebang, expected):
+        hook_file = _write_hook(tmp_path, shebang)
+        with patch('edkrepo.common.common_repo_functions.sys.platform', 'linux'), \
+             patch('edkrepo.common.common_repo_functions._edkrepo_hook_interpreter',
+                   return_value='/opt/edkrepo_python'):
+            _repin_hook_shebang(hook_file)
+        assert _read_first_line(hook_file) == expected
+
+    def test_non_shebang_file_is_left_alone(self, tmp_path):        # kept separate -- different shape
+        hook_file = tmp_path / 'binary-hook'
+        hook_file.write_bytes(b'\x7fELF\x02\x01\x01\x00garbage')
+        with patch('edkrepo.common.common_repo_functions.sys.platform', 'linux'), \
+             patch('edkrepo.common.common_repo_functions._edkrepo_hook_interpreter',
+                   return_value='/opt/edkrepo_python'):
+            _repin_hook_shebang(str(hook_file))
+        with open(str(hook_file), 'rb') as f:
+            assert f.read() == b'\x7fELF\x02\x01\x01\x00garbage'
+
+class TestRepinHookShebangBestEffort:
+    def test_missing_file_does_not_raise(self, tmp_path):
+        hook_file = str(tmp_path / 'does-not-exist')
+        with patch('edkrepo.common.common_repo_functions.sys.platform', 'linux'), \
+             patch('edkrepo.common.common_repo_functions._edkrepo_hook_interpreter', return_value='/opt/edkrepo_python'):
+            _repin_hook_shebang(hook_file)  # should not raise

--- a/edkrepo_installer/linux-scripts/install.py
+++ b/edkrepo_installer/linux-scripts/install.py
@@ -408,6 +408,30 @@ def get_site_packages_directory():
     res = default_run([def_python, '-c', 'import site; print(site.getsitepackages()[0])'])
     return res.stdout.strip()
 
+def get_python_executable_path():
+    res = default_run([def_python, '-c', 'import sys; print(sys.executable)'])
+    return res.stdout.strip()
+
+edkrepo_python_shim_name = 'edkrepo_python'
+edkrepo_python_shim_template = '''#!/bin/sh
+# @file edkrepo_python
+#  Launcher that runs the Python interpreter EdkRepo is installed on, so that
+#  Python git hooks can "import edkrepo".
+#
+# Automatically generated please DO NOT modify !!!
+#
+exec "{interpreter}" "$@"
+'''
+
+def generate_edkrepo_python_shim(default_cfg_dir, interpreter_path, username):
+    shim_path = os.path.join(default_cfg_dir, edkrepo_python_shim_name)
+    with open(shim_path, 'w') as f:
+        f.write(edkrepo_python_shim_template.format(interpreter=interpreter_path).replace('\r\n', '\n'))
+    shutil.chown(shim_path, user=username)
+    stat_data = os.stat(shim_path)
+    os.chmod(shim_path, stat_data.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return shim_path
+
 def is_current_user_root():
     res = default_run(['id', '-u'])
     if res.stdout.strip() == '0':
@@ -1007,6 +1031,16 @@ def do_install():
             log.info('+ Generated pyenv shims')
         except:
             log.info('- Failed to generate pyenv shim')
+
+    #Create/refresh the edkrepo_python launcher. Regenerated on every install so
+    #that the launcher shim remains accurate after a Python interpreter upgrade.
+    try:
+        generate_edkrepo_python_shim(default_cfg_dir, get_python_executable_path(), username)
+        log.info('+ Created edkrepo_python launcher')
+    except Exception:
+        log.info('- Failed to create edkrepo_python launcher')
+        if args.verbose:
+            traceback.print_exc()
 
     #There is a possibility that ~/.local/bin is not in the PATH if ~/.local/bin
     #did not exist when the current shell was started


### PR DESCRIPTION
Add logic to repin Python shebangs in git hooks to use the Python interpreter that EdkRepo is installed on, instead of relying on generic shebangs like '/usr/bin/env python3' which resolve ambiguously at hook execution time based on the invoking shell's PATH.

This ensures git hooks remain in sync with the EdkRepo Python installation, so hooks can "import edkrepo" if desired.

Fixes #436 