### PR TITLE
EdkRepo: Add tcsh shell support for command completion

### DIFF
--- a/edkrepo/edkrepo_cli.py
+++ b/edkrepo/edkrepo_cli.py
@@ -118,7 +118,16 @@ command_completion_script_header='''#!/usr/bin/env bash
 #
 
 '''
-def generate_command_completion_script(script_filename, parser):
+
+tcsh_command_completion_script_header='''#
+## @file edkrepo_completions.csh
+#
+# Automatically generated please DO NOT modify !!!
+#
+
+'''
+
+def _get_command_completion_commands(parser):
     import edkrepo.command_completion_edkrepo as completion
     commands = []
     for action in parser._positionals._group_actions:
@@ -128,6 +137,38 @@ def generate_command_completion_script(script_filename, parser):
     commands = sorted(commands)
     commands_with_3rd_param_completion = [c for c in completion.command_completions if c in commands]
     commands_with_3rd_param_completion = sorted(commands_with_3rd_param_completion)
+    return commands, commands_with_3rd_param_completion
+
+def _write_tcsh_command_completion_script(f, commands, commands_with_3rd_param_completion):
+    # Completion rules MUST be single quoted so that the `...` command
+    # substitution used for dynamic (3rd parameter) completion is stored
+    # literally and evaluated by tcsh at completion (TAB) time.  Double quotes
+    # would evaluate it once when the script is sourced, freezing the results.
+    f.write(tcsh_command_completion_script_header)
+    first_param_rule = "'p/1/({})/'".format(' '.join(commands))
+    dynamic_rules = ["'n/{0}/`command_completion_edkrepo {0}`/'".format(command)
+                     for command in commands_with_3rd_param_completion]
+    f.write('which edkrepo >& /dev/null\n')
+    f.write('if ($status == 0) then\n')
+    if dynamic_rules:
+        # The dynamic rules require command_completion_edkrepo. If it is not
+        # available, fall back to first parameter completion only.
+        f.write('  which command_completion_edkrepo >& /dev/null\n')
+        f.write('  if ($status == 0) then\n')
+        f.write('    complete edkrepo {}\n'.format(' '.join([first_param_rule] + dynamic_rules)))
+        f.write('  else\n')
+        f.write('    complete edkrepo {}\n'.format(first_param_rule))
+        f.write('  endif\n')
+    else:
+        f.write('  complete edkrepo {}\n'.format(first_param_rule))
+    f.write('endif\n')
+
+def generate_command_completion_script(script_filename, parser, shell='bash'):
+    commands, commands_with_3rd_param_completion = _get_command_completion_commands(parser)
+    if shell == 'tcsh':
+        with open(script_filename, 'w') as f:
+            _write_tcsh_command_completion_script(f, commands, commands_with_3rd_param_completion)
+        return
     with open(script_filename, 'w') as f:
         f.write(command_completion_script_header)
         if sys.platform == "win32":
@@ -184,7 +225,22 @@ def main():
         parser.print_help()
         return 1
     if sys.argv[1] == 'generate-command-completion-script' and len(sys.argv) >= 3:
-        generate_command_completion_script(sys.argv[2], parser)
+        rest = sys.argv[2:]
+        shell = 'bash'
+        if '--shell' in rest:
+            i = rest.index('--shell')
+            if i + 1 < len(rest):
+                shell = rest[i + 1]
+                del rest[i:i + 2]
+            else:
+                del rest[i:i + 1]
+        if not rest:
+            print('Error: no output path specified for generate-command-completion-script')
+            return 1
+        if shell not in ('bash', 'tcsh'):
+            print("Error: unsupported shell '{}' for generate-command-completion-script (expected 'bash' or 'tcsh')".format(shell))
+            return 1
+        generate_command_completion_script(rest[0], parser, shell)
         return 0
     parsed_args = parser.parse_args()
     command_name = parsed_args.subparser_name

--- a/edkrepo_installer/linux-scripts/install.py
+++ b/edkrepo_installer/linux-scripts/install.py
@@ -164,6 +164,9 @@ zsh_colors = 'colors'
 zsh_compinit = 'compinit -u'
 zsh_bashcompinit = 'bashcompinit'
 
+# TCSH Configuration options
+tcsh_completion_regex = re.compile(r"if\s*\(\s*\$\?tcsh\s*&&\s*-r\s+\"\S*edkrepo_completions\.csh\"\s*\)\s*source\s+\"\S*edkrepo_completions\.csh\"")
+
 def default_run(cmd):
     return subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
 
@@ -785,6 +788,20 @@ def get_command_completion_script_path(default_cfg_dir, user_home_dir, install_t
     else:
         return (os.path.join('/', 'etc', 'profile.d', 'edkrepo_completions.sh'), True)
 
+def get_tcsh_command_completion_script_path(default_cfg_dir):
+    # Unlike bash-completion, there is no widely adopted convention for a
+    # system-wide tcsh completions directory, so the script always lives
+    # alongside EdkRepo's other configuration files.
+    return os.path.join(default_cfg_dir, 'edkrepo_completions.csh')
+
+def get_tcsh_startup_file(user_home_dir):
+    # tcsh reads ~/.tcshrc in preference to ~/.cshrc if it exists; fall back
+    # to ~/.cshrc otherwise, which will be created if neither file exists
+    tcshrc_file = os.path.join(user_home_dir, '.tcshrc')
+    if os.path.isfile(tcshrc_file):
+        return tcshrc_file
+    return os.path.join(user_home_dir, '.cshrc')
+
 def add_command_to_startup_script(script_file, regex, command, username):
     script = ''
     if os.path.isfile(script_file):
@@ -872,6 +889,17 @@ def add_command_completions_to_shell(command_completion_script, args, username, 
             add_command_comment_to_startup_script(zsh_rc_file, regex, new_source_line, comment, username)
         if get_add_prompt_customization(args, username, user_home_dir):
             add_command_to_startup_script(zsh_rc_file, prompt_regex, zsh_prompt_customization, username)
+
+def add_tcsh_completion_to_shell(command_completion_csh_script, username, user_home_dir):
+    # tcsh is configured independently of bash/zsh. It has different syntax for
+    # command completions, so a different command completion script must be
+    # generated for it.
+    if shutil.which('tcsh') is None and shutil.which('csh') is None:
+        return
+    tcsh_rc_file = get_tcsh_startup_file(user_home_dir)
+    new_source_line = 'if ($?tcsh && -r "{0}") source "{0}"'.format(command_completion_csh_script)
+    comment = '\n# Add EdkRepo command completions'
+    add_command_comment_to_startup_script(tcsh_rc_file, tcsh_completion_regex, new_source_line, comment, username)
 
 def do_install():
     global def_python
@@ -1239,12 +1267,12 @@ def do_install():
     if not completion_configured_by_vendor and shutil.which('edkrepo') is not None:
         (command_completion_script, source_command_completion) = \
             get_command_completion_script_path(default_cfg_dir, user_home_dir, install_to_local)
+        user_is_root = False
         try:
-            user_is_root = False
-            try:
-                user_is_root = is_current_user_root()
-            except:
-                pass
+            user_is_root = is_current_user_root()
+        except:
+            pass
+        try:
             current_home = None
             if 'HOME' in os.environ:
                 current_home = os.environ['HOME']
@@ -1267,6 +1295,30 @@ def do_install():
                     log.info('+ Note: You may need to reboot to fully activate shell integration')
         except:
             log.info('- Failed to configure edkrepo command completion')
+            if args.verbose:
+                traceback.print_exc()
+
+        #If tcsh is installed, create the tcsh command completion script
+        try:
+            tcsh_completion_script = get_tcsh_command_completion_script_path(default_cfg_dir)
+            if shutil.which('tcsh') is not None or shutil.which('csh') is not None:
+                current_home = None
+                if 'HOME' in os.environ:
+                    current_home = os.environ['HOME']
+                try:
+                    if user_is_root and current_home is not None and current_home != user_home_dir:
+                        os.environ['HOME'] = user_home_dir
+                    res = default_run(['edkrepo', 'generate-command-completion-script', tcsh_completion_script, '--shell', 'tcsh'])
+                finally:
+                    if current_home is not None and os.environ['HOME'] != current_home:
+                        os.environ['HOME'] = current_home
+                if install_to_local or ostype == MAC:
+                    shutil.chown(tcsh_completion_script, user=username)
+                    os.chmod(tcsh_completion_script, 0o644)
+                add_tcsh_completion_to_shell(tcsh_completion_script, username, user_home_dir)
+                log.info('+ Configured edkrepo tcsh command completion')
+        except:
+            log.info('- Failed to configure edkrepo tcsh command completion')
             if args.verbose:
                 traceback.print_exc()
     else:


### PR DESCRIPTION
This change enables edkrepo command completion to work with the tcsh shell in addition to the existing bash/zsh.

- Add tcsh-specific completion script generation
- Add --shell flag for generate-command-completion-script command
- Add tcsh startup file configuration

Fixes #440