### PR TITLE
EdkRepo: Add self-extracting installer for Linux & macOS

### DIFF
--- a/build-scripts/build_linux_installer.py
+++ b/build-scripts/build_linux_installer.py
@@ -92,6 +92,24 @@ def create_archive(version):
         out_targz.add('.', filter=mode_change)
     os.chdir(cwd)
 
+def create_self_extractor(version):
+    global edkrepo_version
+    dist_dir = os.path.abspath(os.path.join('..', 'dist'))
+    tar_path = os.path.join(dist_dir, '{}.tar.gz'.format(edkrepo_version))
+    run_path = os.path.join(dist_dir, '{}.run'.format(edkrepo_version))
+    linux_root = os.path.abspath(os.path.join('..', 'edkrepo_installer', 'linux-scripts'))
+    header_path = os.path.join(linux_root, 'self_extract_header.sh')
+    with open(header_path, 'rb') as f:
+        header_data = f.read()
+    if not header_data.endswith(b'\n'):
+        header_data += b'\n'
+    with open(tar_path, 'rb') as f:
+        archive_data = f.read()
+    with open(run_path, 'wb') as f:
+        f.write(header_data)
+        f.write(archive_data)
+    os.chmod(run_path, 0o755)
+
 def main():
     parser = ArgumentParser()
     parser.add_argument('-b', '--build', action='store', default=None, help='Specifies the build number to use for the installer package.')
@@ -149,6 +167,14 @@ def main():
         print('Generated installer archive file successfully')
     except:
         print('Failed to generate installer package')
+        return 1
+
+    # Generate self-extracting installer
+    try:
+        create_self_extractor(version)
+        print('Generated self-extracting installer successfully')
+    except:
+        print('Failed to generate self-extracting installer')
         return 1
 
     # Clean up temporary files

--- a/edkrepo_installer/linux-scripts/self_extract_header.sh
+++ b/edkrepo_installer/linux-scripts/self_extract_header.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+## @file
+# self_extract_header.sh
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# This is a self-extracting installer stub. A gzip-compressed tar archive
+# containing the EdkRepo installer payload is appended immediately after the
+# __EDKREPO_ARCHIVE__ marker line below. This script extracts that archive
+# to a temporary directory, locates install.py inside it, and runs it,
+# passing through any command line arguments given to this script.
+#
+
+set -u
+
+cleanup() {
+    if [ -n "${tmp_dir:-}" ] && [ -d "$tmp_dir" ]; then
+        rm -rf "$tmp_dir"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+self="$0"
+
+archive_line=$(awk '/^__EDKREPO_ARCHIVE__$/ { print NR + 1; exit }' "$self")
+if [ -z "$archive_line" ]; then
+    echo "Error: unable to locate embedded archive" >&2
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d 2>/dev/null || mktemp -d -t edkrepo)
+if [ -z "$tmp_dir" ] || [ ! -d "$tmp_dir" ]; then
+    echo "Error: unable to create temporary directory" >&2
+    exit 1
+fi
+
+tail -n "+${archive_line}" "$self" | tar xzf - -C "$tmp_dir"
+if [ $? -ne 0 ]; then
+    echo "Error: failed to extract embedded archive" >&2
+    exit 1
+fi
+
+install_py=$(find "$tmp_dir" -maxdepth 2 -name install.py | head -n 1)
+if [ -z "$install_py" ]; then
+    echo "Error: unable to locate install.py in extracted archive" >&2
+    exit 1
+fi
+
+install_dir=$(dirname "$install_py")
+cd "$install_dir" || exit 1
+chmod +x ./install.py 2>/dev/null
+
+./install.py "$@"
+status=$?
+
+exit "$status"
+
+__EDKREPO_ARCHIVE__


### PR DESCRIPTION
Implement functionality to create self-extracting .run installers for Linux by combining a shell script header with a gzip-compressed tar archive.

This allows users to run a single .run file to install EdkRepo without needing to manually extract and run the installer script.

Fixes #441