### PR TITLE
Add EdkRepo Uninstaller for Linux & macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,40 @@ Tested versions:
 
 ### Install EdkRepo on Linux
 
-Installing EdkRepo on Linux requires one to extract the tarball and run the included installer script.
+Installing EdkRepo on Linux requires one to run the self-extracting installer. Make it executable, run it, and follow the on-screen prompts.
 
-1. Extract the archive using the following command
-  `tar -xzvf edkrepo-<version>.tar.gz`
-2. Run the installer script `./install.py` and follow the on-screen prompts.
+1. `chmod +x edkrepo-<version>.run`
+2. `./edkrepo-<version>.run`
 
 The -v flag can be added for more verbose output if desired.
 
+### Linux Installation Types
+
+- **Local install (`--local`)** - Installs EdkRepo to the current user's home directory. Root access is not required and no system wide changes are made. This is the **recommended** installation method. The `--user` parameter can sometimes be needed when running in a container environment. A `--local` install is fully configured for the invoking user as soon as it completes.
+
+- **System install (`--system`)** - Installs EdkRepo system-wide. Root access is required. This method is useful for systems where multiple users will be running EdkRepo as in that scenario it saves disk space.
+
+For system level installations, one must run the installation script as root.
+
+#### System Installs Are a Two-Step Process
+
+Unlike a `--local` install, a `--system` install does not modify the current user's home directory. It only installs EdkRepo's files and Python packages system-wide. This means a `--system` install requires an additional configuration step.
+
+Every user who wants to use EdkRepo, including the administrator who performed the `--system` install, must separately run `edkrepo setup` once. This creates `~/.edkrepo`, sets up shell command completion, and optionally adds the current combo and git branch to the shell prompt.
+
+If a user runs an `edkrepo` command before running `edkrepo setup`, EdkRepo detects this and automatically performs the configuration process on the user's behalf. Unlike invoking `edkrepo setup` directly, this will interactively ask the user if they want to add the current combo and git branch to the shell prompt. If a fully automated install process is desired, make sure to run `edkrepo setup --prompt/--no-prompt` first. After the home directory configuration is complete, edkrepo asks the user to re-run their original command.
+
 ### Automated Linux Installation
 
-For an automated non-interactive install, one must provide at least 2 arguments: `--local` or `--system` and `--prompt` or `--no-prompt`.
+For an automated non-interactive install, one must provide either the `--local` argument or the `--system` argument. If `--local` is chosen, one must also provide either the `--prompt` or `--no-prompt` argument.
 
-`--local` requests installation to the current user's home directory. Root access is not required and no system wide changes are made. This is the **recommended** installation method.
+### Uninstalling EdkRepo on Linux
 
-`--system` request a system-wide installation. Root access is required. This method is useful for systems where multiple users will be running EdkRepo as it saves disk space in that scenario.
+Run `edkrepo uninstall` to remove EdkRepo. Pass `--yes` to skip the confirmation prompt.
 
-For system level installations, one must provide the `--user` parameter and run the installation script as root. The `--user` parameter can sometimes be needed when running in a container environment.
+On a `--local` install, this will completely remove EdkRepo. On a `--system` install, this will only remove the edkrepo configuration files from the current user's home directory.
+
+To remove a `--system` install, run `sudo edkrepo uninstall --system --yes`.
 
 ### Linux and macOS Build Process
 
@@ -135,23 +152,25 @@ If you are upgrading from an older version and have already run this script once
 
 ### Install EdkRepo on macOS
 
-Extract the archive:
+Mark the self-extracting installer as executable and run it:
 
-`tar -xzvf edkrepo-<version>.tar.gz`
+1. `chmod +x edkrepo-<version>.run`
+2. `./edkrepo-<version>.run`
 
-If you are installing from source, you will need to build the distribution tarball using the following commands first:
+If you are installing from source, you will need to build the self-extracting installer using the following commands first:
 
 1. `pip install wheel` (If not done already)
 2. `cd build-scripts`
 3. `./build_linux_installer.py`
 
-Install EdkRepo:
-
-`./install.py`
 
 Restart your shell so the new Pyenv shim for EdkRepo can take effect:
 
 `exec $SHELL`
+
+### Uninstalling EdkRepo on macOS
+
+Run `edkrepo uninstall` to remove EdkRepo. Pass `--yes` to skip the confirmation prompt.
 
 ## Windows Build and Installation
 
@@ -171,6 +190,10 @@ Python 3.10.16 or later is required, with Python 3.13.11 or later recommended du
 
 1. Run the installer .exe
 2. Click Install
+
+### Uninstalling EdkRepo on Windows
+
+Run `edkrepo uninstall`, or use the Windows Control Panel/Settings App to uninstall EdkRepo like any other application.
 
 ### Install From Source on Windows
 

--- a/docs/command_references/setup.md
+++ b/docs/command_references/setup.md
@@ -1,0 +1,51 @@
+# edkrepo setup
+
+## Summary
+
+Configures EdkRepo for your user account after a system-level install.
+
+A system-level EdkRepo install makes EdkRepo available for all users on the machine, but does not modify any user's home directory. Each user who wants to use EdkRepo, should run `edkrepo setup` once to add edkrepo configuration files to their home directory. This process creates `~/.edkrepo`, sets up shell command completion, and optionally adds the current combo and git branch to the shell prompt. See the [Installation](../edkrepo_users_guide.md#installation) section of the User's Guide for more details on this two-phase install process.
+
+`edkrepo setup` is not needed after a `--local` install, since a local install configures the user's home directory as part of installation process. Because of this, the `edkrepo setup` command will not exist unless a system-level EdkRepo install is present.
+
+If EdkRepo is run by a user for whom `edkrepo setup` has not yet been run, and a system-level install is present, EdkRepo automatically runs `edkrepo setup` on the user's behalf and then asks the user to re-run their command.
+
+## Usage
+
+```
+edkrepo setup [-h] [--prompt] [--no-prompt] [-v]
+```
+
+Either `--prompt` or `--no-prompt` must be specified.
+
+## Options
+
+### -h, --help
+
+Show help message and exit.
+
+### --prompt
+
+Add EdkRepo combo and git branch to the shell prompt.
+
+### --no-prompt
+
+Do NOT add EdkRepo combo and git branch to the shell prompt.
+
+### -v, --verbose
+
+Increases command verbosity.
+
+## Examples
+
+### Configure EdkRepo for the current user, and add the combo/branch to the shell prompt
+
+```
+edkrepo setup --prompt
+```
+
+### Configure EdkRepo for the current user, without shell prompt changes
+
+```
+edkrepo setup --no-prompt
+```

--- a/docs/command_references/uninstall.md
+++ b/docs/command_references/uninstall.md
@@ -1,0 +1,51 @@
+# edkrepo uninstall
+
+## Summary
+
+Uninstalls EdkRepo.
+
+The `~/.edkrepo` directory is intentionally preserved in case it contains modified configuration files. It can be safely deleted if no longer needed.
+
+## Usage
+
+```
+edkrepo uninstall [-h] [--yes] [--system] [-v]
+```
+
+## Options
+
+### -h, --help
+
+Show help message and exit.
+
+### -y, --yes
+
+Do not prompt for confirmation before uninstalling. Has no effect on Windows.
+
+### -s, --system
+
+Linux only. Uninstall a system-level EdkRepo install instead of a user-level install (requires root).
+
+### -v, --verbose
+
+Increases command verbosity.
+
+## Examples
+
+### Uninstall EdkRepo for the current user, with a confirmation prompt
+
+```
+edkrepo uninstall
+```
+
+### Uninstall EdkRepo for the current user without prompting
+
+```
+edkrepo uninstall --yes
+```
+
+### Uninstall a system-level EdkRepo install (requires root)
+
+```
+sudo edkrepo uninstall --system --yes
+```

--- a/docs/edkrepo_users_guide.md
+++ b/docs/edkrepo_users_guide.md
@@ -25,6 +25,11 @@ To begin using EdkRepo, you'll typically:
 
 For detailed information about each command, see the Command References section below.
 
+## Installation
+
+For detailed platform-specific installation instructions, see the
+[README](../README.md).
+
 <details>
 <summary>
 
@@ -50,10 +55,13 @@ The commands provided by EdkRepo are documented below. These commands provide fu
 - [manifest-repos](command_references/manifest-repos.md) - Lists, adds or removes a manifest repository
 - [reset](command_references/reset.md) - Unstages all staged files in the workspace
 - [send-review](command_references/send-review.md) - Sends a local change for code review
+- [setup](command_references/setup.md) - Configures EdkRepo for your user account after a system-level install
 - [sparse](command_references/sparse.md) - Displays the current sparse checkout status
 - [squash](command_references/squash.md) - Convert multiple commits into a single commit
 - [status](command_references/status.md) - Displays the current combo and the status of each repository
 - [sync](command_references/sync.md) - Updates the local copy of the current combination's target branches
+- [uninstall](command_references/uninstall.md) - Uninstalls EdkRepo
 - [update-manifest-repo](command_references/update-manifest-repo.md) - Updates the global manifest repository
 
 </details>
+

--- a/edkrepo/commands/arguments/setup_args.py
+++ b/edkrepo/commands/arguments/setup_args.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+#
+## @file
+# setup_args.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+''' Contains the help and description strings for arguments in the
+setup command meta data.
+'''
+
+#Args for setup_command.py
+SETUP_COMMAND_DESCRIPTION = 'Configures EdkRepo for your user account after a system-level install'
+SETUP_PROMPT_HELP = 'Add EdkRepo combo and git branch to the shell prompt'
+SETUP_NO_PROMPT_HELP = 'Do NOT add EdkRepo combo and git branch to the shell prompt'

--- a/edkrepo/commands/arguments/uninstall_args.py
+++ b/edkrepo/commands/arguments/uninstall_args.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+#
+## @file
+# uninstall_args.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+''' Contains the help and description strings for arguments in the
+uninstall command meta data.
+'''
+
+#Args for uninstall_command.py
+UNINSTALL_COMMAND_DESCRIPTION = 'Uninstalls EdkRepo'
+UNINSTALL_YES_HELP = 'Do not prompt for confirmation before uninstalling'
+UNINSTALL_SYSTEM_HELP = 'Uninstall a system-level EdkRepo install instead of a user-level install (requires root)'

--- a/edkrepo/commands/setup_command.py
+++ b/edkrepo/commands/setup_command.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+#
+## @file
+# setup_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+'''
+NOTE: "edkrepo setup" is handled in edkrepo_entry_point.main() before command
+classes are enumerated. This class exists so "setup" appears in "edkrepo
+--help", and as a defensive fallback for any invocation that does not go
+through the standard edkrepo_entry_point.main().
+'''
+
+import sys
+
+from edkrepo.commands.edkrepo_command import EdkrepoCommand
+import edkrepo.commands.arguments.setup_args as arguments
+
+
+class SetupCommand(EdkrepoCommand):
+    def __init__(self):
+        super().__init__()
+
+    def get_metadata(self):
+        metadata = {}
+        metadata['name'] = 'setup'
+        metadata['help-text'] = arguments.SETUP_COMMAND_DESCRIPTION
+        metadata['arguments'] = [
+            {'name': 'prompt',
+             'positional': False,
+             'required': False,
+             'help-text': arguments.SETUP_PROMPT_HELP},
+            {'name': 'no-prompt',
+             'positional': False,
+             'required': False,
+             'help-text': arguments.SETUP_NO_PROMPT_HELP},
+        ]
+        return metadata
+
+    def run_command(self, args, config):
+        from edkrepo.common import install_functions
+        sys.exit(install_functions.handle_setup(sys.argv[2:]))

--- a/edkrepo/commands/uninstall_command.py
+++ b/edkrepo/commands/uninstall_command.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+## @file
+# uninstall_command.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+'''
+NOTE: "edkrepo uninstall" is handled in edkrepo_entry_point.main() before
+command classes are enumerated. This class exists so "uninstall" appears in
+"edkrepo --help", and as a defensive fallback for any invocation that does not
+go through the standard edkrepo_entry_point.main().
+'''
+
+import sys
+
+from edkrepo.commands.edkrepo_command import EdkrepoCommand
+import edkrepo.commands.arguments.uninstall_args as arguments
+
+
+class UninstallCommand(EdkrepoCommand):
+    def __init__(self):
+        super().__init__()
+
+    def get_metadata(self):
+        metadata = {}
+        metadata['name'] = 'uninstall'
+        metadata['help-text'] = arguments.UNINSTALL_COMMAND_DESCRIPTION
+        args = []
+        if sys.platform != 'win32':
+            # --yes has no effect on Windows, see install_functions.py for why.
+            args.append({'name': 'yes',
+                         'short-name': 'y',
+                         'positional': False,
+                         'required': False,
+                         'help-text': arguments.UNINSTALL_YES_HELP})
+        args.append({'name': 'system',
+                     'short-name': 's',
+                     'positional': False,
+                     'required': False,
+                     'help-text': arguments.UNINSTALL_SYSTEM_HELP})
+        metadata['arguments'] = args
+        return metadata
+
+    def run_command(self, args, config):
+        from edkrepo.common import install_functions
+        sys.exit(install_functions.handle_uninstall(sys.argv[2:]))

--- a/edkrepo/common/install_functions.py
+++ b/edkrepo/common/install_functions.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+#
+## @file
+# install_functions.py
+#
+# Copyright (c) 2026, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+'''
+Locates and invokes install.py on behalf of the "edkrepo setup" and "edkrepo
+uninstall" commands.
+
+This module is intentionally self-contained and does not import any other
+edkrepo module. It must be safe to run before edkrepo.cfg is known to exist.
+'''
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+SYSTEM_DIR = os.path.join('/', 'usr', 'local', 'share', 'edkrepo')
+
+_KNOWN_PRODUCT_CODES = (
+    '{AC6D5513-8A33-4B5F-ADA0-AACF2135B760}',
+    '{494DB015-D682-458B-B5F1-3678F0C04D5E}',
+)
+
+_SCOPE_FLAGS = ('--local', '-l', '--system', '-s', '--user-setup')
+
+
+def _user_edkrepo_dir():
+    return os.path.join(os.path.expanduser('~'), '.edkrepo')
+
+
+def _user_installer_dir():
+    return os.path.join(_user_edkrepo_dir(), 'installer')
+
+
+def _system_installer_dir():
+    return os.path.join(SYSTEM_DIR, 'installer')
+
+
+def is_user_configured():
+    '''
+    True if this user's $HOME has been configured, either by a --local install
+    or by "edkrepo setup" after a --system install.
+    '''
+    return os.path.isfile(os.path.join(_user_edkrepo_dir(), 'edkrepo.cfg'))
+
+
+def _has_local_installer():
+    '''
+    True only for a --local install: install.py is persisted under
+    ~/.edkrepo/installer. "edkrepo setup" does not place install.py in
+    ~/.edkrepo since the system-level install.py is used instead.
+    '''
+    return os.path.isfile(os.path.join(_user_installer_dir(), 'install.py'))
+
+
+def has_system_install():
+    return os.path.isfile(os.path.join(_system_installer_dir(), 'install.py'))
+
+
+def _strip_scope_flags(argv):
+    return [a for a in argv if a not in _SCOPE_FLAGS]
+
+
+def _find_windows_uninstaller():
+    '''
+    Looks up _KNOWN_PRODUCT_CODES under HKEY_LOCAL_MACHINE\\...\\Uninstall, and
+    returns the registered UninstallString for the first one found, or None if
+    none of the known product codes are registered.
+    '''
+    import winreg
+    key_path = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall'
+    for product_code in _KNOWN_PRODUCT_CODES:
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, '{}\\{}'.format(key_path, product_code), 0,
+                                 winreg.KEY_READ | winreg.KEY_WOW64_64KEY) as subkey:
+                return winreg.QueryValueEx(subkey, 'UninstallString')[0]
+        except OSError:
+            continue
+    return None
+
+
+def _handle_windows_uninstall(argv):
+    '''
+    Handles "edkrepo uninstall" on Windows by locating the registered
+    uninstaller executable, launching it, and returning immediately without
+    waiting for it to finish.
+
+    This process must not be running by the time the uninstaller starts removing
+    files. Windows has no exec()-like mechanism to replace a running process
+    image, so any executable/DLL this process has loaded (Ex: edkrepo.exe, etc.)
+    remains locked on disk until this process fully exits, which would make file
+    removal fail. The uninstaller's' "Are you sure?" confirmation dialog
+    conveniently blocks it from touching any files until the user responds,
+    which gives plenty of time for this process to exit before that happens.
+    '''
+    uninstall_string = _find_windows_uninstaller()
+    if uninstall_string is None:
+        print('Nothing to uninstall: no EdkRepo installation was found in the Windows registry.')
+        return 0
+    if '--yes' in argv or '-y' in argv:
+        print('Note: --yes has no effect on Windows.')
+    print('Launching the EdkRepo uninstaller...')
+    try:
+        subprocess.Popen(uninstall_string, close_fds=True)
+    except OSError as e:
+        print('Error: Failed to launch the EdkRepo uninstaller ({})'.format(e))
+        return 1
+    return 0
+
+
+def _run_installer(installer_dir, extra_args):
+    '''
+    Copies install.py to a temporary directory and executes it from there. This
+    is done so the installer can safely remove/replace the directory it was
+    originally invoked from (Ex: "edkrepo uninstall" removes
+    ~/.edkrepo/installer, which is where install.py itself would otherwise be
+    running from).
+
+    A local-install places "config" at ~/.edkrepo/installer/config, while a
+    system-install places it at /usr/local/share/edkrepo/config. Both layouts
+    are checked here so this works for either.
+
+    Returns the installer's exit code, or None if no installer was found.
+    '''
+    install_py = os.path.join(installer_dir, 'install.py')
+    if not os.path.isfile(install_py):
+        return None
+    nested_config_dir = os.path.join(installer_dir, 'config')
+    sibling_config_dir = os.path.join(os.path.dirname(installer_dir), 'config')
+    config_dir = nested_config_dir if os.path.isdir(nested_config_dir) else sibling_config_dir
+    tmp_dir = tempfile.mkdtemp(prefix='edkrepo_installer_')
+    try:
+        for name in os.listdir(installer_dir):
+            src = os.path.join(installer_dir, name)
+            if os.path.isfile(src):
+                shutil.copy2(src, os.path.join(tmp_dir, name))
+        if os.path.isdir(config_dir):
+            shutil.copytree(config_dir, os.path.join(tmp_dir, 'config'))
+        tmp_install_py = os.path.join(tmp_dir, 'install.py')
+        os.chmod(tmp_install_py, 0o755)
+        result = subprocess.run([sys.executable, tmp_install_py] + extra_args, cwd=tmp_dir)
+        return result.returncode
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def ask_prompt_customization():
+    '''
+    Interactively asks the user whether they want EdkRepo to add the checked
+    out combo and branch to their command prompt.
+    '''
+    try:
+        print('\n\u2554' + ('\u2550' * 19) + '\u2557')
+    except UnicodeEncodeError:
+        print('\n+' + ('-' * 19) + '+')
+    try:
+        print('\u2551 Shell Integration \u2551')
+    except UnicodeEncodeError:
+        print('| Shell Integration |')
+    try:
+        print('\u255a' + ('\u2550' * 19) + '\u255d')
+    except UnicodeEncodeError:
+        print('+' + ('-' * 19) + '+')
+    print('\nEdkRepo can show the checked out \033[32mcombo\033[00m and \033[36mbranch\033[00m as part of the command prompt')
+    print('For example, instead of:\n')
+    try:
+        print('\u250c' + ('\u2500' * 38) + '\u2510')
+    except UnicodeEncodeError:
+        print('+' + ('-' * 38) + '+')
+    try:
+        print('\u2502 \033[01;32muser@machine\033[00m:\033[01;34msrc\033[00m $                   \u2502')
+    except UnicodeEncodeError:
+        print('| \033[01;32muser@machine\033[00m:\033[01;34msrc\033[00m $                   |')
+    try:
+        print('\u2514' + ('\u2500' * 38) + '\u2518')
+    except UnicodeEncodeError:
+        print('+' + ('-' * 38) + '+')
+    print('\nThe command prompt would look like:\n')
+    try:
+        print('\u250c' + ('\u2500' * 38) + '\u2510')
+    except UnicodeEncodeError:
+        print('+' + ('-' * 38) + '+')
+    try:
+        print('\u2502 \033[01;32muser@machine\033[00m:\033[01;34msrc\033[00m \033[32m[Edk2Main]\033[36m (main)\033[00m $ \u2502')
+    except UnicodeEncodeError:
+        print('| \033[01;32muser@machine\033[00m:\033[01;34msrc\033[00m \033[32m[Edk2Main]\033[36m (main)\033[00m $ |')
+    try:
+        print('\u2514' + ('\u2500' * 38) + '\u2518')
+    except UnicodeEncodeError:
+        print('+' + ('-' * 38) + '+')
+    print('')
+    try:
+        answer = input('Would you like the combo and branch shown on the command prompt? [y/N] ').strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print('')
+        answer = 'n'
+    return answer in ('y', 'yes')
+
+
+def handle_setup(argv):
+    '''
+    Handles "edkrepo setup". argv is everything after "setup" on the command
+    line (Ex: ['--prompt']). Returns a process exit code.
+    '''
+    if '-h' in argv or '--help' in argv:
+        print('Usage: edkrepo setup [--prompt | --no-prompt]')
+        print('')
+        print('Configures EdkRepo for your user account after a system-level install.')
+        return 0
+
+    if is_user_configured():
+        print('EdkRepo is already configured for your user account.')
+        print('To reconfigure it, run "edkrepo uninstall" first.')
+        return 0
+
+    if not has_system_install():
+        print('Error: No system-level EdkRepo install was found at {}.'.format(SYSTEM_DIR))
+        print('Ask your system administrator to run the EdkRepo installer with --system,')
+        print('or install EdkRepo yourself with --local.')
+        return 1
+
+    rc = _run_installer(_system_installer_dir(), ['--user-setup'] + _strip_scope_flags(argv))
+    if rc is None:
+        print('Error: {} is missing or corrupt.'.format(_system_installer_dir()))
+        print('Ask your system administrator to re-run the EdkRepo --system installer.')
+        return 1
+    return rc
+
+
+def handle_uninstall(argv):
+    '''
+    Handles "edkrepo uninstall". argv is everything after "uninstall" on the
+    command line (Ex: '--yes', '--system', etc.). Returns a process exit code.
+    '''
+    if sys.platform == 'win32':
+        if '-h' in argv or '--help' in argv:
+            print('Usage: edkrepo uninstall')
+            print('')
+            print('Uninstalls EdkRepo. A confirmation dialog will be shown.')
+            return 0
+        return _handle_windows_uninstall(argv)
+
+    if '-h' in argv or '--help' in argv:
+        print('Usage: edkrepo uninstall [--yes] [--system]')
+        print('')
+        print('Uninstalls EdkRepo for your user account. Pass --system (as root, or')
+        print('via sudo) to remove a system-level install instead.')
+        return 0
+
+    want_system = '--system' in argv or '-s' in argv
+    passthrough = _strip_scope_flags(argv)
+
+    if want_system:
+        if os.geteuid() != 0:
+            print('System-level EdkRepo uninstalls require root.')
+            extra = ' --yes' if ('--yes' in argv or '-y' in argv) else ''
+            print('Run: sudo edkrepo uninstall --system{}'.format(extra))
+            return 1
+        rc = _run_installer(_system_installer_dir(), ['--uninstall', '--system'] + passthrough)
+        if rc is None:
+            print('Error: No system-level EdkRepo install was found at {}.'.format(SYSTEM_DIR))
+            return 1
+        return rc
+
+    is_mac = sys.platform == 'darwin'
+
+    if _has_local_installer() or is_mac:
+        scope_args = [] if is_mac else ['--local']
+        rc = _run_installer(_user_installer_dir(), ['--uninstall'] + scope_args + passthrough)
+    elif is_user_configured():
+        # Remove EdkRepo from the user's $HOME
+        rc = _run_installer(_system_installer_dir(), ['--uninstall', '--user-setup'] + passthrough)
+    else:
+        print('Nothing to uninstall: EdkRepo is not configured for your user account.')
+        if has_system_install():
+            print('However, a system-level EdkRepo install does exist. To remove it, an')
+            print('administrator can run: sudo edkrepo uninstall --system')
+        return 0
+    if rc is None:
+        print('Error: install.py could not be found. Please re-run the')
+        print('EdkRepo installer package with --uninstall to clean up manually.')
+        return 1
+    return rc

--- a/edkrepo/edkrepo_cli.py
+++ b/edkrepo/edkrepo_cli.py
@@ -33,6 +33,7 @@ from edkrepo.common.edkrepo_exception import EdkrepoWarningException
 from edkrepo.common.edkrepo_exception import EdkrepoConfigFileInvalidException
 from edkrepo.common.humble import KEYBOARD_INTERRUPT, GIT_CMD_ERROR
 from edkrepo.common.pathfix import get_actual_path
+from edkrepo.common import install_functions
 
 def generate_command_line(command):
     parser = argparse.ArgumentParser(prog='edkrepo')
@@ -49,8 +50,12 @@ def generate_command_line(command):
         #To prevent errors if edkrepo is being run without being installed (Python 3.8 and later)
         current_version = "0.0.0"
     parser.add_argument("--version", action="version", version="%(prog)s {0}".format(current_version))
-    #command_names = command.command_list()
+    # "setup" is only relevant on Linux systems with a system-level EdkRepo
+    # install; hide it from --help/shell completion everywhere else.
+    show_setup_command = sys.platform.startswith('linux') and install_functions.has_system_install()
     for command_name in command.command_list():
+        if command_name == 'setup' and not show_setup_command:
+            continue
         subparser_name = 'parser_' + command_name
         command_name_metadata = command.get_metadata(command_name)
         if 'alias' in command_name_metadata:

--- a/edkrepo/edkrepo_entry_point.py
+++ b/edkrepo/edkrepo_entry_point.py
@@ -83,7 +83,29 @@ if __name__ == "__main__" or run_via_launcher_script:
 from edkrepo.config.config_factory import GlobalConfig
 
 def main():
-    cfg_file = GlobalConfig()
+    # "edkrepo setup" and "edkrepo uninstall" must work even when
+    # ~/.edkrepo/edkrepo.cfg does not exist yet.
+    if len(sys.argv) >= 2 and sys.argv[1] in ('setup', 'uninstall'):
+        from edkrepo.common import install_functions
+        if sys.argv[1] == 'setup':
+            return install_functions.handle_setup(sys.argv[2:])
+        else:
+            return install_functions.handle_uninstall(sys.argv[2:])
+
+    try:
+        cfg_file = GlobalConfig()
+    except Exception as e:
+        print('Error: {}'.format(str(e)))
+        if sys.platform.startswith('linux'):
+            from edkrepo.common import install_functions
+            if install_functions.has_system_install() and not install_functions.is_user_configured():
+                print('EdkRepo has not been configured for your user account yet.')
+                print('Running "edkrepo setup" automatically...')
+                prompt_flag = '--prompt' if install_functions.ask_prompt_customization() else '--no-prompt'
+                install_functions.handle_setup([prompt_flag])
+                print('')
+                print('Please run edkrepo again.')
+        return 1
     pref_entry = (cfg_file.preferred_entry[0]).replace('.py', '')
     pref_entry_func = cfg_file.preferred_entry[1]
 

--- a/edkrepo_installer/linux-scripts/install.py
+++ b/edkrepo_installer/linux-scripts/install.py
@@ -8,9 +8,11 @@
 #
 
 from argparse import ArgumentParser
+import base64
 import collections
 import configparser
 import getpass
+import gzip
 import hashlib
 import importlib.util
 import logging
@@ -108,21 +110,47 @@ _copyright_year = '2026'  # patched at build time by build_linux_installer.py
 #         Called after all wheels are installed and shell integration is
 #         configured, immediately before the installer exits with success.
 #         '''
+#
+#     def pre_uninstall(self, context):
+#         '''
+#         Called at the start of an uninstall, before any files are removed or
+#         packages are uninstalled.
+#         '''
+#
+#     def get_uninstall_packages(self, context, base_packages):
+#         '''
+#         Called just before the uninstaller removes EdkRepo's pip packages.
+#         Receives "base_packages", a tuple of pip package names that the
+#         generic installer uninstalls (Ex: ('edkrepo',)). Must return an
+#         iterable of package names; the return value replaces the package
+#         list. Use this to have additional vendor-specific pip packages
+#         (Ex: an internal companion package) removed alongside edkrepo.
+#         '''
+#
+#     def post_uninstall(self, context):
+#         '''
+#         Called at the end of an uninstall, after the generic uninstall
+#         logic has completed. Use this to reverse any vendor-specific
+#         customizations made in pre_install()/post_install().
+#         '''
 class InstallerContext:
     '''
     Provides the install environment to the vendor customizer plugin.
     All attributes are read-only from the plugin's perspective.
     '''
     def __init__(self, ostype, python, install_to_local, log,
-                 whl_src_dir, username, user_home_dir):
+                 whl_src_dir, username, user_home_dir, scope=None):
         self.ostype = ostype                     # MAC or LINUX
         self.python = python                     # Python executable
-        self.install_to_local = install_to_local # True for --user installs
+        self.install_to_local = install_to_local # True for --user and --user-setup, False for --system
         self.log = log                           # standard logging.Logger
         self.whl_src_dir = whl_src_dir           # absolute path to wheels/ directory
-        self.username = username                 # target user name
-        self.user_home_dir = user_home_dir       # absolute path to target user's home directory
+        self.username = username                 # target user name (None for --system)
+        self.user_home_dir = user_home_dir       # absolute path to target user's home directory (None for --system)
+        self.scope = scope                       # 'local', 'system', or 'user-setup'
         self.run = run_with_externally_managed_check  # pip helper (handles --break-system-packages)
+        self.get_pyenv_version_name = get_pyenv_version_name    # macOS: get Python version
+        self.make_pyenv_launcher = write_pyenv_pinned_launcher  # macOS: write a pyenv launcher shim
 
 def _load_vendor_customizer():
     '''
@@ -151,6 +179,11 @@ nfs_home_directory_data = re.compile(r"NFSHomeDirectory:\s*(\S+)")
 
 # ZSH Configuration options
 prompt_regex = re.compile(r"#\s+[Aa][Dd][Dd]\s+[Ee][Dd][Kk][Rr][Ee][Pp][Oo]\s+&\s+[Gg][Ii][Tt]\s+[Tt][Oo]\s+[Tt][Hh][Ee]\s+[Pp][Rr][Oo][Mm][Pp][Tt]")
+# Marks the end of the prompt customization block written to ~/.bashrc &
+# ~/.zshrc. Having an explicit end marker lets uninstall reliably remove the
+# block even if it was written by an older/newer version of install.py whose
+# block content differs.
+prompt_end_regex = re.compile(r"#\s+[Ee][Nn][Dd]\s+[Ee][Dd][Kk][Rr][Ee][Pp][Oo]\s+[Pp][Rr][Oo][Mm][Pp][Tt]\s+[Cc][Uu][Ss][Tt][Oo][Mm][Ii][Zz][Aa][Tt][Ii][Oo][Nn]")
 zsh_autoload_compinit_regex = re.compile(r"autoload\s+-U\s+compinit")
 zsh_autoload_bashcompinit_regex = re.compile(r"autoload\s+-U\s+bashcompinit")
 zsh_autoload_colors_regex = re.compile(r"autoload\s+-U\s+colors")
@@ -167,8 +200,34 @@ zsh_bashcompinit = 'bashcompinit'
 # TCSH Configuration options
 tcsh_completion_regex = re.compile(r"if\s*\(\s*\$\?tcsh\s*&&\s*-r\s+\"\S*edkrepo_completions\.csh\"\s*\)\s*source\s+\"\S*edkrepo_completions\.csh\"")
 
+# macOS pyenv launcher PATH customization (see add_pyenv_launcher_dir_to_path())
+mac_local_bin_path_regex = re.compile(r"#\s+[Aa][Dd][Dd]\s+[Ee][Dd][Kk][Rr][Ee][Pp][Oo]\s+[Ll][Aa][Uu][Nn][Cc][Hh][Ee][Rr]\s+[Dd][Ii][Rr][Ee][Cc][Tt][Oo][Rr][Yy]\s+[Tt][Oo]\s+[Tt][Hh][Ee]\s+[Pp][Aa][Tt][Hh]")
+mac_local_bin_path_end_regex = re.compile(r"#\s+[Ee][Nn][Dd]\s+[Ee][Dd][Kk][Rr][Ee][Pp][Oo]\s+[Ll][Aa][Uu][Nn][Cc][Hh][Ee][Rr]\s+[Pp][Aa][Tt][Hh]\s+[Cc][Uu][Ss][Tt][Oo][Mm][Ii][Zz][Aa][Tt][Ii][Oo][Nn]")
+mac_local_bin_path_block = r'''
+# Add EdkRepo launcher directory to the PATH
+# This must be after the "eval $(pyenv init -)" block added by
+# setup_git_pyenv_mac.sh, so that ~/.local/bin/edkrepo is found before
+# ~/.pyenv/shims/edkrepo. The pyenv shim uses the currently active Python
+# interpreter, which could potentially not be the one EdkRepo is installed in.
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+# End EdkRepo launcher PATH customization
+'''
+
 def default_run(cmd):
     return subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+
+def is_python_module_installed(python_command, module):
+    '''
+    True if "module" is importable in the given python interpreter, False
+    otherwise.
+    '''
+    try:
+        default_run([python_command, '-c', 'import {}'.format(module)])
+        return True
+    except Exception:
+        return False
 
 def run_with_externally_managed_check(cmd):
     res = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -195,34 +254,41 @@ def get_args():
     parser = ArgumentParser()
     if ostype != MAC:
         parser.add_argument('-l', '--local', action='store_true', default=False, help='Install edkrepo to the user directory instead of system wide')
-        parser.add_argument('-s', '--system', action='store_true', default=False, help='Install edkrepo system wide')
+        parser.add_argument('-s', '--system', action='store_true', default=False,
+                            help='Install edkrepo system wide. Does not modify $HOME; each user must run "edkrepo setup" afterward')
+        parser.add_argument('--user-setup', action='store_true', default=False,
+                            help='Configure the invoking user\'s $HOME using an existing --system install. This is what "edkrepo setup" runs')
     parser.add_argument('-p', '--py', action='store', default=None, help='Specify the python command to use when installing')
     parser.add_argument('-u', '--user', action='store', default=None, help='Specify user account to install edkrepo support on')
     parser.add_argument('-v', '--verbose', action='store_true', default=False, help='Enables verbose output')
     parser.add_argument('--no-prompt', action='store_true', default=False, help='Do NOT add EdkRepo combo and git branch to the shell prompt')
     parser.add_argument('--prompt', action='store_true', default=False, help='Add EdkRepo combo and git branch to the shell prompt')
+    parser.add_argument('--uninstall', action='store_true', default=False,
+                        help='Uninstall EdkRepo instead of installing it. Requires --local, --system, or --user-setup')
+    parser.add_argument('-y', '--yes', action='store_true', default=False, help='Do not prompt for confirmation before uninstalling')
     return parser.parse_args()
 
 def check_args(args):
     check_prompt = False
     check_local = False
+    user_setup = getattr(args, 'user_setup', False)
     if ostype != MAC:
-        if args.local:
-            check_prompt = True
-        if args.system:
-            check_prompt = True
-        if args.prompt:
-            check_local = True
-        if args.no_prompt:
-            check_local = True
-        if args.local and args.system:
-            return 'ERROR: --local and --system are mutually exclusive.'
-        if args.system and not args.user:
-            return 'ERROR: --user must be specified if --system is specified.'
-        if check_prompt and not check_local:
-            return 'ERROR: --prompt or --no-prompt must be specified.'
-        if check_local and not check_prompt:
-            return 'ERROR: --local or --system must be specified.'
+        scope_flags = [args.local, args.system, user_setup]
+        if sum(1 for f in scope_flags if f) > 1:
+            return 'ERROR: --local, --system, and --user-setup are mutually exclusive.'
+        if args.uninstall and sum(1 for f in scope_flags if f) != 1:
+            return 'ERROR: --uninstall requires exactly one of --local, --system, or --user-setup.'
+        if args.system and (args.prompt or args.no_prompt):
+            return 'ERROR: --prompt & --no-prompt do not apply to --system installs; run "edkrepo setup" as each user instead.'
+        if not args.uninstall:
+            if args.local or user_setup:
+                check_prompt = True
+            if args.prompt or args.no_prompt:
+                check_local = True
+            if check_prompt and not check_local:
+                return 'ERROR: --prompt or --no-prompt must be specified.'
+            if check_local and not (args.local or user_setup):
+                return 'ERROR: --local or --user-setup must be specified.'
     if args.prompt and args.no_prompt:
         return 'ERROR: --prompt and --no-prompt are mutually exclusive.'
     return None
@@ -332,10 +398,11 @@ def get_add_prompt_customization(args, username, user_home_dir):
     elif args.prompt:
         __add_prompt_customization = True
         return True
-    #Check if the prompt customization has already been installed
+    #If the prompt customization has already been installed, upgrade it to the
+    #latest version.
     if is_prompt_customization_installed(user_home_dir):
-        __add_prompt_customization = False
-        return False
+        __add_prompt_customization = True
+        return True
     #If the prompt has not been installed and EdkRepo >= 2.0.0 is installed, then don't install the prompt customization
     if shutil.which('edkrepo') is not None:
         try:
@@ -441,7 +508,7 @@ def get_installed_packages(python_command):
             version = version.strip().strip('()')
         except:
             continue
-        installed_packages[name] = version
+        installed_packages[name.replace('_', '-')] = version
     return installed_packages
 
 def get_required_wheels():
@@ -523,6 +590,78 @@ def get_python_version(python_command):
     res = default_run([python_command, '-c', 'import platform; print(platform.python_version())'])
     return res.stdout.strip()
 
+#
+# pyenv launcher support
+#
+# On macOS, EdkRepo uses a Python interpreter installed by pyenv. It is unlikely
+# that EdkRepo is installed into every pyenv interpreter, so without help,
+# EdkRepo would stop working the moment "pyenv shell" or "pyenv local" selects a
+# different version. To mitigate this, shim launchers are created that
+# explicitly invoke the interpreter EdkRepo is installed in.
+#
+_pyenv_version_from_interpreter_regex = re.compile(r"^.*/versions/([^/]+)/bin/[^/]+$")
+
+def get_pyenv_version_name(interpreter_path):
+    '''
+    Returns the pyenv version name for the given interpreter. Returns None if
+    not a pyenv-managed interpreter (Ex: the Apple-bundled system Python).
+    '''
+    if interpreter_path is None:
+        return None
+    match = _pyenv_version_from_interpreter_regex.match(interpreter_path.replace(os.sep, '/'))
+    return match.group(1) if match else None
+
+_pyenv_launcher_template = '''#!/bin/sh
+# @file {script_name}
+#  Launcher that runs "{script_name}" using the Python interpreter EdkRepo was
+#  installed on (currently {pinned_version}).
+#
+# Automatically generated please DO NOT modify !!!
+#
+pyenv_root="${{PYENV_ROOT:-$HOME/.pyenv}}"
+pinned="{pinned_version}"
+target="$pyenv_root/versions/$pinned/bin/{script_name}"
+if [ -x "$target" ]; then
+    exec "$target" "$@"
+fi
+
+#
+# The preferred Python version is no longer installed. Attempt to find an
+# alternate Python interpreter that has "{script_name}" installed, so EdkRepo
+# keeps working. If more than one Python interpreter has "{script_name}",
+# choose the newest Python interpreter that matches.
+#
+best="$(
+    for dir in "$pyenv_root"/versions/*/; do
+        v=$(basename "$dir")
+        candidate="$pyenv_root/versions/$v/bin/{script_name}"
+        [ -x "$candidate" ] || continue
+        key=$(printf '%s' "$v" | awk -F. '{{ printf "%05d%05d%05d\\n", ($1+0), ($2+0), ($3+0) }}')
+        printf '%s %s\\n' "$key" "$candidate"
+    done | sort | tail -n 1 | cut -d' ' -f2-
+)"
+if [ -n "$best" ]; then
+    exec "$best" "$@"
+fi
+
+echo "error: could not find a Python interpreter with \\"{script_name}\\"" >&2
+echo "Please run the EdkRepo installer again." >&2
+exit 1
+'''
+
+def write_pyenv_pinned_launcher(shim_path, target_script_name, pinned_version, username, log):
+    '''
+    Writes a launcher shim that executes target_script_name using
+    the Python interpreter that EdkRepo is installed in.
+    '''
+    with open(shim_path, 'w') as f:
+        f.write(_pyenv_launcher_template.format(
+            script_name=target_script_name, pinned_version=pinned_version).replace('\r\n', '\n'))
+    shutil.chown(shim_path, user=username)
+    stat_data = os.stat(shim_path)
+    os.chmod(shim_path, stat_data.st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return shim_path
+
 edkrepo_python_shim_name = 'edkrepo_python'
 edkrepo_python_shim_template = '''#!/bin/sh
 # @file edkrepo_python
@@ -534,8 +673,11 @@ edkrepo_python_shim_template = '''#!/bin/sh
 exec "{interpreter}" "$@"
 '''
 
-def generate_edkrepo_python_shim(default_cfg_dir, interpreter_path, username):
+def generate_edkrepo_python_shim(default_cfg_dir, interpreter_path, username, log):
     shim_path = os.path.join(default_cfg_dir, edkrepo_python_shim_name)
+    pinned_version = get_pyenv_version_name(interpreter_path) if ostype == MAC else None
+    if pinned_version is not None:
+        return write_pyenv_pinned_launcher(shim_path, 'python3', pinned_version, username, log)
     with open(shim_path, 'w') as f:
         f.write(edkrepo_python_shim_template.format(interpreter=interpreter_path).replace('\r\n', '\n'))
     shutil.chown(shim_path, user=username)
@@ -621,7 +763,7 @@ if [ -x "$(command -v edkrepo)" ] && [ -x "$(command -v command_completion_edkre
       fi
     fi
   }
-  
+
   # Integrate with bash-preexec if available, otherwise use direct trap
   if declare -f __bp_preexec_invoke_cmd &>/dev/null; then
     # bash-preexec is available - use its hook system
@@ -685,6 +827,7 @@ parse_git_branch() {
 }
 
 PS1="$newps1\[\033[36m\]\$(parse_git_branch)\[\033[00m\]$prompt_suffix"
+# End EdkRepo prompt customization
 '''
 
 zsh_prompt_customization = r'''
@@ -751,8 +894,190 @@ zstyle ':vcs_info:git:*' formats " %{$fg[cyan]%}(%b)%{$reset_color%}"
 # Set up the prompt (with git branch name)
 setopt PROMPT_SUBST
 eval "PROMPT='$new_prompt\${vcs_info_msg_0_}\$prompt_suffix'"
-
+# End EdkRepo prompt customization
 '''
+
+#
+# Legacy prompt customization blocks
+#
+# These are earlier versions of bash_prompt_customization and
+# zsh_prompt_customization from prior versions of install.py. They are used to
+# detect and remove older versions of the prompt customizations.
+#
+# They are stored gzip-compressed and base64-encoded, to discourage accidental
+# modification.
+def _decode_legacy_block(encoded):
+    '''
+    Decodes a gzip-compressed, base64-encoded string.
+    '''
+    return gzip.decompress(base64.b64decode(encoded)).decode('utf-8')
+
+# EdkRepo: Add command completion setup to install.py (original) (9cb41d8877)
+bash_prompt_customization_v1 = _decode_legacy_block('''
+H4sIAAAAAAACA6VU207bQBB9368YnAhiSnAuUh/aGgkV1JemINqHSnGwjD2JVzi77q5zg+bfO7t2
+yAW3lVqkkM3OmTNnbssacJkkcJ083mEu4RgmvIBCQpEi5EpO84Llupuh8J3mc+P2a3ftsAwLcHKp
+++BDaYQ29Lf3vd37nsP4GIZA7uT9zritHfB9cIKgCQ6M3ptYggEIXJCXXwE7FZQMpY5Qz8ZjvvRL
+P4bZb2jh31ihlrRXkf6Vs1fHWVJq3HUhjxqkw8acscZLH2I5fZDARYU7L2vYXpKSFtmmkUigPQdM
+HhXBXRIHx8d1iOoY0ndO/eFShDtOrzMqD8Ew6PT7w35vGoyCZjxTCkWxcQytOJNErcF/iV8TdOPS
+tlCXEUkDrrBANeWCi4mduwpjiqG2xVD4Y8YVaqrKXD4a7O2qSKUAk2keKU1Xlo5C8zHqAr4PPp/B
+IuVxClxDRAxZVPA5ZivAZY5C0xlkjioyEs3UJxJwjmoFBZ+iJTN6ZhoVNQK1pugfrgWpvTi31ktD
+SwRjqShqbNjIkz9ZwjOQgkIlZpkoPnWwXCrUJrmFVDaJhHKKC6lWljBOIzHBhM6m4UM4gvYT0Jjd
+3Qxuv4UfbwaDyy9Xb5ZrGJUNN7O6b3TgiOZ1ryNhnOaLhNq97TeAzJKwGsKqXf4BE8FoKCvkgswt
++u/SRQ15y4VnS7sR7pToUk2zojiQ8CJjl7z8+//JKnlsAltVfyjngS6cRxk0Xxdpl3dNn30qv6Y0
+1WZ/onf1QdGQpLtrbeYWQ3pzw9JW1XGyBfcuwEtw7olZlsFP0EhrjXDi3Q/vT0decmJ/ae8Ugtb5
+aeB60Aq6rnfC1ozRU/Nqo9/ajW4dxnUre6dD9ube4+SwX/o1f60kBgAA
+''')
+
+# EdkRepo: Update combo displayed in shell after checkout (3a67aad9ac)
+bash_prompt_customization_v2 = _decode_legacy_block('''
+H4sIAAAAAAACA71V227aQBB936+YGBQuDeEm9aGtI5EmSh9KEyWtVAkTy7EHsDBed9fckvLvnbXX
+YGJQq1YqEtjsnDkzs2d2lpWg53lw7U3vMeJwCmM/hphDPEGIBJ9FMYtkO8DQNMovpbuH9sZgAcZg
+RFx2wYTUCA3o7tY7+fWOwfwRDIDcyfudctsYYJpgWFYZDBi+V7FCBhDikrxMDWxpKBnSPGw5H438
+lZn6MQyO0MLfscJB0o4m/S1n5xBnSikx70IeB5AGG/mMlbY6uHz2xMEPNe483cPGijKpkm3mhB40
+FoDeVBC8RsnB6ekhhH616RmRPj4P7ZxTsaL0xRpYrW530O3MrKFVdudCYBhnjnaSnCrioMHcxj8Q
+NHNpJNAaI5ISXGGMYuaHfjhO+k5j1GaI3WYI/DH3BUralQWfKuzdOp7wEFSlkSMkLSV0FNofoYzh
+e//zGSwnvjsBX4JDDIET+wsM1oCrCENJ78AjFI5KUXW9xwEXKNYQ+zNMyFQ+c4mChEApKfqH65Cy
+vThPrD1FSwQjLiiqq9jI039OCM+AhxTKU4eJ4pOC6aFCqYpbcpEU4VFNbszFOiF0J044Rg+4yPCB
+Q5VkguIK3XlM9qUjM/HJz9Nbb7sTdKem0VLibEVRa7aisTVNtQYvBAAVYqC6/bL38Mn+eNvv975c
+Jf1eN7S3UYdh2lpF3InC2Xngtp2Ok5/kyO2iU7GW5LSoDx2Q7WND31g4EVSOV1mBq+vLbzcsy+QE
+Gs9AJ/b+tn/3NUvozWqTL3DfmGRr7DU3xYmWnrGfNg88W59nHdt8xcR03glySeYq/dbyIu3It+rs
+tjBBp9mUNYVR3LkCefr590N6TJpWJs12bO4j0tHZzs+Z/5aS7pY/EP9VbrhwAigXJc3zqvbbpzIP
+CKlH+g1dqE+CpsMkP8/VwEKbLls7tWnVxztw5wKaHi6a4TwI4CdIOvUNhErzcfBYHzapvdU/2ayD
+VT2vW7UmVK12rVlhG8bojimM8rfJKK++jlvT9laL7OW9W8lgvwBJ8KWzHQgAAA==
+''')
+
+# EdkRepo: Linux Installer Improvements (6235c33540)
+bash_prompt_customization_v3 = _decode_legacy_block('''
+H4sIAAAAAAACA72WbW/aQAyAv9+vcAMqLyuFwMSHdalE16r7MNaq3aRJhEZpckBEyGV34a0d/32+
+5AKBBHXapEWChLP92D6fHUgJeq4LN+70gYYMTmHsRRAxiCYUQs5mYURCofs0MLTya+n+Ud9oxKcR
+aCETHTAgEUIDOrv1dna9vVvXu1mB3tWIN4IBIBi5HyRwo4FhgGaaZdBgeCGjCAhAQJdoZijFllJF
+QRKhJeajkbcyEjtC/SNY+DsqFELbCvoms13ELETq3TRQTMQcmK1OZ9BqzczhWy6kYUHcKUK/6LxH
+ygES/Qua5SGugKKRkUdIaXtCHDZ7ZuAFSu88qWFjhXlUUTazAxcaC6DulKN6DSOH09MiDfVo4T3E
+E+KxwMoY5dNNHlQOnTbmYJadOec0iFJDKw5OJlEoMLb+C5ymJo1YtUYQUoJrGlE+8wIvGMcdoXTk
+ZvDdZnD6c+5xKnBXFmwqde/X0YQFIDMNbS5wKcaha29ERQQ/+l/OYDnxnAl4Amwk+HbkLai/BroK
+aSDwGVhIuS1DlP3oMqALytcQeTMaw2Q8c0E5FoIKgd4/3gQY7eV5LO1JLAJGjKNXR9LQ0nuJgWfA
+AnTlyjZH/1jBpN2pkMktGY+TcDEnJ2J8HQOdiR2MqQuMp/q+jZmkBaUr6swjlC9tkRYf7Vy19ZYz
+oc7U0FqyONuiyDVLYiyFqdbgFRVAuhjI1rjqPX62Pt31+72v13Fv1DVlrdVhmBytvN6J1LOyitvj
+dBx+koFbeaN8LnG3yAsbZHvb4CfidgiV41lW4Prm6vstSSM5gcYLYDs/3PXvv6UBvVttsgnuC+No
+tb3DjX7Cpavth81811L9rHwbBySi4o41lyiu4nctW6QdfFud3RbG2kk0ZYXQ8juXgyfXvzfpsdK0
+0tJsZ+y+RjJm9eyc+W8hqdPyB8U/iI0ubB/K+ZJmufL47aOMgkKqkX6Lr/pnjtNhkp3ncmBRC/8G
+WIlMVX28U25fQtOli2Yw9334BQK7vkGh0nwaPNWHTTze8pdo1sGsntfNWhOqpl5rVsiGEHzH5EZ5
+Nx7l1UO/tezrqrz3VtLIb46MR++3CAAA
+''')
+
+# EdkRepo: Fix Corner Case in EdkRepo Prompt Customization (a76ab9061e)
+bash_prompt_customization_v4 = _decode_legacy_block('''
+H4sIAAAAAAACA72WbW/aMBCAv/tXXAMqLyuFwMSHdanE1qr7MNaq3aRJhEZpYiAixJkT3trx33d2
+HAgkrNMmDQlifHfP3fnOdkgJeq4L1+70noYMTmHsxRAziCcUQs5mYUzCSPdpYGjll9Ldg77RiE9j
+0EIWdcCARAgN6Ozm29n59m5e72YFelcj3ggGgGDkvhPAjQaGAZpplkGD4YWIIiAAAV2imaEUW0oV
+BUmEVjQfjbyVkdgR6h/Bwt9RoRDaVtBXme0iZiFS76aBYiLmwGx1OoNWa2YOX3MhDAviThH6Rect
+Ug6Q6D+iWR7iCigaGXmElLYd4rDZEwMvUHrnSQ0bK8yjirKZHbjQWAB1pxzVaxg5nJ4Waaihhc8Q
+O8RjgZUxyqebDFQOnTbmYJadOec0iFNDSwYnkigUGFv/BU5Tk4ZUrRGElOCKxpTPvMALxnJHKB2x
+GHy3GJz+mHucRrgqCzYVunfreMICEJmGNo9wSuLQtTeiUQzf+5/PYDnxnAl4EdhI8O3YW1B/DXQV
+0iDCMbCQcluEKPajy4AuKF9D7M2ohIl45hHlWAgaRej9/XWA0V6eS2lPYBEwYhy9OoKGlt6zBJ4B
+C9CVK7Y5+scKJtudRiK5JeMyCRdzcmLG1xLoTOxgTF1gPNX3bcwkLShdUWceo3xpR2nx0c5VS285
+E+pMDa0lirMtipizBMZSmGoNXlABhIuB2Bofeg+frI+3/X7vy5XcG3VNWWt1GCatldc7EXrHSy1N
+tw123N1Jxl1BsHnMn4HUeoTLQsJvGbbr7re0FTMr2YjFrHwF5B5PP7i1c0M1kI8NfmNuh1A5vgwV
+uLr+8O2GpIGfQOMZ8HC6v+3ffU3jf7PaZMu1L5TJFa7PfkrMd1WyqW/jgERU3FJzieIq/tayLbeD
+b3ttt+JSO4mmrBBaflVz8OTz70fOsZK10pJtb4x9jeTS0LOn5n8Lads2rxb/IDa6sH0o50ua5Yr2
+20cZBYVUF9QNvrg8cTzrJtnbSRy/1MKXGiuRqaqPd8rtS2i6dNEM5r4PPyHCM6xBodJ8HDzWh01s
+b/EvatbBrJ7XzVoTqqZea1bIhhC8MXMXU1deTNVDv7Xs5Vveu2M18gv0JS7fhQkAAA==
+''')
+
+# EdkRepo: Remove Installation of Shell Trap Signal (4e3dfd0dad)
+bash_prompt_customization_v5 = _decode_legacy_block('''
+H4sIAAAAAAACA71XbW/bNhD+rl9xkY34pXX8NuTDOgVI26AbsKxB2gEDrESQJdoiIosqKb818377
+jhRl681JmgEzkFjW3T13x7vnSBoNuPR9uPIfbknM4BTmNIGEQRIQiDlbxIkRi2FIIstsPjZuvgx3
+phGSBMyYiTFYkAqhB+PD+1H+/ejwfnieFwzPTYPOYAIIjLg/S8CdCZYFpm03wYS7dzKKyACIyBrN
+LK040KooSCN0xHI2oxsrtTNIeAQWXocKtaAjDfos5qgOsxZyeJ4FionYE3swHk8Gg4V995wLaVgT
+dwYxfDf+CVFKkOhfkDwewtWgmMaMGkZj3yEeW0wZ0EjrnaU17G0wjzbKFm7kQ28FxH/gqN7ByOH0
+tE5DPzr4HWOHUBY5OaNquumDzmE8whzsprfknERJZuio4GQStQJr77/GaWbSU6odA0Ea8JEkhC9o
+RKO5YoTWkYvBD4vBybcl5UTgqqzYg9S92SYBi0BmGrtc4CsFh67pjIgE/rr+/S2sA+oFQAW4iBC6
+CV2RcAtkE5NI4DOwmHBXhij56DMgK8K3kNAFUWAynqUgHAtBhEDvv1xFGO3FmZJeSlgEmDGOXj2J
+hpb0uwJ8CyxCV76kOfrHCqZ0J0Imt2ZcJeFjTl7C+FYBeoEbzYkPjGf6oYuZZAUlG+ItE5SvXZEV
+H+18vfSOFxDvwTIHsjj7osh3joRxNEy7A4+oANLFRFLj/eWXX50Pn6+vL//4qLjRNbW12YW7tLWq
+eidS73iplem+wY67O8m5qwm2CvMyIL0e8boW4UkM1/eLLe0kzEmJWI/1JBoWXJbt+LL8QFY+mS7n
+TsLd+DhMtR3UwMl/cNYc/Zn7sX/UD+prh3+qVX9DHsyROgTWNAlg6oqgp3OVqbgrl4buNCRIA4yS
+r6lQTNINDzIJQyXtEy90OYHeDBxnGjvZgimeE8db+HB60ffJqh8twzCXc6PkVByc4s4nfdFEQMDY
+A4itSMhCWZXqsSeDxPvghiGwJQe1cmliaiJp/iWBm7TQzZQt1f6t+ajtQ+a5IWC8OEf3a55VFV8/
+RS0l/mFGleBfQaUnEZ7jUJ3xK8hTB/Ni1jyVwMvo8gLCVCjzag7tdOfekjnFluRV8rR0y7qcu9vc
+mD6RR6vHbF1my8iTvSEm3bsdSqx/8F9p0eSBpph0xfqN1S4ZdQ5U10eXCtEilhSYprY0jnsp2WBO
+ahfHJVf7MnaD5JNQMJk4Vxc8LCjdXgwfr97/+Qn+BoHbW4+AKfr3qagHLdtun3Vtu9NKtZp92x72
+zbKabdtmpimfC8ppXtXOKPD/KuVzKZEZ5bgHYxXw0K4kosDtXoTNV5Obmed3rRybta5Xq61KVjhY
+6kGMUp814CtaZpNJDbOQzamnxcenQ649VdatamR6+Q3tLuvL3ndszJvbz9c3X7N9681ml8++KCwm
+np8yxcxZ6OvJkcVolZCySJTmGsVt/N/JH34O4LlCZxNDaafRNDVEzeJXwNPPfz/8Hhs/g6yo+7tL
+USO9vgzz5/f/LaR9nz1b/LoWblZLmseV3VeEsmoKqa9Kn5CNU46n7iB/T5IXAeLg9dpJZbrq84Py
+6AL2h4nDuGn17yf33bu+31K/RL8LapJ0+tC2h51+y9gZBt7dKlekc3VFapf9dvLXwGbhtmca/wJ1
+rk59DxAAAA==
+''')
+
+# EdkRepo: Add command completion setup to install.py (original) (9cb41d8877)
+zsh_prompt_customization_v1 = _decode_legacy_block('''
+H4sIAAAAAAACA61Uy27bMBC88ysWshzbhR00dU9pVTRF01OCBHkABRxDkKWVREQiVZKS4xj+9y4p
+O45TFeihFz3I2ZnhLndZD86SBM6TxxusJBxBxg0YCSZHqJQsK8PaV1igyEweeP66d31zdXl9t/FY
+gQa8SuqPEMABDCYw3W9PO7Y/eIynMAPia+lmviUa+wfA+caj2AH0e/SYf7K2BAMQuAxbXLCPPxk7
+hskJBRFmy6PrNOVPgWcpPIZFh+i0U9SzAf+mOf2L5lZS49vwNrojwmMpZ6z3Uo9YlgsJXGxxx23O
+Jk90giHtlZFIYNIAJo+K4CPyC0dHXYjtZ0jvisrCpQhfBXUfcv/TX/tpNssUopj3Nw9+XCuFwuwo
+QmeTQAo1GvorpOq7hHQCgxdnHXZ2IRMHHTEi6cF3NKhKLrjI3M3cYmya1D5NCn/VnCxQvhr5aLHX
+K5NLATYHVaQ0LTk6kuYpagM/Ly/GsMx5nAPXEBFDERneYLECfKpQaPoGWaGKrEXbF4kEbFCtwPAS
+HZn1U2tUVCLUmtQ/nwty++XY7Z5ZWiJIpSLV2LJRJH92hGOQgqQS226kT7Vt246ySIdbSuUOkdCZ
+YiPVyhHGeSQyTOg7rUXsbB0kN4zzapkMR7AmyP8oAMDGFtKyhjtJHQz99Zul2df5BrwOL95oe6kv
+ZJQAJU9b07EURsmCauVSYylYVBu6OgSa3D9DE+vQbtL8wbh0J3pZI0vE98MFupztNsJSZ+H7EJpI
+8WhRIHvWZlUgDE53iFMacKfvBtCqamrx9nLHq8je7WF/MfrzIpPYLc2yuno1F2G45DTJ7LxcKCpt
+DiIqccQokGoMbYuHt/ffbu8YNlEBXrsUDF411oO/fmOduutgJgw89hudFwYfpAUAAA==
+''')
+
+# EdkRepo: Update combo displayed in shell after checkout (3a67aad9ac)
+zsh_prompt_customization_v2 = _decode_legacy_block('''
+H4sIAAAAAAACA61VTW/aQBC9+1dMDASIIAqlp7RUTdX0lKhRPqRKBFnGHmCF2XV313wE8d87u7YB
+g1FzyAXjnTdv3sx4Zp0K3IQh3IbTR4wFnMOYadAC9AQhlmIWayd9eBHysZ703Oq68vD4+/7heeM6
+EWpwY6E+Qw8KMGhDd2fulpg/uQ4bQR+IL6XrVw1Rq1oADjYu+dahVqGfwRcjizsAHBdeiuvt/Dst
+y9DukBNhMh6VjEZs2XMNhetgVBK0WxrUNQ7vi9k9ETMLqfDQPfUu8XCdEXOcyrYfgZgNBTCe4S7T
+mrWXlEGDbDOfh9CeA4ZTSfAm6YXz8zJE9tejZ0xtYYJ7e07lSe5eauvqaNwfS0Q+qG1eq0EiJXKd
+U3hWJoEkKtT0FglZswUpBfa2ykrk5C5tC206RFKBn6hRzhhnfGy/zAxjyiR3ZZL4N2Ekgeo1F1OD
+fVjpieBgahD7UtGRpaPQbIRKw5/7uxYsJiyYAFPgE0PkazbHaAW4jJEr+g8iRukbiWYuQgE4R7kC
+zWZoyYyeRKGkFqFSFP3rLSe13y6t9cbQEsFISIoaGDbyZG+WsAWCU6jQjBvFp96mY0dVpOQWQtok
+Qsop0EKuLGEw8fkYQxAyx0c+ZZK3GpcYJJrsC1/lnwX5hVnpvWCCwbTnXpnmjBIe2LwK3SFIvAgb
+TVgT5CM6aFhK42/MB2KCebkS1WtU1wdH/e+DDbglEt3m6RyohqYS2yzM2Jix75jJvsjZ3AsYpAOT
+2c6M0du3bifjgOVsj8Y7Rh5n3HEzEw349rGxG8BKLdbg6LCsChnoP3UIZmGhDKS/qM0uu87+Fvi4
+vp/ofDF9UniUfeHsRPKEodzThXkn/BBoMJWpQSC4liKiPWDHznA4fqJpLRGo/fIG80B5xujQbbdX
+o+05KXu/rh0HqSEpv2xMO5o5nzdTY+/Kg7kvmT+M0HlTehUh1K9zxDWxXF/UIRWs6OZJd26w8s3K
+bdSGzeP9SsGe6IpN4r3rGhoLRhesucaHkjbOBLg/w6ZDjrR6IL15vKeXH0/PDs79CNz0qFff2/ev
+1fWBdFr6hauqTtH/AV3+g1Q8CAAA
+''')
+
+# EdkRepo: Fix Corner Case in EdkRepo Prompt Customization (a76ab9061e)
+zsh_prompt_customization_v3 = _decode_legacy_block('''
+H4sIAAAAAAACA61WTW/aQBC9+1dMDQSIIAqlp7RUTdX0lKhRPqRKBFnGHmCF2XV313wE8d87u7YB
+g2lzyAWb3Tdv3szsztipwHUYwk04fcBYwBmMmQYtQE8QYilmsXbShxchH+tJz62uK/cPv+7unzau
+E6EGNxbqE/SgAIM2dHfb3ZLtj67DRtAH4kvp+lVD1KoWgIONS7Z1qFXoZ/DZyOIOAMeFl+J6O/tO
+yzK0O2REmIxHJaMRW/ZcQ+E6GJU47ZY6dY3B23x2T/jMXCo8NE+tSyxcZ8Qcp7KtRyBmQwGMZ7iL
+NGftJUXQoL2Zz0NozwHDqSR4k/TC2VkZInv16BlTWZjg3p5ReZC7P7V1dTTujyUiH9Q2L9UgkRK5
+zik8K5NAEhVq+hcJWbMJKQX2tspK5OQmbQttOkRSgR+oUc4YZ3xsT2aGMWmSuzRJ/JMwkkD5moup
+wd6v9ERwMDmIfaloydKRazZCpeH33W0LFhMWTIAp8Ikh8jWbY7QCXMbIFb2DiFH6RqK5F6EAnKNc
+gWYztGRGT6JQUolQKfL+5YaT2q8Xdvfa0BLBSEjyGhg2smSvlrAFgpOr0Fw38k+1Ta8dZZGCWwhp
+gwgppkALubKEwcTnYwxByBwf+RRJXmpcYpBo2l/4Kj8WZBdmqfeCCQbTnntpijNKeGDjKlSHIPEi
+bDRhTZD3qKBhKfW/MQfEOPNyJarXqK4PlvrfBhtwSyS6zdMxUA5NJrZRmGtjrn3H3OzznM09h0F6
+YbK9D2bzdGQWv70rB7wf9oiLKo7N/meYxldi9gaPweyE5XEVOu7eNjWeo9fsxT42tlvZgIr1Olos
+q1iein/XjLQXSkZxFjXbxtzZ71jvd0ZPnNJi+KTwKPrC2ongTVWaWXO/FX4I1ESUyUEguJYiop5l
+W4ThcPxEUwslUPv5FeaB8symQ5N5L0fbdVL2dl07DlJDUn5an7aN5HzeTI29Sw/mvmT+MELnVelV
+hFC/yhFXxHJ1XodUsKIpmc6HYOWb8dCoDZvHs4CcPdLnQBLvfVpAY8HoY8B8cgwldccJcH+GTYcM
+qU1COiW9x+fvj08Ozv0I3HSpV9+bTS/V9YF0GlCFsVon738B/yGFw+gIAAA=
+''')
+
+# Tried, in order, newest first.
+bash_prompt_customization_legacy_blocks = (
+    bash_prompt_customization_v5,
+    bash_prompt_customization_v4,
+    bash_prompt_customization_v3,
+    bash_prompt_customization_v2,
+    bash_prompt_customization_v1,
+)
+zsh_prompt_customization_legacy_blocks = (
+    zsh_prompt_customization_v3,
+    zsh_prompt_customization_v2,
+    zsh_prompt_customization_v1,
+)
 
 def get_command_completion_script_path(default_cfg_dir, user_home_dir, install_to_local):
     bash_completion_path = None
@@ -834,7 +1159,7 @@ def add_command_comment_to_startup_script(script_file, regex, command, comment, 
         shutil.chown(script_file, user=username)
         os.chmod(script_file, 0o644)
 
-def add_command_completions_to_shell(command_completion_script, args, username, user_home_dir, source_command_completion):
+def add_command_completions_to_shell(command_completion_script, args, username, user_home_dir, source_command_completion, log):
     if ostype == MAC:
         # Add "source ~/.bashrc" to ~/.bash_profile if it does not have it already
         bash_profile_file = os.path.join(user_home_dir, '.bash_profile')
@@ -874,6 +1199,10 @@ def add_command_completions_to_shell(command_completion_script, args, username, 
             distributor = res.stdout.strip()
             if distributor == "Distributor ID:	Raspbian":
                 add_command_to_startup_script(bash_rc_file, prompt_regex, raspberry_pi_bashrc_workaround, username)
+        # Remove any existing prompt customizations before writing the new version.
+        remove_marked_block_from_startup_script(
+            bash_rc_file, prompt_regex, prompt_end_regex,
+            (bash_prompt_customization,) + bash_prompt_customization_legacy_blocks, username, log)
         add_command_to_startup_script(bash_rc_file, prompt_regex, bash_prompt_customization, username)
 
     # Add edkrepo command completion to ~/.zshrc if it does not have it already and zsh is installed
@@ -888,6 +1217,10 @@ def add_command_completions_to_shell(command_completion_script, args, username, 
         if source_command_completion:
             add_command_comment_to_startup_script(zsh_rc_file, regex, new_source_line, comment, username)
         if get_add_prompt_customization(args, username, user_home_dir):
+            # Remove any existing prompt customizations before writing the new version.
+            remove_marked_block_from_startup_script(
+                zsh_rc_file, prompt_regex, prompt_end_regex,
+                (zsh_prompt_customization,) + zsh_prompt_customization_legacy_blocks, username, log)
             add_command_to_startup_script(zsh_rc_file, prompt_regex, zsh_prompt_customization, username)
 
 def add_tcsh_completion_to_shell(command_completion_csh_script, username, user_home_dir):
@@ -900,6 +1233,643 @@ def add_tcsh_completion_to_shell(command_completion_csh_script, username, user_h
     new_source_line = 'if ($?tcsh && -r "{0}") source "{0}"'.format(command_completion_csh_script)
     comment = '\n# Add EdkRepo command completions'
     add_command_comment_to_startup_script(tcsh_rc_file, tcsh_completion_regex, new_source_line, comment, username)
+
+def add_pyenv_launcher_dir_to_path(username, user_home_dir):
+    '''
+    macOS only: Adds a script block to ~/.bashrc and ~/.zshrc that inserts
+    ~/.local/bin into the PATH.
+    '''
+    bash_rc_file = os.path.join(user_home_dir, '.bashrc')
+    add_command_to_startup_script(bash_rc_file, mac_local_bin_path_regex, mac_local_bin_path_block, username)
+    zsh_rc_file = os.path.join(user_home_dir, '.zshrc')
+    add_command_to_startup_script(zsh_rc_file, mac_local_bin_path_regex, mac_local_bin_path_block, username)
+
+#
+# System-level install/uninstall support.
+#
+# A --system install does not modify $HOME. Instead, install.py and a copy of
+# its configuration files are persisted so that "edkrepo setup" and "edkrepo
+# uninstall --system" can be run later without needing the original installer
+# package.
+#
+system_dir = os.path.join('/', 'usr', 'local', 'share', 'edkrepo')
+_persisted_installer_files = ['install.py', 'vendor_customizer.py']
+
+def system_installer_dir():
+    return os.path.join(system_dir, 'installer')
+
+def get_system_config_dir():
+    return os.path.join(system_dir, 'config')
+
+def persist_installer(dest_dir, username):
+    '''
+    Copies install.py and vendor_customizer.py (if present) into dest_dir so
+    that "edkrepo setup" & "edkrepo uninstall" can run install.py later without
+    needing the original installer package.
+    '''
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    os.makedirs(dest_dir, exist_ok=True)
+    for name in _persisted_installer_files:
+        src = os.path.join(src_dir, name)
+        if not os.path.isfile(src):
+            continue
+        dst = os.path.join(dest_dir, name)
+        shutil.copyfile(src, dst)
+        os.chmod(dst, 0o755 if name == 'install.py' else 0o644)
+        if username is not None:
+            try:
+                shutil.chown(dst, user=username)
+            except Exception:
+                pass
+
+def persist_config_dir(src_dir, dest_dir):
+    '''
+    Recursively copies the contents of src_dir into dest_dir, so that install.py
+    can locate its configuration later.
+
+    Unlike shutil.copytree(), this only copies file data and does not try to
+    preserve file metadata (permissions, timestamps, ownership, etc). Preserving
+    metadata can fail on some networked filesystems (Ex: NFS), even when the
+    user has write access.
+    '''
+    os.makedirs(dest_dir, exist_ok=True)
+    for name in os.listdir(src_dir):
+        src = os.path.join(src_dir, name)
+        dst = os.path.join(dest_dir, name)
+        if os.path.isdir(src):
+            persist_config_dir(src, dst)
+        elif os.path.isfile(src):
+            shutil.copyfile(src, dst)
+
+def prepare_user_config_dir(default_cfg_dir, username, log):
+    if not os.path.exists(default_cfg_dir):
+        log.info('\nCreating configuration directory structure:')
+        try:
+            os.makedirs(default_cfg_dir)
+        except:
+            log.info('- Failed to create configuration directory {}'.format(default_cfg_dir))
+            return False
+        # Need to change the group on the directory
+        try:
+            shutil.chown(default_cfg_dir, user=username)
+        except:
+            log.info('- Unable to update owner {0}:{0} on {1}'.format(username, default_cfg_dir))
+            return False
+        log.info('+ Created configuration directory: {}'.format(default_cfg_dir))
+    return True
+
+def copy_config_files(cfg, sha_data, cfg_source_dir, default_cfg_dir, username, log):
+    log.info('\nCopy configuration files:')
+    if not os.path.isdir(cfg_source_dir):
+        log.info('- Missing configuration file directory')
+        return False
+    for cfg_file in cfg['config_files']:
+        dst_cfg_file = os.path.join(default_cfg_dir, cfg_file)
+        if cfg['config_files'][cfg_file].lower() == 'true' and os.path.isfile(dst_cfg_file):
+            with open(dst_cfg_file, 'rb') as f:
+                current_sha_obj = hashlib.sha256(f.read())
+            with open(os.path.join(cfg_source_dir, cfg_file), 'rb') as f:
+                new_sha_obj = hashlib.sha256(f.read())
+            if current_sha_obj.hexdigest() != new_sha_obj.hexdigest():
+                if current_sha_obj.hexdigest() not in sha_data['previous_cfg_sha256']:
+                    file_inc = 0
+                    back_file = '{}.old{}'.format(dst_cfg_file, file_inc)
+                    while os.path.isfile(back_file):
+                        file_inc += 1
+                        back_file = '{}.old{}'.format(dst_cfg_file, file_inc)
+                    log.debug('+ Copy {} to {}'.format(dst_cfg_file, back_file))
+                    try:
+                        shutil.copyfile(dst_cfg_file, back_file)
+                        shutil.chown(back_file, user=username)
+                        os.chmod(back_file, 0o644)
+                    except:
+                        log.info('- Failed to create backup copy of configuration file')
+                        return False
+        try:
+            shutil.copyfile(os.path.join(cfg_source_dir, cfg_file), dst_cfg_file)
+            shutil.chown(dst_cfg_file, user=username)
+            os.chmod(dst_cfg_file, 0o644)
+        except:
+            log.info('- Failed to copy {} to {}'.format(cfg_file, default_cfg_dir))
+            return False
+        log.debug('+ Copied {} to {}'.format(cfg_file, default_cfg_dir))
+    log.info('+ Configuration files copy complete')
+    return True
+
+def install_wheels(args, log, whl_src_dir, install_to_local, _customizer, _context):
+    '''
+    Determines which wheels need to be installed (or upgraded) and installs them.
+    Returns True on success.
+    '''
+    log.info('\nDetermining python modules to install/upgrade:')
+    try:
+        wheels_to_install = get_required_wheels()
+    except:
+        log.info('- Failed to determine installed python modules and versions')
+        return False
+
+    # Vendor customizer get_wheels() can change the wheel list.
+    if _customizer is not None and hasattr(_customizer, 'get_wheels'):
+        try:
+            wheels_to_install = _customizer.get_wheels(_context, wheels_to_install)
+        except Exception as e:
+            log.info('- Vendor get_wheels failed: {}'.format(e))
+            if args.verbose:
+                traceback.print_exc()
+            return False
+    if wheels_to_install:
+        log.info('+ Complete')
+    else:
+        log.info('+ Complete - Nothing to install')
+
+    # Install python wheels
+    if wheels_to_install:
+        log.info('\nInstalling python modules:')
+        if not os.path.isdir(whl_src_dir):
+            log.info('- Missing wheel file directory')
+            return False
+
+        #Uninstall wheels with the UninstallAllOtherCopies attribute set
+        updating_edkrepo = False
+        for whl_name in wheels_to_install:
+            uninstall_whl = wheels_to_install[whl_name]['uninstall']
+            whl_name = whl_name.replace('_','-')  #pip doesn't understand the difference between '_' and '-'
+            if uninstall_whl:
+                updating_edkrepo = True
+                try:
+                    run_with_externally_managed_check([def_python, '-m', 'pip', 'uninstall', '--yes', whl_name])
+                except:
+                    log.info('- Failed to uninstall {}'.format(whl_name))
+                    return False
+                log.info('+ Uninstalled {}'.format(whl_name))
+
+        #Delete obsolete dependencies
+        if updating_edkrepo:
+            installed_packages = get_installed_packages(def_python)
+            for whl_name in ['smmap2', 'gitdb2']:
+                if whl_name in installed_packages:
+                    try:
+                        run_with_externally_managed_check([def_python, '-m', 'pip', 'uninstall', '--yes', whl_name])
+                    except:
+                        log.info('- Failed to uninstall {}'.format(whl_name))
+                        return False
+                    log.info('+ Uninstalled {}'.format(whl_name))
+
+        #Install new wheels
+        for whl_name in wheels_to_install:
+            whl = wheels_to_install[whl_name]['wheel']
+            install_whl = wheels_to_install[whl_name]['install']
+            if install_whl:
+                install_cmd = [def_python, '-m', 'pip', 'install', '--no-index', '--find-links={}'.format(whl_src_dir)]
+                if install_to_local:
+                    install_cmd.append('--user')
+                install_cmd.append(os.path.join(whl_src_dir, whl))
+                try:
+                    run_with_externally_managed_check(install_cmd)
+                except:
+                    log.info('- Failed to install {}'.format(whl_name))
+                    return False
+                log.info('+ Installed {}'.format(whl_name))
+
+    #Mark scripts as executable
+    set_execute_permissions()
+    log.info('+ Marked scripts as executable')
+
+    #If pyenv is being used, regenerate the pyenv shims
+    if shutil.which('pyenv') is not None:
+        try:
+            res = default_run(['pyenv', 'rehash'])
+            log.info('+ Generated pyenv shims')
+        except:
+            log.info('- Failed to generate pyenv shim')
+    return True
+
+def configure_user_home(args, username, user_home_dir, default_cfg_dir, install_to_local, _customizer, _context, log):
+    '''
+    Configures the invoking user's $HOME directory. Creates the edkrepo_python
+    launcher, shell command completion, and the shell prompt customization.
+    '''
+    #Create/refresh the edkrepo_python launcher. Regenerated on every install so
+    #that the launcher shim remains accurate after a Python interpreter upgrade.
+    try:
+        generate_edkrepo_python_shim(default_cfg_dir, get_python_executable_path(), username, log)
+        log.info('+ Created edkrepo_python launcher')
+    except Exception:
+        log.info('- Failed to create edkrepo_python launcher')
+        if args.verbose:
+            traceback.print_exc()
+
+    #Create shim launchers on macOS.
+    if ostype == MAC:
+        pinned_version = get_pyenv_version_name(_context.python)
+        if pinned_version is not None:
+            try:
+                local_bin_dir = os.path.join(user_home_dir, '.local', 'bin')
+                os.makedirs(local_bin_dir, exist_ok=True)
+                shutil.chown(local_bin_dir, user=username)
+                for script_name in ('edkrepo', 'command_completion_edkrepo'):
+                    write_pyenv_pinned_launcher(
+                        os.path.join(local_bin_dir, script_name), script_name, pinned_version, username, log)
+                add_pyenv_launcher_dir_to_path(username, user_home_dir)
+                os.environ['PATH'] = local_bin_dir + os.pathsep + os.environ['PATH']
+                log.info('+ Created pyenv shim launchers in ~/.local/bin')
+            except Exception:
+                log.info('- Failed to create pyenv shim launchers in ~/.local/bin')
+                if args.verbose:
+                    traceback.print_exc()
+        else:
+            log.info('- Could not determine the active pyenv version; skipping pyenv shim launchers')
+
+    #There is a possibility that ~/.local/bin is not in the PATH if ~/.local/bin
+    #did not exist when the current shell was started
+    if shutil.which('edkrepo') is None and install_to_local:
+        os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.join(user_home_dir, '.local', 'bin')
+        if shutil.which('edkrepo') is not None:
+            if ostype == MAC:
+                log.info('- Note: You may need to restart Terminal to use EdkRepo')
+                log.info('        If you don\'t want to restart Terminal right now, run "export PATH=$HOME/.local/bin:$PATH"')
+            else:
+                log.info('- Note: You may need to reboot to use EdkRepo')
+                log.info('        If you don\'t want to reboot right now, run "export PATH=$PATH:~/.local/bin"')
+
+    #Install the command completion script
+    completion_configured_by_vendor = False
+    if _customizer is not None and hasattr(_customizer, 'configure_command_completion'):
+        try:
+            completion_configured_by_vendor = bool(_customizer.configure_command_completion(_context))
+        except Exception as e:
+            log.info('- Vendor configure_command_completion failed: {}'.format(e))
+            if args.verbose:
+                traceback.print_exc()
+    if not completion_configured_by_vendor and shutil.which('edkrepo') is not None:
+        (command_completion_script, source_command_completion) = \
+            get_command_completion_script_path(default_cfg_dir, user_home_dir, install_to_local)
+        try:
+            user_is_root = False
+            try:
+                user_is_root = is_current_user_root()
+            except:
+                pass
+            current_home = None
+            if 'HOME' in os.environ:
+                current_home = os.environ['HOME']
+            try:
+                if user_is_root and current_home is not None and current_home != user_home_dir:
+                    os.environ['HOME'] = user_home_dir
+                res = default_run(['edkrepo', 'generate-command-completion-script', command_completion_script])
+            finally:
+                if current_home is not None and os.environ['HOME'] != current_home:
+                    os.environ['HOME'] = current_home
+            if install_to_local or ostype == MAC:
+                shutil.chown(command_completion_script, user=username)
+                os.chmod(command_completion_script, 0o644)
+            add_command_completions_to_shell(command_completion_script, args, username, user_home_dir, source_command_completion, log)
+            log.info('+ Configured edkrepo command completion')
+            if get_add_prompt_customization(args, username, user_home_dir) or source_command_completion:
+                if ostype == MAC:
+                    log.info('+ Note: You may need to restart Terminal to fully activate shell integration')
+                else:
+                    log.info('+ Note: You may need to reboot to fully activate shell integration')
+        except:
+            log.info('- Failed to configure edkrepo command completion')
+            if args.verbose:
+                traceback.print_exc()
+
+        #If tcsh is installed, create the tcsh command completion script
+        try:
+            tcsh_completion_script = get_tcsh_command_completion_script_path(default_cfg_dir)
+            if shutil.which('tcsh') is not None or shutil.which('csh') is not None:
+                current_home = None
+                if 'HOME' in os.environ:
+                    current_home = os.environ['HOME']
+                try:
+                    if user_is_root and current_home is not None and current_home != user_home_dir:
+                        os.environ['HOME'] = user_home_dir
+                    res = default_run(['edkrepo', 'generate-command-completion-script', tcsh_completion_script, '--shell', 'tcsh'])
+                finally:
+                    if current_home is not None and os.environ['HOME'] != current_home:
+                        os.environ['HOME'] = current_home
+                if install_to_local or ostype == MAC:
+                    shutil.chown(tcsh_completion_script, user=username)
+                    os.chmod(tcsh_completion_script, 0o644)
+                add_tcsh_completion_to_shell(tcsh_completion_script, username, user_home_dir)
+                log.info('+ Configured edkrepo tcsh command completion')
+        except:
+            log.info('- Failed to configure edkrepo tcsh command completion')
+            if args.verbose:
+                traceback.print_exc()
+    else:
+        if not completion_configured_by_vendor:
+            log.info('- Failed to configure edkrepo command completion')
+
+#
+# Uninstall support.
+#
+_uninstall_package_names = ('edkrepo',)
+
+def _read_script(path):
+    if os.path.isfile(path):
+        with open(path, 'r') as f:
+            return f.read()
+    return None
+
+_backed_up_files = set()
+
+def _write_script_with_backup(path, new_content, username):
+    '''
+    Writes new_content to path, first backing up the existing file to path.oldN.
+    Only the first modification made to a given path during the lifetime of this
+    process creates a backup, subsequent modifications to the same path reuse
+    that same backup instead of creating additional ones.
+    '''
+    if path not in _backed_up_files:
+        file_inc = 0
+        back_file = '{}.old{}'.format(path, file_inc)
+        while os.path.isfile(back_file):
+            file_inc += 1
+            back_file = '{}.old{}'.format(path, file_inc)
+        shutil.copyfile(path, back_file)
+        try:
+            shutil.chown(back_file, user=username)
+            os.chmod(back_file, 0o644)
+        except Exception:
+            pass
+        _backed_up_files.add(path)
+    with open(path, 'w') as f:
+        f.write(new_content)
+
+def remove_regex_block_from_startup_script(script_file, regex, comment, username, log):
+    '''
+    Removes the line matching regex, plus an immediately preceding comment line
+    if present, backing up the original file to script_file.oldN first.
+    '''
+    script = _read_script(script_file)
+    if script is None:
+        return
+    lines = script.split('\n')
+    comment_line = comment.strip()
+    out = []
+    changed = False
+    for line in lines:
+        if regex.search(line):
+            changed = True
+            if out and out[-1].strip() == comment_line:
+                out.pop()
+            if out and out[-1].strip() == '':
+                out.pop()
+            continue
+        out.append(line)
+    if changed:
+        new_script = '\n'.join(out).strip()
+        if new_script:
+            new_script += '\n'
+        _write_script_with_backup(script_file, new_script, username)
+        log.info('+ Removed EdkRepo integration from {}'.format(script_file))
+
+def remove_literal_block_from_startup_script(script_file, block, username, log):
+    '''
+    Removes a static block of text from the given file.
+    '''
+    script = _read_script(script_file)
+    if script is None or block not in script:
+        return
+    new_script = script.replace(block, '')
+    new_script = re.sub(r'\n{3,}', '\n\n', new_script).strip()
+    if new_script:
+        new_script += '\n'
+    _write_script_with_backup(script_file, new_script, username)
+    log.info('+ Removed EdkRepo integration from {}'.format(script_file))
+
+def remove_marked_block_from_startup_script(script_file, begin_regex, end_regex, legacy_blocks, username, log):
+    '''
+    Removes an EdkRepo-managed block delimited by a line matching begin_regex
+    and a later line matching end_regex.
+
+    Using explicit begin/end markers lets this reliably remove the block even if
+    it was written by an older or newer version of install.py whose block
+    content differs from the one currently running.
+
+    Installations created before the end marker was introduced won't have one.
+    For those, a string-exact match against each block in legacy_blocks is
+    attempted as a fallback. If neither approach can locate the block, a warning
+    is logged so the user knows to remove it manually.
+    '''
+    script = _read_script(script_file)
+    if script is None:
+        return
+    lines = script.split('\n')
+    begin_idx = None
+    end_idx = None
+    for i, line in enumerate(lines):
+        if begin_idx is None and begin_regex.search(line):
+            begin_idx = i
+            continue
+        if begin_idx is not None and end_regex.search(line):
+            end_idx = i
+            break
+    if begin_idx is None:
+        return
+    if end_idx is not None:
+        out = lines[:begin_idx] + lines[end_idx + 1:]
+        if begin_idx > 0 and out and out[begin_idx - 1].strip() == '':
+            out.pop(begin_idx - 1)
+        new_script = '\n'.join(out).strip()
+        if new_script:
+            new_script += '\n'
+        _write_script_with_backup(script_file, new_script, username)
+        log.info('+ Removed EdkRepo integration from {}'.format(script_file))
+        return
+    # No end marker: this is an installation from an older EdkRepo that
+    # predates the end marker. Fall back to a string-exact match, attempting
+    # each candidate legacy block.
+    for legacy_block in legacy_blocks:
+        if legacy_block in script:
+            new_script = script.replace(legacy_block, '')
+            new_script = re.sub(r'\n{3,}', '\n\n', new_script).strip()
+            if new_script:
+                new_script += '\n'
+            _write_script_with_backup(script_file, new_script, username)
+            log.info('+ Removed EdkRepo integration from {}'.format(script_file))
+            return
+    log.info('- Could not automatically remove the EdkRepo shell prompt integration from {}'.format(script_file))
+    log.info('  It appears to have been added by an older version of EdkRepo. Please manually')
+    log.info('  remove the block starting with the comment "# Add EdkRepo & git to the prompt".')
+
+def teardown_user_home(username, user_home_dir, default_cfg_dir, log):
+    '''
+    Removes EdkRepo from the invoking user's $HOME directory. ~/.edkrepo is
+    intentionally left as it may contain user-modified configuration files.
+    '''
+    log.info('\nRemoving EdkRepo shell integration:')
+    completion_regex = re.compile(r"\[\[\s+-r\s+\"\S*edkrepo_completions.sh\"\s+\]\]\s+&&\s+.\s+\"\S*edkrepo_completions.sh\"")
+    completion_comment = '\n# Add EdkRepo command completions'
+    bash_rc_file = os.path.join(user_home_dir, '.bashrc')
+    remove_regex_block_from_startup_script(bash_rc_file, completion_regex, completion_comment, username, log)
+    remove_literal_block_from_startup_script(bash_rc_file, raspberry_pi_bashrc_workaround, username, log)
+    remove_marked_block_from_startup_script(
+        bash_rc_file, prompt_regex, prompt_end_regex,
+        (bash_prompt_customization,) + bash_prompt_customization_legacy_blocks, username, log)
+    if ostype == MAC:
+        remove_marked_block_from_startup_script(
+            bash_rc_file, mac_local_bin_path_regex, mac_local_bin_path_end_regex, (mac_local_bin_path_block,), username, log)
+
+    if shutil.which('zsh') is not None or ostype == MAC:
+        zsh_rc_file = os.path.join(user_home_dir, '.zshrc')
+        remove_regex_block_from_startup_script(zsh_rc_file, completion_regex, completion_comment, username, log)
+        remove_marked_block_from_startup_script(
+            zsh_rc_file, prompt_regex, prompt_end_regex,
+            (zsh_prompt_customization,) + zsh_prompt_customization_legacy_blocks, username, log)
+        if ostype == MAC:
+            remove_marked_block_from_startup_script(
+                zsh_rc_file, mac_local_bin_path_regex, mac_local_bin_path_end_regex, (mac_local_bin_path_block,), username, log)
+
+    tcsh_rc_file = get_tcsh_startup_file(user_home_dir)
+    remove_regex_block_from_startup_script(tcsh_rc_file, tcsh_completion_regex, completion_comment, username, log)
+
+    log.info('\nRemoving EdkRepo configuration files:')
+    targets = [
+        os.path.join(default_cfg_dir, 'edkrepo.cfg'),
+        os.path.join(default_cfg_dir, edkrepo_python_shim_name),
+        os.path.join(default_cfg_dir, 'edkrepo_completions.sh'),
+        os.path.join(default_cfg_dir, 'edkrepo_completions.csh'),
+        os.path.join(default_cfg_dir, 'installer'),
+    ]
+    if os.path.isdir(default_cfg_dir):
+        for name in os.listdir(default_cfg_dir):
+            if name.startswith('edkrepo.cfg.old'):
+                targets.append(os.path.join(default_cfg_dir, name))
+    for path in targets:
+        try:
+            if os.path.islink(path) or os.path.isfile(path):
+                os.remove(path)
+                log.info('+ Removed {}'.format(path))
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+                log.info('+ Removed {}'.format(path))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            log.info('- Failed to remove {} ({})'.format(path, e))
+
+    bash_completion_path = os.path.join(user_home_dir, '.local', 'share', 'bash-completion', 'completions', 'edkrepo')
+    if os.path.isfile(bash_completion_path):
+        try:
+            os.remove(bash_completion_path)
+            log.info('+ Removed {}'.format(bash_completion_path))
+        except Exception as e:
+            log.info('- Failed to remove {} ({})'.format(bash_completion_path, e))
+
+    if ostype == MAC:
+        for script_name in ('edkrepo', 'command_completion_edkrepo'):
+            launcher_path = os.path.join(user_home_dir, '.local', 'bin', script_name)
+            if os.path.isfile(launcher_path):
+                try:
+                    os.remove(launcher_path)
+                    log.info('+ Removed {}'.format(launcher_path))
+                except Exception as e:
+                    log.info('- Failed to remove {} ({})'.format(launcher_path, e))
+
+def uninstall_edkrepo_packages(log, _customizer, _context):
+    log.info('\nRemoving EdkRepo python packages:')
+    package_names = _uninstall_package_names
+    if _customizer is not None and hasattr(_customizer, 'get_uninstall_packages'):
+        try:
+            package_names = tuple(_customizer.get_uninstall_packages(_context, package_names))
+        except Exception as e:
+            log.info('- Vendor get_uninstall_packages failed: {}'.format(e))
+    installed_packages = get_installed_packages(def_python)
+    for name in package_names:
+        pip_name = name.replace('_', '-')
+        if pip_name not in installed_packages:
+            continue
+        try:
+            run_with_externally_managed_check([def_python, '-m', 'pip', 'uninstall', '--yes', pip_name])
+            log.info('+ Uninstalled {}'.format(pip_name))
+        except Exception as e:
+            log.info('- Failed to uninstall {} ({})'.format(pip_name, e))
+
+def teardown_system_install(log):
+    log.info('\nRemoving system-level EdkRepo installation:')
+    for path in (get_system_config_dir(), system_installer_dir(),
+                os.path.join('/', 'etc', 'profile.d', 'edkrepo_completions.sh')):
+        try:
+            if os.path.islink(path) or os.path.isfile(path):
+                os.remove(path)
+                log.info('+ Removed {}'.format(path))
+            elif os.path.isdir(path):
+                shutil.rmtree(path)
+                log.info('+ Removed {}'.format(path))
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            log.info('- Failed to remove {} ({})'.format(path, e))
+    if os.path.isdir(system_dir) and not os.listdir(system_dir):
+        try:
+            os.rmdir(system_dir)
+        except OSError:
+            pass
+    log.log(logging.PRINT, '')
+    log.log(logging.PRINT, 'Note: any per-user ~/.edkrepo directories created by "edkrepo setup" still exist.')
+
+def do_uninstall(mode, args, log, username, user_home_dir, default_cfg_dir, _context, _customizer):
+    if not args.yes:
+        log.log(logging.PRINT, '')
+        if mode == 'user-setup':
+            prompt = 'Removing EdkRepo configuration files. To run EdkRepo after this, run "edkrepo setup" again. Continue? [y/N] '
+        elif mode == 'local':
+            prompt = 'This will uninstall EdkRepo. Continue? [y/N] '
+        elif mode == 'system':
+            prompt = 'This will uninstall EdkRepo for all users on this system. Continue? [y/N] '
+        else:
+            prompt = 'This will uninstall EdkRepo ({} scope). Continue? [y/N] '.format(mode)
+        try:
+            answer = input(prompt).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = 'n'
+        if answer not in ('y', 'yes'):
+            log.log(logging.PRINT, 'Uninstall cancelled.')
+            return 1
+
+    if _customizer is not None and hasattr(_customizer, 'pre_uninstall'):
+        try:
+            _customizer.pre_uninstall(_context)
+        except Exception as e:
+            log.info('- Vendor pre_uninstall failed: {}'.format(e))
+            if args.verbose:
+                traceback.print_exc()
+
+    if mode in ('local', 'user-setup'):
+        try:
+            teardown_user_home(username, user_home_dir, default_cfg_dir, log)
+        except Exception as e:
+            log.info('- Failed to fully remove EdkRepo from the user home directory ({})'.format(e))
+            if args.verbose:
+                traceback.print_exc()
+
+    if mode in ('local', 'system'):
+        uninstall_edkrepo_packages(log, _customizer, _context)
+
+    if mode == 'system':
+        teardown_system_install(log)
+
+    if _customizer is not None and hasattr(_customizer, 'post_uninstall'):
+        try:
+            _customizer.post_uninstall(_context)
+        except Exception as e:
+            log.info('- Vendor post_uninstall failed: {}'.format(e))
+            if args.verbose:
+                traceback.print_exc()
+
+    log.log(logging.PRINT, '\nUninstall complete\n')
+    if mode in ('local', 'user-setup'):
+        log.log(logging.PRINT, 'Note: Your current shell session may still have EdkRepo shell integration loaded.')
+        log.log(logging.PRINT, 'If you see errors like "command_completion_edkrepo: command not found", start a')
+        log.log(logging.PRINT, 'new shell session (aka "exec $SHELL") to clear it.\n')
+    if mode in ('local', 'user-setup') and default_cfg_dir is not None and os.path.isdir(default_cfg_dir):
+        log.log(logging.PRINT, 'Note: {} was preserved in case it contains modified configuration'.format(default_cfg_dir))
+        log.log(logging.PRINT, 'files. If you no longer need it, you may delete it:\n')
+        log.log(logging.PRINT, '    rm -rf {}\n'.format(default_cfg_dir))
+    return 0
 
 def do_install():
     global def_python
@@ -964,21 +1934,34 @@ def do_install():
             pass
     log.log(logging.PRINT, tool_sign_on.format(product_name, cfg['version']['installer_version'], publisher_name, _copyright_year))
 
-    # Initialize information based on command line input
-    username = args.user
-    install_to_local = False
-    if ostype != MAC:
-        install_to_local = get_install_to_local(args)
-    if ostype != MAC and not install_to_local and not args.user:
-        log.error('ERROR: --user must be specified for system installs.')
-        return 1
+    # Determine which mode this run operates in:
+    #   local      - Installs Edkrepo wheels to $HOME and configures the
+    #                ~/.edkrepo directory.
+    #   system     - Installs wheels system-wide. Doesn't create ~/.edkrepo
+    #                Each user, including the administrator, must separately run
+    #                "edkrepo setup" to configure the ~/.edkrepo directory,
+    #                which invokes install.py --user-setup behind the scenes.
+    #   user-setup - Configures the ~/.edkrepo direcotry in invoking user's
+    #                $HOME using an existing system-level install. Installs no
+    #                wheels. This is what "edkrepo setup" runs on Linux systems
+    #                with a system install.
+    if ostype == MAC:
+        mode = 'local'
+    elif getattr(args, 'user_setup', False):
+        mode = 'user-setup'
+    else:
+        mode = 'local' if get_install_to_local(args) else 'system'
+
+    install_to_local = (mode != 'system') if ostype != MAC else False
 
     # Set install flags to default states
     found_deps_issue = False
 
-    # Determine the user running sudo
+    username = args.user
+    user_home_dir = None
+    default_cfg_dir = None
     log.info('\nCollecting system information:')
-    if not install_to_local and ostype != MAC:
+    if mode == 'system':
         try:
             user_is_root = is_current_user_root()
         except:
@@ -987,24 +1970,24 @@ def do_install():
         if not user_is_root:
             log.info('- Installer must be run as root')
             return 1
-    if username is None:
-        try:
+    else:
+        if username is None:
             try:
-                username = os.getlogin()
-            except OSError:
-                if not is_current_user_root():
-                    username = getpass.getuser()
-                else:
-                    raise
-        except Exception:
-            log.info('- Unable to determine current user.  Run installer using the --user flag and specify the correct user name.')
+                try:
+                    username = os.getlogin()
+                except OSError:
+                    if not is_current_user_root():
+                        username = getpass.getuser()
+                    else:
+                        raise
+            except Exception:
+                log.info('- Unable to determine current user.  Run installer using the --user flag and specify the correct user name.')
+                return 1
+        try:
+            user_home_dir = get_user_home_directory(username)
+        except:
+            log.info('- Unable to determine users home directory')
             return 1
-    try:
-        user_home_dir = get_user_home_directory(username)
-    except:
-        log.info('- Unable to determine users home directory')
-        return 1
-    if install_to_local or ostype == MAC:
         try:
             user_is_root = is_current_user_root()
         except:
@@ -1013,58 +1996,73 @@ def do_install():
         if user_is_root and (args.user != 'root' or ostype == MAC):
             log.info('- Installer must NOT be run as root')
             return 1
-    if ostype == MAC:
-        if os.path.commonprefix([user_home_dir, sys.executable]) != user_home_dir:
-            install_to_local = True
-    default_cfg_dir = os.path.join(user_home_dir, cfg_dir)
-    get_add_prompt_customization(args, username, user_home_dir)
+        if ostype == MAC:
+            if os.path.commonprefix([user_home_dir, sys.executable]) != user_home_dir:
+                install_to_local = True
+        default_cfg_dir = os.path.join(user_home_dir, cfg_dir)
+        if not args.uninstall:
+            get_add_prompt_customization(args, username, user_home_dir)
     log.info('+ System information collected')
 
     # Build the shared context object for the vendor customizer.
     _context = InstallerContext(ostype, def_python, install_to_local, log,
-                                whl_src_dir, username, user_home_dir)
+                                whl_src_dir, username, user_home_dir, scope=mode)
+
+    if ostype == MAC:
+        try:
+            _context.python = get_python_executable_path()
+        except Exception:
+            pass
 
     # Display current system information.
     python_version = platform.python_version()
     log.debug('\nSystem Info:')
     log.debug('  System:  {}'.format(platform.platform()))
     log.debug('  Python:  {}'.format(python_version))
-    log.debug('  User:    {}'.format(username))
-    log.debug('  Home:    {}'.format(user_home_dir))
-    log.debug('  CFG Dir: {}'.format(default_cfg_dir))
+    log.debug('  Mode:    {}'.format(mode))
+    if username is not None:
+        log.debug('  User:    {}'.format(username))
+    if user_home_dir is not None:
+        log.debug('  Home:    {}'.format(user_home_dir))
+    if default_cfg_dir is not None:
+        log.debug('  CFG Dir: {}'.format(default_cfg_dir))
+
+    if args.uninstall:
+        return do_uninstall(mode, args, log, username, user_home_dir, default_cfg_dir, _context, _customizer)
 
     log.info('\nVerify Dependencies:')
-    if not os.path.isdir(os.path.dirname(user_home_dir)):
-        log.info('- Unable to locate users home directory')
-        found_deps_issue = True
-    else:
-        log.debug('+ Found users home directory')
-
-    if _check_version(python_version, cfg['version']['py_install']) < 0:
-        log.info('- Installing for python {} (requires {})'.format(python_version, cfg['version']['py_install']))
-        found_deps_issue = True
-    else:
-        log.debug('+ Installing for python {}'.format(python_version))
-
-    # Verify that required tools are installed
-    for tool in cfg['req_tools']:
-        try:
-            res = default_run([tool, '--version'])
-        except:
-            log.info('- Failed to run required tool "{}"'.format(tool))
-            found_deps_issue = True
-            continue
-        tool_version = res.stdout.strip().split()[-1]
-        if _check_version(tool_version, cfg['req_tools'][tool]) < 0:
-            log.info('- {} {} detected (requires {})'.format(tool, tool_version, cfg['req_tools'][tool]))
+    if user_home_dir is not None:
+        if not os.path.isdir(os.path.dirname(user_home_dir)):
+            log.info('- Unable to locate users home directory')
             found_deps_issue = True
         else:
-            log.debug('+ {} {} detected'.format(tool, tool_version))
+            log.debug('+ Found users home directory')
 
-    target_python_version = None
-    # Verify required python modules are installed
-    for module in cfg['req_py_modules']:
-        if importlib.util.find_spec(module) is None:
+    if mode != 'user-setup':
+        if _check_version(python_version, cfg['version']['py_install']) < 0:
+            log.info('- Installing for python {} (requires {})'.format(python_version, cfg['version']['py_install']))
+            found_deps_issue = True
+        else:
+            log.debug('+ Installing for python {}'.format(python_version))
+
+        # Verify that required tools are installed
+        for tool in cfg['req_tools']:
+            try:
+                res = default_run([tool, '--version'])
+            except:
+                log.info('- Failed to run required tool "{}"'.format(tool))
+                found_deps_issue = True
+                continue
+            tool_version = res.stdout.strip().split()[-1]
+            if _check_version(tool_version, cfg['req_tools'][tool]) < 0:
+                log.info('- {} {} detected (requires {})'.format(tool, tool_version, cfg['req_tools'][tool]))
+                found_deps_issue = True
+            else:
+                log.debug('+ {} {} detected'.format(tool, tool_version))
+
+        # Verify required python modules are installed
+        target_python_version = None
+        for module in cfg['req_py_modules']:
             if module == 'setuptools':
                 # setuptools is only required to install wheels on Python 3.11
                 # and older. Python 3.12 and newer no longer need it. EdkRepo
@@ -1079,10 +2077,11 @@ def do_install():
                 if _check_version(target_python_version, '3.12.0') >= 0:
                     log.debug('+ Python module setuptools not required on Python {}'.format(target_python_version))
                     continue
-            log.info('- Python module {} not found'.format(module))
-            found_deps_issue = True
-        else:
-            log.debug('+ Python module {} detected'.format(module))
+            if not is_python_module_installed(def_python, module):
+                log.info('- Python module {} not found'.format(module))
+                found_deps_issue = True
+            else:
+                log.debug('+ Python module {} detected'.format(module))
 
     # Exit if any dependency issues were found.
     if found_deps_issue:
@@ -1091,21 +2090,10 @@ def do_install():
     else:
         log.info('+ All dependencies verified')
 
-    # Create required directory structure
-    if not os.path.exists(default_cfg_dir):
-        log.info('\nCreating configuration directory structure:')
-        try:
-            os.makedirs(default_cfg_dir)
-        except:
-            log.info('- Failed to create configuration directory {}'.format(default_cfg_dir))
+    # Create required directory structure ($HOME modes only)
+    if mode in ('local', 'user-setup'):
+        if not prepare_user_config_dir(default_cfg_dir, username, log):
             return 1
-        # Need to change the group on the directory
-        try:
-            shutil.chown(default_cfg_dir, user=username)
-        except:
-            log.info('- Unable to update owner {0}:{0} on {}'.format(username, default_cfg_dir))
-            return 1
-        log.info('+ Created configuration directory: {}'.format(default_cfg_dir))
 
     # Vendor customizer pre_install() initialization
     if _customizer is not None and hasattr(_customizer, 'pre_install'):
@@ -1117,213 +2105,57 @@ def do_install():
                 traceback.print_exc()
             return 1
 
-    # Update configuration files
-    log.info('\nCopy configuration files:')
-    if not os.path.isdir(cfg_src_dir):
-        log.info('- Missing configuration file directory')
-        return 1
-    for cfg_file in cfg['config_files']:
-        dst_cfg_file = os.path.join(default_cfg_dir, cfg_file)
-        if cfg['config_files'][cfg_file].lower() == 'true' and os.path.isfile(dst_cfg_file):
-            with open(dst_cfg_file, 'rb') as f:
-                current_sha_obj = hashlib.sha256(f.read())
-            with open(os.path.join(cfg_src_dir, cfg_file), 'rb') as f:
-                new_sha_obj = hashlib.sha256(f.read())
-            if current_sha_obj.hexdigest() != new_sha_obj.hexdigest():
-                if current_sha_obj.hexdigest() not in sha_data['previous_cfg_sha256']:
-                    file_inc = 0
-                    back_file = '{}.old{}'.format(dst_cfg_file, file_inc)
-                    while os.path.isfile(back_file):
-                        file_inc += 1
-                        back_file = '{}.old{}'.format(dst_cfg_file, file_inc)
-                    log.debug('+ Copy {} to {}'.format(dst_cfg_file, back_file))
-                    try:
-                        shutil.copyfile(dst_cfg_file, back_file)
-                        shutil.chown(back_file, user=username)
-                        os.chmod(back_file, 0o644)
-                    except:
-                        log.info('- Failed to create backup copy of configuration file')
-                        return 1
-        try:
-            shutil.copyfile(os.path.join(cfg_src_dir, cfg_file), dst_cfg_file)
-            shutil.chown(dst_cfg_file, user=username)
-            os.chmod(dst_cfg_file, 0o644)
-        except:
-            log.info('- Failed to copy {} to {}'.format(cfg_file, default_cfg_dir))
+    if mode == 'local':
+        if not copy_config_files(cfg, sha_data, cfg_src_dir, default_cfg_dir, username, log):
             return 1
-        log.debug('+ Copied {} to {}'.format(cfg_file, default_cfg_dir))
-    log.info('+ Configuration files copy complete')
 
-    # Determining wheels that need to be installed for the current system
-    log.info('\nDetermining python modules to install/upgrade:')
-    try:
-        wheels_to_install = get_required_wheels()
-    except:
-        log.info('- Failed to determine installed python modules and versions')
-        return 1
+    if mode == 'user-setup':
+        system_cfg_dir = get_system_config_dir()
+        if not os.path.isdir(system_cfg_dir):
+            log.info('- No system-level EdkRepo install was found at {}.'.format(system_dir))
+            log.info('  Ask your system administrator to run the EdkRepo installer with --system.')
+            return 1
+        if not copy_config_files(cfg, sha_data, system_cfg_dir, default_cfg_dir, username, log):
+            return 1
 
-    # Vendor customizer get_wheels() can change the wheel list.
-    if _customizer is not None and hasattr(_customizer, 'get_wheels'):
+    if mode in ('local', 'system'):
+        if not install_wheels(args, log, whl_src_dir, install_to_local, _customizer, _context):
+            return 1
+
+    if mode == 'system':
         try:
-            wheels_to_install = _customizer.get_wheels(_context, wheels_to_install)
+            persist_installer(system_installer_dir(), None)
+            persist_config_dir(cfg_src_dir, get_system_config_dir())
+            log.info('+ Persisted installer to {}'.format(system_dir))
         except Exception as e:
-            log.info('- Vendor get_wheels failed: {}'.format(e))
+            log.info('- Failed to persist installer to {} ({})'.format(system_dir, e))
             if args.verbose:
                 traceback.print_exc()
             return 1
-    if wheels_to_install:
-        log.info('+ Complete')
-    else:
-        log.info('+ Complete - Nothing to install')
 
-    # Install python wheels
-    if wheels_to_install:
-        log.info('\nInstalling python modules:')
-        if not os.path.isdir(whl_src_dir):
-            log.info('- Missing wheel file directory')
-            return 1
+    if mode in ('local', 'user-setup'):
+        configure_user_home(args, username, user_home_dir, default_cfg_dir, install_to_local,
+                            _customizer, _context, log)
 
-        #Uninstall wheels with the UninstallAllOtherCopies attribute set
-        updating_edkrepo = False
-        for whl_name in wheels_to_install:
-            uninstall_whl = wheels_to_install[whl_name]['uninstall']
-            whl_name = whl_name.replace('_','-')  #pip doesn't understand the difference between '_' and '-'
-            if uninstall_whl:
-                updating_edkrepo = True
-                try:
-                    run_with_externally_managed_check([def_python, '-m', 'pip', 'uninstall', '--yes', whl_name])
-                except:
-                    log.info('- Failed to uninstall {}'.format(whl_name))
-                    return 1
-                log.info('+ Uninstalled {}'.format(whl_name))
-
-        #Delete obsolete dependencies
-        if updating_edkrepo:
-            installed_packages = get_installed_packages(def_python)
-            for whl_name in ['smmap2', 'gitdb2']:
-                if whl_name in installed_packages:
-                    try:
-                        run_with_externally_managed_check([def_python, '-m', 'pip', 'uninstall', '--yes', whl_name])
-                    except:
-                        log.info('- Failed to uninstall {}'.format(whl_name))
-                        return 1
-                    log.info('+ Uninstalled {}'.format(whl_name))
-
-        #Install new wheels
-        for whl_name in wheels_to_install:
-            whl = wheels_to_install[whl_name]['wheel']
-            install_whl = wheels_to_install[whl_name]['install']
-            if install_whl:
-                install_cmd = [def_python, '-m', 'pip', 'install', '--no-index', '--find-links={}'.format(whl_src_dir)]
-                if install_to_local:
-                    install_cmd.append('--user')
-                install_cmd.append(os.path.join(whl_src_dir, whl))
-                try:
-                    run_with_externally_managed_check(install_cmd)
-                except:
-                    log.info('- Failed to install {}'.format(whl_name))
-                    return 1
-                log.info('+ Installed {}'.format(whl_name))
-
-    #Mark scripts as executable
-    set_execute_permissions()
-    log.info('+ Marked scripts as executable')
-
-    #If pyenv is being used, regenerate the pyenv shims
-    if shutil.which('pyenv') is not None:
+    if mode == 'local':
+        assert default_cfg_dir is not None
         try:
-            res = default_run(['pyenv', 'rehash'])
-            log.info('+ Generated pyenv shims')
-        except:
-            log.info('- Failed to generate pyenv shim')
-
-    #Create/refresh the edkrepo_python launcher. Regenerated on every install so
-    #that the launcher shim remains accurate after a Python interpreter upgrade.
-    try:
-        generate_edkrepo_python_shim(default_cfg_dir, get_python_executable_path(), username)
-        log.info('+ Created edkrepo_python launcher')
-    except Exception:
-        log.info('- Failed to create edkrepo_python launcher')
-        if args.verbose:
-            traceback.print_exc()
-
-    #There is a possibility that ~/.local/bin is not in the PATH if ~/.local/bin
-    #did not exist when the current shell was started
-    if shutil.which('edkrepo') is None and install_to_local and ostype != MAC:
-        os.environ['PATH'] = os.environ['PATH'] + os.pathsep + os.path.join(user_home_dir, '.local', 'bin')
-        if shutil.which('edkrepo') is not None:
-            log.info('- Note: You may need to reboot to use EdkRepo')
-            log.info('        If you don\'t want to reboot right now, run "export PATH=$PATH:~/.local/bin"')
-
-    #Install the command completion script
-    completion_configured_by_vendor = False
-    if _customizer is not None and hasattr(_customizer, 'configure_command_completion'):
-        try:
-            completion_configured_by_vendor = bool(_customizer.configure_command_completion(_context))
+            installer_dest = os.path.join(default_cfg_dir, 'installer')
+            persist_installer(installer_dest, username)
+            installer_cfg_dest = os.path.join(installer_dest, 'config')
+            persist_config_dir(cfg_src_dir, installer_cfg_dest)
+            if username is not None:
+                for root, dirs, files in os.walk(installer_cfg_dest):
+                    for name in dirs + files:
+                        try:
+                            shutil.chown(os.path.join(root, name), user=username)
+                        except Exception:
+                            pass
+            log.info('+ Persisted installer to {}'.format(installer_dest))
         except Exception as e:
-            log.info('- Vendor configure_command_completion failed: {}'.format(e))
+            log.info('- Failed to persist installer ({})'.format(e))
             if args.verbose:
                 traceback.print_exc()
-    if not completion_configured_by_vendor and shutil.which('edkrepo') is not None:
-        (command_completion_script, source_command_completion) = \
-            get_command_completion_script_path(default_cfg_dir, user_home_dir, install_to_local)
-        user_is_root = False
-        try:
-            user_is_root = is_current_user_root()
-        except:
-            pass
-        try:
-            current_home = None
-            if 'HOME' in os.environ:
-                current_home = os.environ['HOME']
-            try:
-                if user_is_root and current_home is not None and current_home != user_home_dir:
-                    os.environ['HOME'] = user_home_dir
-                res = default_run(['edkrepo', 'generate-command-completion-script', command_completion_script])
-            finally:
-                if current_home is not None and os.environ['HOME'] != current_home:
-                    os.environ['HOME'] = current_home
-            if install_to_local or ostype == MAC:
-                shutil.chown(command_completion_script, user=username)
-                os.chmod(command_completion_script, 0o644)
-            add_command_completions_to_shell(command_completion_script, args, username, user_home_dir, source_command_completion)
-            log.info('+ Configured edkrepo command completion')
-            if get_add_prompt_customization(args, username, user_home_dir) or source_command_completion:
-                if ostype == MAC:
-                    log.info('+ Note: You may need to restart Terminal to fully activate shell integration')
-                else:
-                    log.info('+ Note: You may need to reboot to fully activate shell integration')
-        except:
-            log.info('- Failed to configure edkrepo command completion')
-            if args.verbose:
-                traceback.print_exc()
-
-        #If tcsh is installed, create the tcsh command completion script
-        try:
-            tcsh_completion_script = get_tcsh_command_completion_script_path(default_cfg_dir)
-            if shutil.which('tcsh') is not None or shutil.which('csh') is not None:
-                current_home = None
-                if 'HOME' in os.environ:
-                    current_home = os.environ['HOME']
-                try:
-                    if user_is_root and current_home is not None and current_home != user_home_dir:
-                        os.environ['HOME'] = user_home_dir
-                    res = default_run(['edkrepo', 'generate-command-completion-script', tcsh_completion_script, '--shell', 'tcsh'])
-                finally:
-                    if current_home is not None and os.environ['HOME'] != current_home:
-                        os.environ['HOME'] = current_home
-                if install_to_local or ostype == MAC:
-                    shutil.chown(tcsh_completion_script, user=username)
-                    os.chmod(tcsh_completion_script, 0o644)
-                add_tcsh_completion_to_shell(tcsh_completion_script, username, user_home_dir)
-                log.info('+ Configured edkrepo tcsh command completion')
-        except:
-            log.info('- Failed to configure edkrepo tcsh command completion')
-            if args.verbose:
-                traceback.print_exc()
-    else:
-        if not completion_configured_by_vendor:
-            log.info('- Failed to configure edkrepo command completion')
 
     # Vendor customizer post_install() optional extras after the core install is done.
     if _customizer is not None and hasattr(_customizer, 'post_install'):
@@ -1335,6 +2167,11 @@ def do_install():
                 traceback.print_exc()
 
     log.log(logging.PRINT, '\nInstallation complete\n')
+    if mode == 'system':
+        log.log(logging.PRINT, 'IMPORTANT: This was a system-level install. EdkRepo has NOT been')
+        log.log(logging.PRINT, 'configured for any individual user, including yourself. Each user')
+        log.log(logging.PRINT, 'who wants to use EdkRepo, including you, must first run:\n')
+        log.log(logging.PRINT, '    edkrepo setup\n')
 
     return 0
 


### PR DESCRIPTION
## Description

Adds an "edkrepo uninstall" command which uninstalls EdkRepo.

Also improves support for system-level installs on Linux by separating the installation process into two phases. The installer makes EdkRepo available on the system but does not modify the $HOME directory initially. After that, each user runs "edkrepo setup" to create the ~/.edkrepo directory and any needed configuration files.

On macOS, adds launcher shims that explicitly execute the Python version EdkRepo is installed in. This prevents EdkRepo from breaking when users switch Python versions with pyenv.

Updates documentation accordingly.

Fixes #442

## Dependencies

All dependent PRs have been merged. This PR can now be reviewed normally.

~~Note that this PR depends on PRs #432, #434, #439, and #443. This PR cannot be merged until those PRs are merged and will need to be rebased on top of `main` after those 4 PRs land. Once that is done, this PR will apply to `main` cleanly and can be approved. In the meantime, the content of this change can be reviewed by looking at the last commit in the commit series.~~