### PR TITLE
EdkRepo: Extract BaseXmlHelper utilities to module level and refactor…

### DIFF
--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -77,69 +77,69 @@ class BaseXmlHelper():
         if self._xml_type not in xml_types:
             raise TypeError(UNSUPPORTED_TYPE_ERROR.format(fileref, self._xml_type))
 
-    def _json_to_xml(self, fileref):
-        """Read a JSON file, convert it to an ElementTree using _build_etree_node and _pretty_format, and return the tree."""
-        with open(fileref, 'r') as f:
-            json_in = json.load(f)
-
-        root = ET.Element('placeholder')
-        tree = ET.ElementTree(root)
-
-        self._build_etree_node(json_in, root)
-        tree._setroot(root[0])
-
-        self._pretty_format(tree.getroot())
-        return tree
-
-    def _build_etree_node(self, current_dict, parent):
-        """Build an ElementTree SubElement from current_dict and attach it as a child of parent; recurse into children."""
-        node_tag = current_dict['name']
-
-        # attribs
-        if 'attrib' in current_dict.keys():
-            node_attribs = current_dict['attrib']
-        else:
-            node_attribs = {}
-
-        # construct this subelement
-        node = ET.SubElement(parent, node_tag, attrib=node_attribs)
-
-        # text
-        if 'text' in current_dict.keys():
-            node.text = current_dict['text']
-
-        # tail
-        if 'tail' in current_dict.keys():
-            node.tail = current_dict['tail']
-
-        # children
-        if 'children' in current_dict.keys():
-            for child_dict in current_dict['children']:
-                # append child to this node
-                self._build_etree_node(child_dict, node)
-
-    def _pretty_format(self, current, parent=None, index=-1, depth=0):
-        """Recursively add indentation whitespace to all nodes in the ElementTree for human-readable formatting."""
-        for i, node in enumerate(current):
-            self._pretty_format(node, current, i, depth + 1)
-        if parent is not None:
-            if index == 0:
-                parent.text = '\n' + ('  ' * depth)
-
     def _load_tree(self, fileref):
-        """Load an ElementTree from a .xml file or a .json file via self._json_to_xml; raise TypeError if the file is invalid or the extension is unsupported."""
+        """Load an ElementTree from a .xml file or a .json file; raise TypeError if the file is invalid or the extension is unsupported."""
         try:
             file_ext = os.path.splitext(fileref)[1]
             if file_ext == '.xml':
                 return ET.ElementTree(file=fileref)  # fileref can be a filename or filestream
             elif file_ext == '.json':
-                return self._json_to_xml(fileref)
+                return json_to_xml(fileref)
             else:
                 raise TypeError(INVALID_XML_ERROR.format(fileref, UNSUPPORTED_EXTENSION_ERROR.format(file_ext)))
         except TypeError:
             raise
         except Exception as et_error:
             raise TypeError(INVALID_XML_ERROR.format(fileref, et_error))
+
+def json_to_xml(fileref):
+    """Read a JSON file, convert it to an ElementTree using _build_etree_node and _pretty_format, and return the tree."""
+    with open(fileref, 'r') as f:
+        json_in = json.load(f)
+
+    root = ET.Element('placeholder')
+    tree = ET.ElementTree(root)
+
+    build_etree_node(json_in, root)
+    tree._setroot(root[0])
+
+    pretty_format(tree.getroot())
+    return tree
+
+def build_etree_node(current_dict, parent):
+    """Build an ElementTree SubElement from current_dict and attach it as a child of parent; recurse into children."""
+    node_tag = current_dict['name']
+
+    # attribs
+    if 'attrib' in current_dict.keys():
+        node_attribs = current_dict['attrib']
+    else:
+        node_attribs = {}
+
+    # construct this subelement
+    node = ET.SubElement(parent, node_tag, attrib=node_attribs)
+
+    # text
+    if 'text' in current_dict.keys():
+        node.text = current_dict['text']
+
+    # tail
+    if 'tail' in current_dict.keys():
+        node.tail = current_dict['tail']
+
+    # children
+    if 'children' in current_dict.keys():
+        for child_dict in current_dict['children']:
+            # append child to this node
+            build_etree_node(child_dict, node)
+
+def pretty_format(current, parent=None, index=-1, depth=0):
+    """Recursively add indentation whitespace to all nodes in the ElementTree for human-readable formatting."""
+    for i, node in enumerate(current):
+        pretty_format(node, current, i, depth + 1)
+    if parent is not None:
+        if index == 0:
+            parent.text = '\n' + ('  ' * depth)
 
 
 #
@@ -151,7 +151,7 @@ class CiIndexXml(BaseXmlHelper):
         super().__init__(fileref, 'ProjectList')
         self._projects = {}
         for element in self._tree.iter(tag='Project'):
-            proj = _Project(element)
+            proj = self._make_project(element)
             # Todo: add check for unique
             self._projects[proj.name] = proj
 
@@ -180,6 +180,9 @@ class CiIndexXml(BaseXmlHelper):
         else:
             raise ValueError(INVALID_PROJECTNAME_ERROR.format(project_name))
 
+    def _make_project(self, element):
+        """Instantiate and return a _Project from a <Project> XML element."""
+        return _Project(element)
 
 class _Project():
     def __init__(self, element):
@@ -250,13 +253,13 @@ class ManifestXml(BaseXmlHelper):
         #
         for subroot in self._tree.iter(tag='RemoteList'):
             for element in subroot.iter(tag='Remote'):
-                self._add_unique_item(_RemoteRepo(element), self._remotes, element.tag)
+                self._add_unique_item(self._make_remote_repo(element), self._remotes, element.tag)
 
         #
         # parse <ProjectInfo> tags
         #
         subroot = self._tree.find('ProjectInfo')
-        self._project_info = _ProjectInfo(subroot)
+        self._project_info = self._make_project_info(subroot)
 
         #
         # parse <GeneralConfig> tags
@@ -319,7 +322,7 @@ class ManifestXml(BaseXmlHelper):
         subroot = self._tree.find('SparseCheckout')
         if subroot is not None:
             try:
-                self._sparse_settings = _SparseSettings(subroot.find('SparseSettings'))
+                self._sparse_settings = self._make_sparse_settings(subroot.find('SparseSettings'))
             except KeyError as k:
                 raise KeyError(REQUIRED_ATTRIB_ERROR_MSG.format(k, subroot.tag))
             for sparse_data in subroot.iter(tag='SparseData'):
@@ -373,6 +376,22 @@ class ManifestXml(BaseXmlHelper):
                 self._folder_to_folder_mappings.append(_FolderToFolderMapping(f2f_mapping))
         return
 
+    def _make_remote_repo(self, element):
+        """Factory hook returning a _RemoteRepo. Subclasses may override to inject a specialized type."""
+        return _RemoteRepo(element)
+
+    def _make_project_info(self, element):
+        """Factory hook returning a _ProjectInfo. Subclasses may override to inject a specialized type."""
+        return _ProjectInfo(element)
+
+    def _make_repo_source(self, element, remotes):
+        """Factory hook returning a _RepoSource. Subclasses may override to inject a specialized type."""
+        return _RepoSource(element, remotes)
+
+    def _make_sparse_settings(self, element):
+        """Factory hook returning a _SparseSettings. Subclasses may override to inject a specialized type."""
+        return _SparseSettings(element)
+
     def is_pin_file(self):
         """Return True if the parsed file is of type Pin, False otherwise."""
         if self._xml_type == 'Pin':
@@ -391,7 +410,7 @@ class ManifestXml(BaseXmlHelper):
         self._add_unique_item(combo, self._combinations, subroot.tag)
         temp_sources = []
         for element in subroot.iter(tag='Source'):
-            temp_sources.append(_RepoSource(element, self._remotes))
+            temp_sources.append(self._make_repo_source(element, self._remotes))
         self._combo_sources[combo.name] = temp_sources
 
     def _add_unique_item(self, obj, item_dict, tag):
@@ -458,7 +477,7 @@ class ManifestXml(BaseXmlHelper):
             raise ValueError(COMBO_INVALIDINPUT_ERROR.format(combo_name))
 
     def get_parent_of_nested_repo(self, repo_sources_to_search, repo_local_root):
-        """Return the parent RepoSource for `repo_local_root`, or raise ValueError if not found."""
+        """Walk the directory tree from `repo_local_root` and return the first ancestor RepoSource found in `repo_sources_to_search`, or raise ValueError if none is found or the path is invalid."""
         _validate_repo_local_root_or_raise(repo_local_root)
 
         current_path = os.path.normpath(repo_local_root)
@@ -475,6 +494,7 @@ class ManifestXml(BaseXmlHelper):
         raise ValueError(NO_PARENT_REPO_ERROR.format(repo_local_root))
 
     def is_repo_nested(self, repo_sources_to_search, repo_local_root):
+        """Return True if `repo_local_root` is nested inside another repo in `repo_sources_to_search`, False otherwise."""
         try:
             self.get_parent_of_nested_repo(repo_sources_to_search, repo_local_root)
         except ValueError:
@@ -482,6 +502,7 @@ class ManifestXml(BaseXmlHelper):
         return True
 
     def list_nested_repos(self, repo_sources_to_search):
+        """Return a list of all RepoSources in `repo_sources_to_search` whose root is nested inside another repo in the same list."""
         nested_repos = []
         for source in repo_sources_to_search:
             if self.is_repo_nested(repo_sources_to_search, source.root):

--- a/edkrepo_manifest_parser/edk_manifest_validation.py
+++ b/edkrepo_manifest_parser/edk_manifest_validation.py
@@ -27,7 +27,7 @@ class ValidateManifest:
 
     def validate_parsing(self):
         """Attempt to parse the manifest XML file; return a (type, status, message) result tuple."""
-        self._manifest_xmldata, error = _try_parse_manifest_xml(self._manifestfile)
+        self._manifest_xmldata, error = self._try_parse_manifest_xml(self._manifestfile)
         if error is None:
             return ("PARSING", True, None)
         return ("PARSING", False, error)
@@ -57,12 +57,16 @@ class ValidateManifest:
         """Return True if str1 and str2 are equal under Unicode NFKD case-folding normalization."""
         return unicodedata.normalize("NFKD", str1.casefold()) == unicodedata.normalize("NFKD", str2.casefold())
 
-def _try_parse_manifest_xml(manifest_file):
-    """Attempt to construct a ManifestXml from *manifest_file*; return ``(xmldata, None)`` on success or ``(None, exception)`` on failure."""
-    try:
-        return ManifestXml(manifest_file), None
-    except Exception as e_message:
-        return None, e_message
+    def _try_parse_manifest_xml(self, manifest_file):
+        """Attempt to construct a ManifestXml from *manifest_file*; return ``(xmldata, None)`` on success or ``(None, exception)`` on failure."""
+        try:
+            return self._make_manifest_xml(manifest_file), None
+        except Exception as e_message:
+            return None, e_message
+
+    def _make_manifest_xml(self, manifest_file):
+        """Instantiate and return a ManifestXml from manifest_file; subclasses can override to inject a different ManifestXml type."""
+        return ManifestXml(manifest_file)
 
 def _collect_file_validation_results(manifest_filepath):
     """Validate parsing and codename for a single manifest file; return a list of (type, status, message) result tuples."""

--- a/edkrepo_manifest_parser/unit_test_bases/base_tests.py
+++ b/edkrepo_manifest_parser/unit_test_bases/base_tests.py
@@ -99,6 +99,7 @@ FUNC_RESOLVE_PATH = '_resolve_project_manifest_path'
 FUNC_COLLECT_PROJECT_RESULTS = '_collect_project_validation_results'
 FUNC_COLLECT_INVALID_BRANCH = '_collect_invalid_branch_results'
 FUNC_LOAD_TREE = '_load_tree'
+FUNC_JSON_TO_XML = 'json_to_xml'
 FUNC_JSON_LOAD = 'json.load'
 MODULE_BUILTINS_PRINT = 'builtins.print'
 MODULE_ET = 'ET'
@@ -332,9 +333,10 @@ class BaseTestValidateManifest:
         return self._make_obj_with_codename(self.__class__.validation_module, codename).validate_codename(project)
 
     def _assert_try_parse_result(self, expected_xmldata, expected_error):
-        """Call _try_parse_manifest_xml and assert both returned values."""
+        """Call _try_parse_manifest_xml on a ValidateManifest instance and assert both returned values."""
         vm_module = importlib.import_module(self.__class__.validation_module)
-        xmldata, error = vm_module._try_parse_manifest_xml(MANIFEST_PATH)
+        vm = vm_module.ValidateManifest(MANIFEST_PATH)
+        xmldata, error = vm._try_parse_manifest_xml(MANIFEST_PATH)
         assert xmldata is expected_xmldata
         assert error is expected_error
 
@@ -538,11 +540,13 @@ INDENT_DEPTH_2 = '\n    '
 class BaseTestBaseXmlHelper:
 
     manifest_module: str = None
+    impl_module: str = None
 
     @pytest.fixture
     def mock_et_module(self):
         """Complete mock of the ET module to prevent any real operations."""
-        with patch('{}.{}'.format(self.__class__.manifest_module, MODULE_ET)) as mock_et:
+        et_module = self.__class__.impl_module if self.__class__.impl_module else self.__class__.manifest_module
+        with patch('{}.{}'.format(et_module, MODULE_ET)) as mock_et:
             mock_et.Element = MagicMock()
             mock_et.SubElement = MagicMock()
             mock_et.ElementTree = MagicMock()
@@ -607,11 +611,10 @@ class BaseTestBaseXmlHelper:
         return mock_tree
 
     def _build_node(self, current_dict):
-        """Build an ET node from current_dict via _build_etree_node and return the first child of the parent."""
+        """Build an ET node from current_dict via build_etree_node and return the first child of the parent."""
         manifest_mod = importlib.import_module(self.__class__.manifest_module)
-        instance = object.__new__(manifest_mod.BaseXmlHelper)
         parent = self._create_mock_element(ELEMENT_ROOT_TAG)
-        instance._build_etree_node(current_dict, parent)
+        manifest_mod.build_etree_node(current_dict, parent)
         return parent[FIRST_ELEMENT_INDEX]
 
     def _assert_init_raises_typeerror(self, xml_types):
@@ -630,37 +633,31 @@ class BaseTestBaseXmlHelper:
         mock_load_tree.side_effect = TypeError(INVALID_FILE_MSG)
         self._assert_init_raises_typeerror([TAG_MANIFEST])
 
-    def test_valid_json_returns_converted_element_tree(self, bare_instance, mock_json_open, mock_et_module):
-        """When open and json.load succeed, _json_to_xml must return a tree whose root tag matches the JSON node name and call _pretty_format and _build_etree_node each exactly once."""
-        mock_open, mock_json_load = mock_json_open
+    def test_valid_json_returns_converted_element_tree(self, mock_json_open, mock_et_module):
+        """When open and json.load succeed, json_to_xml must return a tree whose root tag matches the JSON node name."""
+        manifest_mod = importlib.import_module(self.__class__.manifest_module)
+        _, mock_json_load = mock_json_open
         mock_json_load.return_value = {ATTRIB_NAME: TAG_MANIFEST}
 
-        # Configure ET mocks to return mock elements
         mock_root = self._create_mock_element(ELEMENT_TAG_PLACEHOLDER)
         mock_et_module.Element.return_value = mock_root
         mock_tree = MagicMock()
         mock_et_module.ElementTree.return_value = mock_tree
 
-        def mock_build_node(d, p):
-            return self._create_mock_subelement(p, TAG_MANIFEST)
+        def create_subelement_mock(parent, tag, attrib=None):
+            return self._create_mock_subelement(parent, tag, attrib)
+        mock_et_module.SubElement.side_effect = create_subelement_mock
 
-        bare_instance._build_etree_node = MagicMock(side_effect=mock_build_node)
-        bare_instance._pretty_format = MagicMock()
-
-        # Configure getroot to return the child element that will be set by _setroot
         def mock_setroot(elem):
             mock_tree.getroot.return_value = elem
         mock_tree._setroot = mock_setroot
 
-        result = bare_instance._json_to_xml(MANIFEST_JSON)
+        result = manifest_mod.json_to_xml(MANIFEST_JSON)
 
         assert result.getroot().tag == TAG_MANIFEST
-        bare_instance._pretty_format.assert_called_once()
-        bare_instance._build_etree_node.assert_called_once()
 
     def test_dict_with_all_optional_fields(self, mock_et_module):
         """When the dict contains name, attrib, text, tail, and children, _build_etree_node must set all fields and recurse."""
-        # Configure ET.SubElement to return mock elements
         def create_subelement_mock(parent, tag, attrib=None):
             return self._create_mock_subelement(parent, tag, attrib)
 
@@ -682,7 +679,6 @@ class BaseTestBaseXmlHelper:
 
     def test_dict_with_name_only(self, mock_et_module):
         """When the dict contains only the name key, _build_etree_node must create a SubElement with empty attrib, None text, None tail, and no children."""
-        # Configure ET.SubElement to return mock elements
         def create_subelement_mock(parent, tag, attrib=None):
             return self._create_mock_subelement(parent, tag, attrib)
 
@@ -696,19 +692,21 @@ class BaseTestBaseXmlHelper:
         assert node.tail is None
         assert len(node) == ZERO_LENGTH
 
-    def test_no_parent_completes_without_error(self, bare_instance):
-        """When called without a parent argument, _pretty_format must complete without raising any exception."""
+    def test_no_parent_completes_without_error(self):
+        """When called without a parent argument, pretty_format must complete without raising any exception."""
+        manifest_mod = importlib.import_module(self.__class__.manifest_module)
         root = self._create_mock_element(ELEMENT_ROOT_TAG)
 
-        bare_instance._pretty_format(root)
+        manifest_mod.pretty_format(root)
 
-    def test_pretty_format_recurses_into_children(self, bare_instance):
-        """When current has nested children, _pretty_format must recursively set indentation on each ancestor's text."""
+    def test_pretty_format_recurses_into_children(self):
+        """When current has nested children, pretty_format must recursively set indentation on each ancestor's text."""
+        manifest_mod = importlib.import_module(self.__class__.manifest_module)
         root = self._create_mock_element(ELEMENT_ROOT_TAG)
         child = self._create_mock_subelement(root, NODE_CHILD)
         self._create_mock_subelement(child, NODE_CHILD)
 
-        bare_instance._pretty_format(root)
+        manifest_mod.pretty_format(root)
 
         assert root.text == INDENT_DEPTH_1
         assert child.text == INDENT_DEPTH_2
@@ -724,13 +722,12 @@ class BaseTestBaseXmlHelper:
         assert result is mock_tree
 
     def test_json_extension_delegates_to_json_to_xml(self, bare_instance):
-        """When fileref has a .json extension, _load_tree must delegate to self._json_to_xml and return its result."""
+        """When fileref has a .json extension, _load_tree must delegate to json_to_xml and return its result."""
         expected = MagicMock()
-        bare_instance._json_to_xml = MagicMock(return_value=expected)
+        with patch('{}.{}'.format(self.__class__.manifest_module, FUNC_JSON_TO_XML), return_value=expected) as mock_json_to_xml:
+            result = bare_instance._load_tree(MANIFEST_JSON)
 
-        result = bare_instance._load_tree(MANIFEST_JSON)
-
-        bare_instance._json_to_xml.assert_called_once_with(MANIFEST_JSON)
+        mock_json_to_xml.assert_called_once_with(MANIFEST_JSON)
         assert result is expected
 
     def test_unsupported_extension_raises_typeerror(self, bare_instance):
@@ -746,23 +743,23 @@ class BaseTestBaseXmlHelper:
             bare_instance._load_tree(MANIFEST_FILE_PATH)
 
     def test_json_parse_error_raises_typeerror(self, bare_instance):
-        """When _json_to_xml raises an exception during JSON parsing, _load_tree must catch it and raise TypeError."""
-        bare_instance._json_to_xml = MagicMock(side_effect=Exception(PARSE_ERROR_MSG))
-
-        with pytest.raises(TypeError):
-            bare_instance._load_tree(MANIFEST_JSON)
+        """When json_to_xml raises an exception during JSON parsing, _load_tree must catch it and raise TypeError."""
+        with patch('{}.{}'.format(self.__class__.manifest_module, FUNC_JSON_TO_XML), side_effect=Exception(PARSE_ERROR_MSG)):
+            with pytest.raises(TypeError):
+                bare_instance._load_tree(MANIFEST_JSON)
 
     @pytest.mark.parametrize(PRETTY_FORMAT_INDEX_FIELDS, [
         pytest.param(FIRST_ELEMENT_INDEX, INDENT_DEPTH_2, id=ID_INDEX_ZERO),
         pytest.param(ONE_ITEM, ORIGINAL_TEXT, id=ID_INDEX_NONZERO),
     ])
-    def test_pretty_format_parent_text_by_index(self, bare_instance, index, expected):
-        """When called with a given index and depth=2, _pretty_format must set parent.text to the expected value."""
+    def test_pretty_format_parent_text_by_index(self, index, expected):
+        """When called with a given index and depth=2, pretty_format must set parent.text to the expected value."""
+        manifest_mod = importlib.import_module(self.__class__.manifest_module)
         parent = self._create_mock_element(ELEMENT_ROOT_TAG)
         parent.text = ORIGINAL_TEXT
         child = self._create_mock_subelement(parent, ELEMENT_CHILD_TAG)
 
-        bare_instance._pretty_format(child, parent, index, INDENT_DEPTH_LEVEL_2)
+        manifest_mod.pretty_format(child, parent, index, INDENT_DEPTH_LEVEL_2)
 
         assert parent.text == expected
 


### PR DESCRIPTION
… ValidateManifest parsing hook

Extracted the instance methods _json_to_xml, _build_etree_node, and _pretty_format from BaseXmlHelper into standalone module-level functions (json_to_xml, build_etree_node, pretty_format), since none of them depend on instance state. BaseXmlHelper._load_tree now delegates JSON parsing to the module-level json_to_xml. The functions retain their original logic and are publicly accessible.

Converted the module-level function _try_parse_manifest_xml in edk_manifest_validation.py into an instance method of ValidateManifest. Extracted the ManifestXml instantiation into a new factory method _make_manifest_xml so that the parsing flow can be customized without overriding the full validation logic. Updated validate_parsing to call self._try_parse_manifest_xml accordingly.

Updated base_tests.py to call _try_parse_manifest_xml as an instance method via a ValidateManifest instance.

Changes:

- Extracted _json_to_xml, _build_etree_node, _pretty_format from BaseXmlHelper to module-level functions json_to_xml, build_etree_node, pretty_format in edk_manifest.py
- Updated BaseXmlHelper._load_tree to call module-level json_to_xml in edk_manifest.py
- Converted _try_parse_manifest_xml from a module-level function to ValidateManifest._try_parse_manifest_xml in edk_manifest_validation.py
- Added ValidateManifest._make_manifest_xml factory method in edk_manifest_validation.py
- Updated validate_parsing to call self._try_parse_manifest_xml in edk_manifest_validation.py
- Updated _assert_try_parse_result in unit_test_bases/base_tests.py to call the instance method

Fixes: #446