### PR TITLE
Modify nested repo implementation

### DIFF
--- a/edkrepo/commands/unit_tests/test_create_pin.py
+++ b/edkrepo/commands/unit_tests/test_create_pin.py
@@ -37,8 +37,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set=None,
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         ),
         RepoSource(
             root="repo2",
@@ -52,8 +51,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set=None,
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         )
     ]
 
@@ -71,8 +69,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set="patchset1",
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         ),
         RepoSource(
             root="repo2",
@@ -86,8 +83,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set="patchset2",
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         )
     ]
 
@@ -105,8 +101,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set="patchset1",
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         ),
         RepoSource(
             root="repo2",
@@ -120,8 +115,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set=None,
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         ),
         RepoSource(
             root="repo3",
@@ -135,8 +129,7 @@ class TestGeneratePinData:
             venv_cfg=None,
             patch_set=None,
             blobless=False,
-            treeless=False,
-            nested_repo=False
+            treeless=False
         )
     ]
 

--- a/edkrepo/common/clone_utilities.py
+++ b/edkrepo/common/clone_utilities.py
@@ -111,22 +111,13 @@ def generate_clone_order(manifest, repo_sources):
     repo_sources - a list of repo_source tuples representing all repositories to be cloned.
     manifest - the ManifestXml object representing the workspace to be created.
     '''
-    nested_repos_present = any(repo.nested_repo for repo in repo_sources)
-    if not nested_repos_present:
-        return repo_sources
-
-    ordered_repos = [repo for repo in repo_sources if not repo.nested_repo]
-    remaining_repos = [repo for repo in repo_sources if repo.nested_repo]
-
-    # Keep looping until no more repos can be added
+    ordered_repos = []
+    remaining_repos = repo_sources
     while remaining_repos:
-        added_in_this_iteration = [] # Reset to empty list each iteration
-        added_in_this_iteration = [repo for repo in remaining_repos if manifest.get_parent_of_nested_repo(repo_sources, repo.root) in ordered_repos]
-        ordered_repos.extend(added_in_this_iteration)
-        remaining_repos = [repo for repo in remaining_repos if repo not in added_in_this_iteration]
-        if not added_in_this_iteration:
-            break
-
+        # repos with no parents first priority, repos with one parent second priority, etc.
+        nested_repos = manifest.list_nested_repos(remaining_repos)
+        ordered_repos.extend([repo for repo in remaining_repos if repo not in nested_repos])
+        remaining_repos = nested_repos
     return ordered_repos
 
 def calculate_source_manifest_repo_directory(args, config, manifest):

--- a/edkrepo/common/common_repo_functions.py
+++ b/edkrepo/common/common_repo_functions.py
@@ -91,8 +91,12 @@ def clone_repos(args, workspace_dir, repos_to_clone, project_client_side_hooks, 
         clone_single_repository(manifest, repo_to_clone, workspace_dir, global_manifest_path, args, reference_path_map=reference_path_map, dissociate=dissociate)
         duration = time.perf_counter() - start
         clone_times.append((repo_to_clone.root, dt.timedelta(seconds=duration)))
-        if repo_to_clone.nested_repo:
-            parent_path = os.path.join(workspace_dir, manifest.get_parent_of_nested_repo(clone_order, repo_to_clone.root).root)
+        try:
+            parent = manifest.get_parent_of_nested_repo(clone_order, repo_to_clone.root)
+        except ValueError:
+            parent = None
+        if parent:
+            parent_path = os.path.join(workspace_dir, parent.root)
             nested_path = os.path.join(workspace_dir, repo_to_clone.root)
             git_exclude_maintenance.write_git_exclude(parent_path, git_exclude_maintenance.generate_exclude_pattern(parent_path, nested_path))
         if global_manifest_directory:

--- a/edkrepo/common/unit_tests/test_clone_utilities.py
+++ b/edkrepo/common/unit_tests/test_clone_utilities.py
@@ -10,33 +10,35 @@ from edkrepo.common.clone_utilities import generate_clone_order, calculate_sourc
 class TestGenerateCloneOrder:
 
     NO_NESTED_MOCK_REPO_SOURCES = [
-        RepoSource(root="repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=False),
-        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=False)
+        RepoSource(root="repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False),
+        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False)
     ]
 
     NESTED_MOCK_REPO_SOURCES = [
-        RepoSource(root="repo2/repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=True),
-        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=False),
-        RepoSource(root="repo2/repo1/repo3", remote_name="origin", remote_url="https://example.com/repo3.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=True)
+        RepoSource(root="repo2/repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False),
+        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False),
+        RepoSource(root="repo2/repo1/repo3", remote_name="origin", remote_url="https://example.com/repo3.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False)
     ]
 
     EXPECTED_NESTED_CLONE_ORDER = [
-        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=False),
-        RepoSource(root="repo2/repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=True),
-        RepoSource(root="repo2/repo1/repo3", remote_name="origin", remote_url="https://example.com/repo3.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False, nested_repo=True)
+        RepoSource(root="repo2", remote_name="origin", remote_url="https://example.com/repo2.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False),
+        RepoSource(root="repo2/repo1", remote_name="origin", remote_url="https://example.com/repo1.git", branch="main", commit=None, sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False),
+        RepoSource(root="repo2/repo1/repo3", remote_name="origin", remote_url="https://example.com/repo3.git", branch=None, commit="def456", sparse=False, enable_submodule=False, tag=None, venv_cfg=None, patch_set=None, blobless=False, treeless=False)
     ]
 
     MOCK_MANIFEST = MagicMock(spec=ManifestXml)
     @staticmethod
-    def mock_get_parent_of_nested_repo(repo_sources_to_search, repo_local_root):
-        for repo in repo_sources_to_search:
-            if repo.root == "repo2":
-                raise ValueError("Not a nested repo")
-            if repo.root == "repo2/repo1":
-                return TestGenerateCloneOrder.NESTED_MOCK_REPO_SOURCES[1]
-            if repo.root == "repo2/repo1/repo3":
-                return TestGenerateCloneOrder.NESTED_MOCK_REPO_SOURCES[2]
-    MOCK_MANIFEST.get_parent_of_nested_repo = MagicMock(side_effect=mock_get_parent_of_nested_repo)
+    def mock_list_nested_repos(repo_sources_to_search):
+        nested = []
+        for source in repo_sources_to_search:
+            for repo in repo_sources_to_search:
+                if repo.root == source.root:
+                    continue
+                if source.root.startswith(repo.root + "/"):
+                    nested.append(source)
+                    break
+        return nested
+    MOCK_MANIFEST.list_nested_repos = MagicMock(side_effect=mock_list_nested_repos)
 
     def test_generate_clone_order_no_nesting(self):
         clone_order = generate_clone_order(self.MOCK_MANIFEST, self.NO_NESTED_MOCK_REPO_SOURCES)
@@ -84,7 +86,7 @@ class TestCalculateSourceManifestRepoDirectory:
         global_manifest_directory = calculate_source_manifest_repo_directory(self.MOCK_ARGS_SOURCE_MANIFEST_REPO_FLAG_CFG, self.MOCK_CONFIG, self.MOCK_MANIFEST)
         print(global_manifest_directory)
         assert global_manifest_directory == '/path/to/manifest/repo1'
-  
+
     @patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.list_available_manifest_repos')
     @patch('edkrepo.common.workspace_maintenance.manifest_repos_maintenance.find_source_manifest_repo')
     def test_source_manifest_repo_found_in_user_cfg_no_flag(self, mock_find_source_manifest_repo, mock_list_available_manifest_repos):
@@ -120,7 +122,7 @@ class TestCalculateSourceManifestRepoDirectory:
 
         global_manifest_directory = calculate_source_manifest_repo_directory(self.MOCK_ARGS_SOURCE_MANIFEST_REPO_FLAG, self.MOCK_CONFIG, self.MOCK_MANIFEST)
         assert global_manifest_directory is None
-    
+
     def test_source_manifest_repo_not_found(self):
         mock_find_source_manifest_repo = MagicMock()
         mock_find_source_manifest_repo.return_value = None

--- a/edkrepo_manifest_parser/edk_manifest.py
+++ b/edkrepo_manifest_parser/edk_manifest.py
@@ -27,8 +27,7 @@ RemoteRepo = namedtuple('RemoteRepo', ['name', 'url', 'owner', 'review_type', 'p
 RepoHook = namedtuple('RepoHook', ['source', 'dest_path', 'dest_file', 'remote_url'])
 Combination = namedtuple('Combination', ['name', 'description', 'venv_enable'])
 RepoSource = namedtuple('RepoSource', ['root', 'remote_name', 'remote_url', 'branch', 'commit', 'sparse',
-                                       'enable_submodule', 'tag', 'venv_cfg', 'patch_set', 'blobless', 'treeless',
-                                       'nested_repo'])
+                                       'enable_submodule', 'tag', 'venv_cfg', 'patch_set', 'blobless', 'treeless'])
 PatchSet = namedtuple('PatchSet', ['remote', 'name', 'parent_sha', 'fetch_branch'])
 PatchOperation = namedtuple('PatchOperation',['type', 'file', 'sha', 'source_remote', 'source_branch', 'merge_strategy'])
 SparseSettings = namedtuple('SparseSettings', ['sparse_by_default'])
@@ -467,13 +466,27 @@ class ManifestXml(BaseXmlHelper):
         while True:
             parent_local_root = os.path.dirname(current_path)
             for source in repo_sources_to_search:
-                if source.root == parent_local_root:
+                if os.path.normpath(source.root) == parent_local_root:
                     return source
             if parent_local_root == current_path:  # Reached the root directory
                 break
             current_path = parent_local_root
 
         raise ValueError(NO_PARENT_REPO_ERROR.format(repo_local_root))
+
+    def is_repo_nested(self, repo_sources_to_search, repo_local_root):
+        try:
+            self.get_parent_of_nested_repo(repo_sources_to_search, repo_local_root)
+        except ValueError:
+            return False
+        return True
+
+    def list_nested_repos(self, repo_sources_to_search):
+        nested_repos = []
+        for source in repo_sources_to_search:
+            if self.is_repo_nested(repo_sources_to_search, source.root):
+                nested_repos.append(source)
+        return nested_repos
 
     @property
     def repo_hooks(self):
@@ -1214,17 +1227,11 @@ class _RepoSource():
         if self.patch_set is not None and (self.branch is not None or self.commit is not None or self.tag is not None):
             raise ValueError(INVALID_COMBO_DEFINITION_ERROR)
 
-        if len(os.path.normpath(self.root).split(os.path.sep)) > 1:
-            self.nested_repo = True
-        else:
-            self.nested_repo = False
-
     @property
     def tuple(self):
         """Return a :class:`RepoSource` namedtuple representation of this repository source."""
         return RepoSource(self.root, self.remote_name, self.remote_url, self.branch,
-                          self.commit, self.sparse, self.enableSub, self.tag, self.venv_cfg, self.patch_set, self.blobless, self.treeless,
-                          self.nested_repo)
+                          self.commit, self.sparse, self.enableSub, self.tag, self.venv_cfg, self.patch_set, self.blobless, self.treeless)
 
 def _parse_repo_source_required_attribs(element, remotes):
     """Return ``(root, remote_name, remote_url)`` from a ``<Source>`` element, or raise ``KeyError`` if any required attribute or remote lookup fails."""

--- a/edkrepo_manifest_parser/unit_test_bases/base_tests.py
+++ b/edkrepo_manifest_parser/unit_test_bases/base_tests.py
@@ -1308,6 +1308,34 @@ class BaseTestManifestXml:
             manifest_instance.get_parent_of_nested_repo(sources, path)
         assert str(exc_info.value) == expected_msg
 
+    def test_is_repo_nested_returns_true_when_parent_found(self, manifest_instance):
+        """When get_parent_of_nested_repo finds a parent source, must return True."""
+        mock_src = MagicMock()
+        mock_src.root = PARENT_REPO
+        assert manifest_instance.is_repo_nested([mock_src], NESTED_REPO) is True
+
+    def test_is_repo_nested_returns_false_when_no_parent_found(self, manifest_instance):
+        """When get_parent_of_nested_repo raises ValueError, must return False."""
+        assert manifest_instance.is_repo_nested([], NESTED_REPO) is False
+
+    def test_list_nested_repos_returns_only_nested_sources(self, manifest_instance):
+        """Given a mix of root-level and nested sources, must return only the nested ones."""
+        mock_parent = MagicMock()
+        mock_parent.root = PARENT_REPO
+        mock_nested = MagicMock()
+        mock_nested.root = NESTED_REPO
+        result = manifest_instance.list_nested_repos([mock_parent, mock_nested])
+        assert result == [mock_nested]
+
+    def test_list_nested_repos_returns_empty_list_when_none_nested(self, manifest_instance):
+        """When no source in the list has a parent within the list, must return an empty list."""
+        mock_src1 = MagicMock()
+        mock_src1.root = 'repo1'
+        mock_src2 = MagicMock()
+        mock_src2.root = 'repo2'
+        result = manifest_instance.list_nested_repos([mock_src1, mock_src2])
+        assert result == []
+
     @pytest.mark.parametrize(PARAM_SUBMODULE_ALTS, [
         pytest.param(REMOTE_NAME, REMOTE_NAME, True, id=ID_ALT_MATCHING),
         pytest.param(UPSTREAM, REMOTE_NAME, False, id=ID_NO_MATCH),
@@ -2145,9 +2173,7 @@ ATTRIB_SPARSE = 'sparseCheckout'
 ATTRIB_ENABLE_SUB = 'enableSubmodule'
 ATTRIB_BLOBLESS = 'blobless'
 ATTRIB_TREELESS = 'treeless'
-NESTED_LOCAL_ROOT = 'parent/{}'.format(LOCAL_ROOT)
 FIELD_SPARSE = 'sparse'
-FIELD_NESTED_REPO = 'nested_repo'
 PARAM_BOOL_FIELD = 'extra, field_name, expected'
 ID_SPARSE_MISSING = 'sparse_missing'
 ID_SPARSE_TRUE = 'sparse_true'
@@ -2161,8 +2187,6 @@ ID_BLOBLESS_FALSE = 'blobless_false'
 ID_TREELESS_MISSING = 'treeless_missing'
 ID_TREELESS_TRUE = 'treeless_true'
 ID_TREELESS_FALSE = 'treeless_false'
-ID_NESTED_REPO_TRUE = 'nested_repo_true'
-ID_NESTED_REPO_FALSE = 'nested_repo_false'
 
 
 class BaseTestRepoSource:
@@ -2274,7 +2298,6 @@ class BaseTestRepoSource:
             patch_set=None,
             blobless=False,
             treeless=False,
-            nested_repo=False,
         )
 
     @pytest.mark.parametrize(PARAM_PARSE_RAISES, [
@@ -2356,8 +2379,6 @@ class BaseTestRepoSource:
         pytest.param({}, ATTRIB_TREELESS, False, id=ID_TREELESS_MISSING),
         pytest.param({ATTRIB_TREELESS: ATTRIB_BOOL_TRUE}, ATTRIB_TREELESS, True, id=ID_TREELESS_TRUE),
         pytest.param({ATTRIB_TREELESS: ATTRIB_BOOL_FALSE}, ATTRIB_TREELESS, False, id=ID_TREELESS_FALSE),
-        pytest.param({ATTRIB_LOCAL_ROOT: NESTED_LOCAL_ROOT}, FIELD_NESTED_REPO, True, id=ID_NESTED_REPO_TRUE),
-        pytest.param({}, FIELD_NESTED_REPO, False, id=ID_NESTED_REPO_FALSE),
     ])
     def test_init_sets_bool_field(self, base_attrib, extra, field_name, expected):
         """Each boolean attribute must default to False when absent and map 'true'/'false' to True/False correctly."""

--- a/edkrepo_manifest_parser/unit_tests/ManifestXml_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/ManifestXml_TestCases.md
@@ -85,6 +85,28 @@ Tests `get_parent_of_nested_repo` which returns the parent `RepoSource` for a ne
 - **Description**: When no source matches any ancestor directory.
 - **Expected Outcome**: `ValueError` is raised containing `NO_PARENT_REPO_ERROR`.
 
+### TestIsRepoNested
+Tests `is_repo_nested` which returns True/False for whether a repo path has a parent in the given source list, delegating to `get_parent_of_nested_repo`.
+
+#### 1. Returns True When Parent Found
+- **Description**: When `get_parent_of_nested_repo` finds a parent source for the given path.
+- **Expected Outcome**: Returns `True`.
+
+#### 2. Returns False When No Parent Found
+- **Description**: When `get_parent_of_nested_repo` raises `ValueError` (no parent found, or path invalid).
+- **Expected Outcome**: Returns `False`.
+
+### TestListNestedRepos
+Tests `list_nested_repos` which returns the subset of a list of `RepoSource` tuples that are nested (have a parent elsewhere in the same list).
+
+#### 1. Returns Only Nested Sources
+- **Description**: When the list contains a mix of root-level and nested sources.
+- **Expected Outcome**: A list containing only the nested source(s) is returned.
+
+#### 2. Returns Empty List When None Nested
+- **Description**: When no source in the list has a parent within the list.
+- **Expected Outcome**: An empty list is returned.
+
 ### TestGetComboElement
 Tests `get_combo_element` which returns a deep copy of the named `<Combination>` element, or raises `ValueError` if absent.
 

--- a/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
+++ b/edkrepo_manifest_parser/unit_tests/RepoSource_TestCases.md
@@ -148,33 +148,19 @@ Tests `_RepoSource.__init__` which parses a `<Source>` XML element including req
 - **Description**: When the element has a `treeless` attribute with value `"false"`.
 - **Expected Outcome**: `self.treeless` is `False`.
 
-#### 25. Sets nested_repo to True When localRoot Contains a Path Separator
-- **Test Name**: `test_init_sets_bool_field[nested_repo_true]`
-- **Description**: When the `localRoot` value contains a `/` path separator (nested directory).
-- **Expected Outcome**: `self.nested_repo` is `True`.
-
-#### 26. Sets nested_repo to False When localRoot Is a Simple Name
-- **Test Name**: `test_init_sets_bool_field[nested_repo_false]`
-- **Description**: When the `localRoot` value is a plain name with no path separator.
-- **Expected Outcome**: `self.nested_repo` is `False`.
-
-#### 27. Raises KeyError When No Reference Attribute Provided
-- **Test Name**: `test_init_raises_key_error_when_no_ref_specified`
+#### 25. Raises KeyError When No Reference Attribute Provided
 - **Description**: When the element has no `branch`, `commit`, `tag`, or `patchSet` attribute.
 - **Expected Outcome**: Raises `KeyError` indicating that a reference attribute is required.
 
-#### 28. Raises ValueError When patchSet and branch Are Both Present
-- **Test Name**: `test_init_raises_value_error_when_patch_set_combined_with_ref[patch_set_with_branch]`
+#### 26. Raises ValueError When patchSet and branch Are Both Present
 - **Description**: When the element has both a `patchSet` attribute and a `branch` attribute.
 - **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
 
-#### 29. Raises ValueError When patchSet and commit Are Both Present
-- **Test Name**: `test_init_raises_value_error_when_patch_set_combined_with_ref[patch_set_with_commit]`
+#### 27. Raises ValueError When patchSet and commit Are Both Present
 - **Description**: When the element has both a `patchSet` attribute and a `commit` attribute.
 - **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
 
-#### 30. Raises ValueError When patchSet and tag Are Both Present
-- **Test Name**: `test_init_raises_value_error_when_patch_set_combined_with_ref[patch_set_with_tag]`
+#### 28. Raises ValueError When patchSet and tag Are Both Present
 - **Description**: When the element has both a `patchSet` attribute and a `tag` attribute.
 - **Expected Outcome**: Raises `ValueError` indicating mutual exclusivity violation.
 


### PR DESCRIPTION
Git repos can be put in a sub-directory without being classified as a nested git repo.

Remove RepoSource.nested_repo and all unit test dependencies on it. -nested_repo status cannot be determined from the scope of a single RepoSource, it requires the scope of all RepoSource in a manifest.

Add a method to the parser called
is_repo_nested(self, repo_sources_to_search, repo_local_root) that calls get_parent_of_nested_repo() and returns True/False accordingly.

Add a method to the parser called
list_nested_repos(self, repo_sources_to_search) that iterates through a list of repo source tuples and returns a list of all that are nested.

Update the generate_clone_order() method to consume the new list_nested_repos() method instead of directly calculating it. Git repo with no parents are first clone priority. Git repo with one parent are second clone priority. Git repo with two parents are third clone priority. etc.

Update the get_parent_of_nested_repo() to be able to match a parent repo directory path that is not in the root of the workspace.

Add unit test coverage for is_repo_nested() and list_nested_repos() to the shared BaseTestManifestXml test base, and remove the stale nested_repo parametrize cases and constants from BaseTestRepoSource. Rebase onto current main to resolve conflicts from unrelated clone-timing instrumentation and test-infrastructure changes.

Fixes: #324