### PR TITLE
EdkRepo: Fix Linux/macOS Installers Built on Windows

### DIFF
--- a/build-scripts/build_linux_installer.py
+++ b/build-scripts/build_linux_installer.py
@@ -64,7 +64,7 @@ def patch_copyright_year(dist_root):
         r"^(_copyright_year\s*=\s*')[0-9]+(.*)",
         r"\g<1>{}\2".format(year),
         content, flags=re.MULTILINE)
-    with open(install_py_path, 'w') as f:
+    with open(install_py_path, 'w', newline='') as f:
         f.write(content)
 
 edkrepo_version=None

--- a/build-scripts/cln.bat
+++ b/build-scripts/cln.bat
@@ -42,6 +42,7 @@ if exist ..\dist (
   del /F EdkRepoSetup*.exe
   del /F *.whl
   del /F edkrepo*.tar.gz
+  del /F edkrepo*.run*
   rmdir /S /Q self_extract
   popd
 )


### PR DESCRIPTION
Add newline='' parameter to file open operations in build_linux_installer.py to ensure UNIX line endings are used, which is required for the shebang to work correctly.

Fixes #452